### PR TITLE
Require origin-country (jurisdiction) declaration; enforce USD-only currency

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -92,6 +92,7 @@ class MyFirstApp(AppAdapter):
             dry_run_supported=True,
             required_connected_accounts=[],
             price_model=PriceModel.FREE,
+            jurisdiction="US",   # ISO 3166-1 alpha-2 — the law your API complies with
             short_description="Hello World agent API",
             example_prompts=["Say hello"],
             compatibility_tags=["utility"],
@@ -134,6 +135,7 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `permission_class` | Permission level ([see guide](#6-permission-classes-guide)) | `PermissionClass.READ_ONLY` |
 | `approval_mode` | How execution is approved | `ApprovalMode.AUTO` |
 | `price_model` | Billing model | `"free"`, `"subscription"` |
+| `jurisdiction` | **Required.** ISO 3166-1 alpha-2 country code declaring the governing law of your API. [Details](docs/jurisdiction-and-compliance.md) | `"US"`, `"JP"`, `"US-CA"` |
 
 ### capability_key rules
 

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -1,10 +1,14 @@
 # Jurisdiction & Compliance Declaration
 
-APIs listed in the Siglume Agent API Store must declare which country's law
-they are designed to comply with. Consumer-protection rules, tax obligations,
-payment regulations, and data-residency requirements differ by country, so
-this up-front declaration lets agent owners (and the platform) make informed
-decisions.
+APIs listed in the Siglume Agent API Store **must** declare which country's
+law they are designed to comply with — there is no default. Consumer-
+protection rules, tax obligations, payment regulations, and data-residency
+requirements differ by country, so this up-front declaration lets agent
+owners (and the platform) make informed decisions.
+
+The `jurisdiction` field is also the basis for the country-flag icon the
+Agent API Store renders next to each listing — an instant visual cue of
+where the API is "from".
 
 ## Why this is required
 
@@ -18,6 +22,31 @@ decisions.
   depend on the seller's declared jurisdiction.
 - **Data residency**: HIPAA-equivalent regimes, GDPR adequacy decisions,
   and Japan's 個人情報保護法 each have residency implications.
+
+## Two concepts — don't confuse them
+
+Two distinct fields govern country scope. They answer different questions:
+
+| Field            | Question answered                                          | Whose perspective   |
+| ---------------- | ---------------------------------------------------------- | ------------------- |
+| `jurisdiction`   | "Under which country's law are **you** offering this API?" | Seller (developer)  |
+| `served_markets` | "Which countries can legitimately **use** this API?"       | Buyer (agent owner) |
+
+A **US-based developer** (`jurisdiction: "US"`) building a GDPR-compliant
+translation tool might set `served_markets: ["US", "GB", "DE", "FR", ...]` —
+US is their governing law but the tool is globally usable.
+
+A **US-based developer** building a HIPAA-only health-records API must set
+`served_markets: ["US"]` — the tool is only fit for the US healthcare
+context, not EU (where it might violate GDPR) or Japan (where 個人情報保護法
+may differ).
+
+A **Japan-based developer** (`jurisdiction: "JP"`) building a crypto-wallet
+integration that's banned in China would set `excluded_markets: ["CN"]`.
+
+When `served_markets` or `excluded_markets` is set, you **must** add
+`restriction_reason` so subscribers understand why. The SDK will emit a
+warning if you omit it.
 
 ## Where to declare it
 

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -1,0 +1,122 @@
+# Jurisdiction & Compliance Declaration
+
+APIs listed in the Siglume Agent API Store must declare which country's law
+they are designed to comply with. Consumer-protection rules, tax obligations,
+payment regulations, and data-residency requirements differ by country, so
+this up-front declaration lets agent owners (and the platform) make informed
+decisions.
+
+## Why this is required
+
+- **Payments**: Stripe Connect destination charges and refund rules vary by
+  country; a US-jurisdiction API settles under US Card-Act-style rules, a
+  JP-jurisdiction API under 資金決済法.
+- **Consumer protection**: CA residents get CCPA, EU residents get GDPR,
+  JP residents get 特定商取引法. The platform surfaces this so owners can
+  evaluate risk before subscribing.
+- **Tax / invoicing**: VAT, consumption tax, and sales-tax obligations
+  depend on the seller's declared jurisdiction.
+- **Data residency**: HIPAA-equivalent regimes, GDPR adequacy decisions,
+  and Japan's 個人情報保護法 each have residency implications.
+
+## Where to declare it
+
+### AppManifest (required, app-level)
+
+```python
+from siglume_app_sdk import AppManifest, PermissionClass, PriceModel, AppCategory
+
+manifest = AppManifest(
+    capability_key="acme-translator",
+    name="Acme Translator",
+    job_to_be_done="Translate short text between EN/JA",
+    category=AppCategory.OTHER,
+    permission_class=PermissionClass.READ_ONLY,
+    price_model=PriceModel.SUBSCRIPTION,
+    price_value_minor=500,          # $5.00
+    currency="USD",
+    jurisdiction="US",              # required — ISO 3166-1 alpha-2
+    applicable_regulations=["CCPA"],
+    data_residency="US",            # optional; defaults to jurisdiction
+)
+```
+
+Accepted formats:
+- Two uppercase letters (ISO 3166-1 alpha-2): `"US"`, `"JP"`, `"GB"`, `"DE"`,
+  `"SG"`, `"AU"`, `"CA"`, `"FR"`, `"KR"`, etc.
+- With sub-region (optional): `"US-CA"` (California), `"US-NY"` (New York),
+  `"CA-ON"` (Ontario).
+
+### ToolManual (required for `action` and `payment` tiers)
+
+Payment tools and state-changing action tools must also declare jurisdiction
+at the tool level. This allows different tools in the same app to opt into
+different legal scopes (e.g. an action tool that's US-only plus a read-only
+tool usable worldwide).
+
+```python
+from siglume_app_sdk import ToolManual, ToolManualPermissionClass, SettlementMode
+
+manual = ToolManual(
+    tool_name="charge_subscription",
+    # ... required fields ...
+    permission_class=ToolManualPermissionClass.PAYMENT,
+    approval_summary_template="Charge ${amount} to {card}?",
+    preview_schema={...},
+    idempotency_support=True,
+    side_effect_summary="Creates a Stripe payment intent for the owner.",
+    quote_schema={...},
+    currency="USD",
+    settlement_mode=SettlementMode.STRIPE_PAYMENT_INTENT,
+    refund_or_cancellation_note="Full refund within 7 days per platform policy.",
+    jurisdiction="US",  # required for action/payment
+    legal_notes="Refunds follow US FTC Rule 16 CFR 429. Not offered to EU users.",
+)
+```
+
+The tool-level `jurisdiction` must not contradict the app-level declaration.
+If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
+`jurisdiction = "JP"` — the app is still the legal seller.
+
+## Validation
+
+- **SDK dataclasses** (`AppManifest.__post_init__`, `ToolManual.to_dict`)
+  validate the format and reject malformed codes at construction / serialize
+  time.
+- **JSON schemas** (`schemas/app-manifest.schema.json`,
+  `schemas/tool-manual.schema.json`) enforce `pattern: ^[A-Z]{2}(-[A-Z0-9]{1,3})?$`.
+- **Platform-side**: the review step checks the declared jurisdiction against
+  the developer's Stripe Connect onboarding country. Mismatches surface as a
+  quality-report warning.
+
+## Applicable regulations
+
+`applicable_regulations` is advisory only — the platform does **not** audit
+compliance claims. Use it to signal intent. Common values:
+
+| Region | Tag |
+|--------|-----|
+| US federal | `CCPA`, `COPPA`, `HIPAA`, `GLBA` |
+| EU / EEA | `GDPR`, `DSA`, `DMA` |
+| UK | `UK-GDPR`, `DPA-2018` |
+| Japan | `資金決済法`, `特定商取引法`, `個人情報保護法` |
+| Global / industry | `PCI-DSS`, `SOC2`, `ISO27001`, `ISO27701` |
+
+## FAQ
+
+**Q: We're US-based but sell to global customers. What do I set?**
+A: Set `jurisdiction = "US"`. That's the law governing *your* offering.
+Consumer-protection laws of the end-user's country may still apply, but
+your contract is under US law.
+
+**Q: We operate in multiple countries with separate legal entities.**
+A: Register separate APIs per entity, each with its own `capability_key`
+and `jurisdiction`. One manifest = one legal seller.
+
+**Q: Can I change jurisdiction after listing?**
+A: Changing it is a breaking change to your terms of service. Create a new
+version (bump `version` in the manifest) and re-submit for review.
+
+**Q: What if I don't know what to put?**
+A: Use the country where your Stripe Connect account is registered. That's
+where you're invoicing from, so that's your jurisdiction.

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -42,6 +42,7 @@ manifest = AppManifest(
 ```
 
 Accepted formats:
+
 - Two uppercase letters (ISO 3166-1 alpha-2): `"US"`, `"JP"`, `"GB"`, `"DE"`,
   `"SG"`, `"AU"`, `"CA"`, `"FR"`, `"KR"`, etc.
 - With sub-region (optional): `"US-CA"` (California), `"US-NY"` (New York),
@@ -94,13 +95,32 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
 `applicable_regulations` is advisory only — the platform does **not** audit
 compliance claims. Use it to signal intent. Common values:
 
-| Region | Tag |
-|--------|-----|
-| US federal | `CCPA`, `COPPA`, `HIPAA`, `GLBA` |
-| EU / EEA | `GDPR`, `DSA`, `DMA` |
-| UK | `UK-GDPR`, `DPA-2018` |
-| Japan | `資金決済法`, `特定商取引法`, `個人情報保護法` |
+| Region            | Tag                                      |
+| ----------------- | ---------------------------------------- |
+| US federal        | `CCPA`, `COPPA`, `HIPAA`, `GLBA`         |
+| EU / EEA          | `GDPR`, `DSA`, `DMA`                     |
+| UK                | `UK-GDPR`, `DPA-2018`                    |
+| Japan             | `資金決済法`, `特定商取引法`, `個人情報保護法` |
 | Global / industry | `PCI-DSS`, `SOC2`, `ISO27001`, `ISO27701` |
+
+## Currency is USD regardless of jurisdiction
+
+The Agent API Store is **USD-unified**. Even if your `jurisdiction` is
+`"JP"`, `"GB"`, `"DE"`, or anything else, your listing price is in US
+dollars. This is enforced:
+
+- `AppManifest.currency` is typed as `"USD"` (literal in TS, validated in Python `__post_init__`, `const` in JSON Schema).
+- `ToolManual.currency` (payment tier) is `const "USD"`.
+- The platform's registration endpoint rejects non-USD payloads with a 422
+  (`CURRENCY_NOT_SUPPORTED`).
+
+Why: Stripe Connect destination charges, platform-fee accounting, the 93.4% /
+6.6% revenue split, and the $5.00/month minimum for subscription APIs all
+operate in USD. Mixing currencies would fragment payouts and break the fee
+model.
+
+Your jurisdiction still controls governing law, tax, consumer-protection
+framework, and data residency — just not the currency.
 
 ## FAQ
 
@@ -108,6 +128,11 @@ compliance claims. Use it to signal intent. Common values:
 A: Set `jurisdiction = "US"`. That's the law governing *your* offering.
 Consumer-protection laws of the end-user's country may still apply, but
 your contract is under US law.
+
+**Q: We're based in Japan and sell mostly to JP customers. Can we price in JPY?**
+A: No. `jurisdiction = "JP"` is fine — that's your governing law — but
+pricing is USD. Convert at your current FX and set a round USD number
+(e.g. ¥2,980/mo → $19.99/mo).
 
 **Q: We operate in multiple countries with separate legal entities.**
 A: Register separate APIs per entity, each with its own `capability_key`

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -23,30 +23,47 @@ where the API is "from".
 - **Data residency**: HIPAA-equivalent regimes, GDPR adequacy decisions,
   and Japan's 個人情報保護法 each have residency implications.
 
-## Two concepts — don't confuse them
+## Why only origin, not buyer-country enforcement
 
-Two distinct fields govern country scope. They answer different questions:
+The platform deliberately does **not** model a "served countries" allowlist
+or "excluded countries" blocklist on the API itself. Whether an API is
+**fit for a buyer's country and use case** is the buyer's judgment — the
+platform cannot adjudicate this in general.
 
-| Field            | Question answered                                          | Whose perspective   |
-| ---------------- | ---------------------------------------------------------- | ------------------- |
-| `jurisdiction`   | "Under which country's law are **you** offering this API?" | Seller (developer)  |
-| `served_markets` | "Which countries can legitimately **use** this API?"       | Buyer (agent owner) |
+Example: a seismic-calculation API built to US building codes (IBC) is
+probably not valid for a Japanese structural engineer filing under
+建築基準法, but it may still be useful as a reference or for a comparative
+study. Whether it's appropriate is context-dependent and the buyer is
+the only party with enough information to decide.
 
-A **US-based developer** (`jurisdiction: "US"`) building a GDPR-compliant
-translation tool might set `served_markets: ["US", "GB", "DE", "FR", ...]` —
-US is their governing law but the tool is globally usable.
+What the platform does:
 
-A **US-based developer** building a HIPAA-only health-records API must set
-`served_markets: ["US"]` — the tool is only fit for the US healthcare
-context, not EU (where it might violate GDPR) or Japan (where 個人情報保護法
-may differ).
+- **Forces sellers to declare `jurisdiction`** so the buyer sees an
+  unambiguous flag on every listing.
+- **Renders the ISO country code as a flag icon** on the API Store card
+  and detail page so the country of origin is visible at a glance.
 
-A **Japan-based developer** (`jurisdiction: "JP"`) building a crypto-wallet
-integration that's banned in China would set `excluded_markets: ["CN"]`.
+What the platform does NOT do:
 
-When `served_markets` or `excluded_markets` is set, you **must** add
-`restriction_reason` so subscribers understand why. The SDK will emit a
-warning if you omit it.
+- Block subscriptions based on the buyer's country.
+- Claim the API is valid for any particular regulatory regime.
+- Validate `applicable_regulations` claims — those are advisory.
+
+The buyer, not the platform, is responsible for determining regulatory
+fitness in their jurisdiction of use.
+
+## Flag icon rendering
+
+The platform converts `jurisdiction` to a flag emoji using the Regional
+Indicator Symbols for the first two letters of the code:
+
+- `"US"` → 🇺🇸
+- `"JP"` → 🇯🇵
+- `"US-CA"` → 🇺🇸 (sub-regions collapse to the parent country flag;
+  the text label still shows the full `"US-CA"`)
+
+If `jurisdiction` is missing or malformed, no flag is shown — which is
+why the SDK and the platform both require a valid value at registration.
 
 ## Where to declare it
 
@@ -124,12 +141,12 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
 `applicable_regulations` is advisory only — the platform does **not** audit
 compliance claims. Use it to signal intent. Common values:
 
-| Region            | Tag                                      |
-| ----------------- | ---------------------------------------- |
-| US federal        | `CCPA`, `COPPA`, `HIPAA`, `GLBA`         |
-| EU / EEA          | `GDPR`, `DSA`, `DMA`                     |
-| UK                | `UK-GDPR`, `DPA-2018`                    |
-| Japan             | `資金決済法`, `特定商取引法`, `個人情報保護法` |
+| Region | Tag |
+| --- | --- |
+| US federal | `CCPA`, `COPPA`, `HIPAA`, `GLBA` |
+| EU / EEA | `GDPR`, `DSA`, `DMA` |
+| UK | `UK-GDPR`, `DPA-2018` |
+| Japan | `資金決済法`, `特定商取引法`, `個人情報保護法` |
 | Global / industry | `PCI-DSS`, `SOC2`, `ISO27001`, `ISO27701` |
 
 ## Currency is USD regardless of jurisdiction

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -41,6 +41,7 @@ class PriceCompareApp(AppAdapter):
             dry_run_supported=True,
             required_connected_accounts=[],
             price_model=PriceModel.FREE,
+            jurisdiction="US",
             short_description="Find the best price for any product across major retailers",
             example_prompts=[
                 "Compare prices for Sony WH-1000XM5",

--- a/examples/metamask_connector.py
+++ b/examples/metamask_connector.py
@@ -75,6 +75,8 @@ class MetaMaskConnectorApp(AppAdapter):
             price_model=PriceModel.FREE,
             price_value_minor=0,
             currency="USD",
+            jurisdiction="US",
+            applicable_regulations=["BSA"],  # US Bank Secrecy Act — MSB rules
             short_description="Connect your agent to Ethereum wallets for on-chain actions",
             docs_url="https://github.com/taihei-05/siglume-app-sdk/blob/main/examples/metamask_connector.py",
             example_prompts=[

--- a/examples/visual_publisher.py
+++ b/examples/visual_publisher.py
@@ -49,6 +49,7 @@ class VisualPublisherApp(AppAdapter):
             price_model=PriceModel.FREE,
             price_value_minor=0,
             currency="USD",
+            jurisdiction="US",
             short_description="Turn your agent's ideas into images and post them to X",
             docs_url="https://github.com/taihei-05/siglume-app-sdk/blob/main/examples/visual_publisher.py",
             example_prompts=[

--- a/examples/x_publisher.py
+++ b/examples/x_publisher.py
@@ -44,6 +44,7 @@ class XPublisherApp(AppAdapter):
             price_model=PriceModel.FREE,
             price_value_minor=0,
             currency="USD",
+            jurisdiction="US",
             short_description="Auto-post your agent's content to X with smart formatting",
             docs_url="https://github.com/taihei-05/siglume-app-sdk/blob/main/examples/x_publisher.py",
             example_prompts=[

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -12,7 +12,8 @@
     "category",
     "permission_class",
     "approval_mode",
-    "price_model"
+    "price_model",
+    "jurisdiction"
   ],
   "properties": {
     "capability_key": {
@@ -99,6 +100,21 @@
     "currency": {
       "type": "string",
       "default": "USD"
+    },
+    "jurisdiction": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+      "description": "ISO 3166-1 alpha-2 country code declaring the governing law this API is designed to comply with (e.g. 'US', 'JP', 'GB', 'DE'). Optional sub-region after hyphen (e.g. 'US-CA' for California). Developers MUST declare the primary jurisdiction under which the API is offered, since consumer-protection, tax, and payment regulations differ by country. Use 'US' if the API follows US federal law (default market)."
+    },
+    "applicable_regulations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional list of specific regulatory frameworks the API claims compliance with (e.g. 'GDPR', 'CCPA', 'PCI-DSS', 'HIPAA', '資金決済法', '特定商取引法'). Advisory only — platform does not audit these claims."
+    },
+    "data_residency": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+      "description": "Optional ISO 3166-1 alpha-2 code indicating where user data is stored/processed. If omitted, defaults to jurisdiction."
     },
     "short_description": {
       "type": "string"

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -99,7 +99,9 @@
     },
     "currency": {
       "type": "string",
-      "default": "USD"
+      "const": "USD",
+      "default": "USD",
+      "description": "The Siglume Agent API Store is USD-unified. All listings — free, subscription, or one-time — are priced in US dollars. Stripe Connect destination charges, payouts, and platform-fee accounting all operate on USD amounts. Submitting a non-USD currency will be rejected by the platform at registration time. Developers outside the US (any jurisdiction value) still price in USD here."
     },
     "jurisdiction": {
       "type": "string",

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -118,6 +118,29 @@
       "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
       "description": "Optional ISO 3166-1 alpha-2 code indicating where user data is stored/processed. If omitted, defaults to jurisdiction."
     },
+    "served_markets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
+      },
+      "uniqueItems": true,
+      "description": "Optional allowlist of ISO 3166-1 alpha-2 country codes where this API can legitimately be used by agent owners. If omitted, the API is offered worldwide (developer accepts the risk). Use this to declare markets where you've verified regulatory fit (e.g. HIPAA API served_markets=['US']; GDPR-compliant API served_markets=['EU','GB','CH']). The platform surfaces this to potential subscribers and may block subscriptions from outside the list."
+    },
+    "excluded_markets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
+      },
+      "uniqueItems": true,
+      "description": "Optional blocklist of ISO 3166-1 alpha-2 country codes where this API is NOT offered (e.g. OFAC-sanctioned countries, markets where the API's output would violate local law). Evaluated after served_markets if both are present."
+    },
+    "restriction_reason": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Optional short explanation of why markets are restricted (e.g. 'Not HIPAA-compliant; US healthcare providers should not use.' or 'Content may violate EU Digital Services Act for minors.'). Surfaced on the store listing and subscription prompt so potential buyers understand the restriction."
+    },
     "short_description": {
       "type": "string"
     },

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -118,29 +118,6 @@
       "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
       "description": "Optional ISO 3166-1 alpha-2 code indicating where user data is stored/processed. If omitted, defaults to jurisdiction."
     },
-    "served_markets": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
-      },
-      "uniqueItems": true,
-      "description": "Optional allowlist of ISO 3166-1 alpha-2 country codes where this API can legitimately be used by agent owners. If omitted, the API is offered worldwide (developer accepts the risk). Use this to declare markets where you've verified regulatory fit (e.g. HIPAA API served_markets=['US']; GDPR-compliant API served_markets=['EU','GB','CH']). The platform surfaces this to potential subscribers and may block subscriptions from outside the list."
-    },
-    "excluded_markets": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$"
-      },
-      "uniqueItems": true,
-      "description": "Optional blocklist of ISO 3166-1 alpha-2 country codes where this API is NOT offered (e.g. OFAC-sanctioned countries, markets where the API's output would violate local law). Evaluated after served_markets if both are present."
-    },
-    "restriction_reason": {
-      "type": "string",
-      "maxLength": 500,
-      "description": "Optional short explanation of why markets are restricted (e.g. 'Not HIPAA-compliant; US healthcare providers should not use.' or 'Content may violate EU Digital Services Act for minors.'). Surfaced on the store listing and subscription prompt so potential buyers understand the restriction."
-    },
     "short_description": {
       "type": "string"
     },

--- a/schemas/tool-manual.schema.json
+++ b/schemas/tool-manual.schema.json
@@ -132,6 +132,16 @@
       "type": "string",
       "minLength": 1,
       "description": "Required for payment. Refund/cancellation policy note."
+    },
+    "jurisdiction": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+      "description": "Required for action/payment. ISO 3166-1 alpha-2 country code declaring the governing law for this tool's execution (e.g. 'US', 'JP'). Must not contradict the parent AppManifest.jurisdiction. Payment tier: currency (USD) and settlement are routed under this jurisdiction's rules."
+    },
+    "legal_notes": {
+      "type": "string",
+      "maxLength": 1000,
+      "description": "Optional free-form note surfaced to the owner on approval prompts, e.g. 'This tool complies with US FTC endorsement guidelines. Output not valid in EU.'"
     }
   },
   "allOf": [
@@ -147,7 +157,8 @@
           "approval_summary_template",
           "preview_schema",
           "idempotency_support",
-          "side_effect_summary"
+          "side_effect_summary",
+          "jurisdiction"
         ]
       }
     },

--- a/siglume-app-types.ts
+++ b/siglume-app-types.ts
@@ -30,7 +30,12 @@ export interface AppManifest {
   permission_scopes: string[];
   price_model: PriceModel;
   price_value_minor: number;
-  currency: string;
+  /**
+   * The Agent API Store is USD-unified. All listings price in US dollars
+   * regardless of the developer's jurisdiction. Non-USD submissions are
+   * rejected by the platform.
+   */
+  currency: "USD";
   /**
    * ISO 3166-1 alpha-2 country code (optionally with sub-region, e.g. "US-CA")
    * declaring the governing law this API is designed to comply with.

--- a/siglume-app-types.ts
+++ b/siglume-app-types.ts
@@ -31,6 +31,19 @@ export interface AppManifest {
   price_model: PriceModel;
   price_value_minor: number;
   currency: string;
+  /**
+   * ISO 3166-1 alpha-2 country code (optionally with sub-region, e.g. "US-CA")
+   * declaring the governing law this API is designed to comply with.
+   * Required. Default market is "US".
+   */
+  jurisdiction: string;
+  /**
+   * Optional list of specific regulatory frameworks the API claims compliance
+   * with (e.g. "GDPR", "CCPA", "PCI-DSS", "資金決済法"). Advisory only.
+   */
+  applicable_regulations?: string[];
+  /** Optional data-residency ISO code. Defaults to `jurisdiction`. */
+  data_residency?: string;
   short_description: string;
   docs_url: string;
   support_contact: string;
@@ -183,6 +196,14 @@ export interface ToolManual {
   preview_schema?: Record<string, unknown>;
   idempotency_support?: boolean;              // must be true for action/payment
   side_effect_summary?: string;
+  /**
+   * Required for action/payment. ISO 3166-1 alpha-2 country code declaring
+   * the governing law for this tool's execution. Must not contradict the
+   * parent AppManifest.jurisdiction.
+   */
+  jurisdiction?: string;
+  /** Optional. Surfaced on the approval prompt. Max 1000 chars. */
+  legal_notes?: string;
 
   // Required for payment only
   quote_schema?: Record<string, unknown>;

--- a/siglume-app-types.ts
+++ b/siglume-app-types.ts
@@ -49,6 +49,24 @@ export interface AppManifest {
   applicable_regulations?: string[];
   /** Optional data-residency ISO code. Defaults to `jurisdiction`. */
   data_residency?: string;
+  /**
+   * Optional allowlist of ISO 3166-1 alpha-2 country codes where this API is
+   * legitimately usable. If omitted, the API is offered worldwide.
+   * Distinct from `jurisdiction` (seller's governing law) — this is about the
+   * buyer's country of use.
+   */
+  served_markets?: string[];
+  /**
+   * Optional blocklist of ISO 3166-1 alpha-2 country codes. Evaluated after
+   * `served_markets` if both are present.
+   */
+  excluded_markets?: string[];
+  /**
+   * Optional short explanation of why markets are restricted (shown on the
+   * store listing). Strongly recommended when `served_markets` or
+   * `excluded_markets` is set.
+   */
+  restriction_reason?: string;
   short_description: string;
   docs_url: string;
   support_contact: string;

--- a/siglume-app-types.ts
+++ b/siglume-app-types.ts
@@ -49,24 +49,6 @@ export interface AppManifest {
   applicable_regulations?: string[];
   /** Optional data-residency ISO code. Defaults to `jurisdiction`. */
   data_residency?: string;
-  /**
-   * Optional allowlist of ISO 3166-1 alpha-2 country codes where this API is
-   * legitimately usable. If omitted, the API is offered worldwide.
-   * Distinct from `jurisdiction` (seller's governing law) — this is about the
-   * buyer's country of use.
-   */
-  served_markets?: string[];
-  /**
-   * Optional blocklist of ISO 3166-1 alpha-2 country codes. Evaluated after
-   * `served_markets` if both are present.
-   */
-  excluded_markets?: string[];
-  /**
-   * Optional short explanation of why markets are restricted (shown on the
-   * store listing). Strongly recommended when `served_markets` or
-   * `excluded_markets` is set.
-   */
-  restriction_reason?: string;
   short_description: string;
   docs_url: string;
   support_contact: string;

--- a/siglume_app_sdk.py
+++ b/siglume_app_sdk.py
@@ -113,6 +113,16 @@ class AppManifest:
     example_prompts: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        # Currency: the Agent API Store is USD-unified. Non-USD submissions
+        # are rejected at registration. Enforce here so developers get a clear
+        # error at adapter-construction time rather than a 422 at register.
+        if self.currency and self.currency.upper() != "USD":
+            raise ValueError(
+                f"AppManifest.currency must be 'USD' — the Agent API Store is "
+                f"USD-unified regardless of jurisdiction. Got: {self.currency!r}"
+            )
+        self.currency = "USD"
+
         if not _JURISDICTION_PATTERN.match(self.jurisdiction):
             raise ValueError(
                 f"AppManifest.jurisdiction must be ISO 3166-1 alpha-2 "

--- a/siglume_app_sdk.py
+++ b/siglume_app_sdk.py
@@ -16,6 +16,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+# ISO 3166-1 alpha-2 country code, optionally with a sub-region suffix.
+# Examples: "US", "US-CA", "JP", "GB", "DE", "SG".
+_JURISDICTION_PATTERN = re.compile(r"^[A-Z]{2}(-[A-Z0-9]{1,3})?$")
+
 
 # ── Permission & Execution Models ──
 
@@ -75,7 +79,16 @@ class AppCategory(str, Enum):
 
 @dataclass
 class AppManifest:
-    """Declares what the app does and what it needs."""
+    """Declares what the app does and what it needs.
+
+    Jurisdiction (REQUIRED):
+        `jurisdiction` is an ISO 3166-1 alpha-2 country code (optionally with
+        a sub-region, e.g. "US", "US-CA", "JP") declaring the governing law
+        this API is designed to comply with. Consumer-protection, tax,
+        payment, and data-residency regulations differ by country — the
+        platform surfaces this to agent owners so they can make an informed
+        subscription decision. Default market is "US".
+    """
     capability_key: str                    # unique identifier e.g. "amazon-purchase-assistant"
     version: str = "0.1.0"
     name: str = ""                         # display name
@@ -89,12 +102,27 @@ class AppManifest:
     price_model: PriceModel = PriceModel.FREE
     price_value_minor: int = 0             # in minor currency units (e.g. cents/yen)
     currency: str = "USD"
+    jurisdiction: str = "US"               # ISO 3166-1 alpha-2, required (e.g. "US", "JP", "US-CA")
+    applicable_regulations: list[str] = field(default_factory=list)  # e.g. ["GDPR", "CCPA", "資金決済法"]
+    data_residency: str | None = None      # ISO code; defaults to jurisdiction if None
     short_description: str = ""
     docs_url: str = ""
     support_contact: str = ""
     compatibility_tags: list[str] = field(default_factory=list)
     latency_tier: str = "normal"           # fast, normal, slow
     example_prompts: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not _JURISDICTION_PATTERN.match(self.jurisdiction):
+            raise ValueError(
+                f"AppManifest.jurisdiction must be ISO 3166-1 alpha-2 "
+                f"(optionally -subregion), got: {self.jurisdiction!r}"
+            )
+        if self.data_residency is not None and not _JURISDICTION_PATTERN.match(self.data_residency):
+            raise ValueError(
+                f"AppManifest.data_residency must be ISO 3166-1 alpha-2 "
+                f"(optionally -subregion), got: {self.data_residency!r}"
+            )
 
 
 @dataclass
@@ -337,6 +365,12 @@ class ToolManual:
     settlement_mode: SettlementMode | None = None
     refund_or_cancellation_note: str | None = None
 
+    # ── Required for action / payment ──
+    # Governing law declaration for this tool's execution. Must not contradict
+    # AppManifest.jurisdiction. ISO 3166-1 alpha-2 (optionally -subregion).
+    jurisdiction: str | None = None
+    legal_notes: str | None = None                       # optional, surfaced on approval prompt
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the dict format expected by the platform API."""
         d: dict[str, Any] = {
@@ -362,6 +396,21 @@ class ToolManual:
             d["preview_schema"] = self.preview_schema or {}
             d["idempotency_support"] = bool(self.idempotency_support)
             d["side_effect_summary"] = self.side_effect_summary or ""
+            # jurisdiction is required for action/payment
+            if not self.jurisdiction:
+                raise ValueError(
+                    "ToolManual.jurisdiction is required for permission_class "
+                    "'action' or 'payment'. Declare the ISO 3166-1 alpha-2 "
+                    "country code whose law governs this tool (e.g. 'US', 'JP')."
+                )
+            if not _JURISDICTION_PATTERN.match(self.jurisdiction):
+                raise ValueError(
+                    f"ToolManual.jurisdiction must be ISO 3166-1 alpha-2 "
+                    f"(optionally -subregion), got: {self.jurisdiction!r}"
+                )
+            d["jurisdiction"] = self.jurisdiction
+            if self.legal_notes:
+                d["legal_notes"] = self.legal_notes
         if self.permission_class == ToolManualPermissionClass.PAYMENT:
             d["quote_schema"] = self.quote_schema or {}
             d["currency"] = self.currency or "USD"

--- a/siglume_app_sdk.py
+++ b/siglume_app_sdk.py
@@ -102,9 +102,21 @@ class AppManifest:
     price_model: PriceModel = PriceModel.FREE
     price_value_minor: int = 0             # in minor currency units (e.g. cents/yen)
     currency: str = "USD"
-    jurisdiction: str = "US"               # ISO 3166-1 alpha-2, required (e.g. "US", "JP", "US-CA")
+    # REQUIRED. No default — every AppManifest must explicitly declare the
+    # country whose law governs the offering. Ambiguous / missing values are
+    # rejected at construction time and at platform registration.
+    jurisdiction: str = ""                 # must be explicitly set; ISO 3166-1 alpha-2 (e.g. "US", "JP", "US-CA")
     applicable_regulations: list[str] = field(default_factory=list)  # e.g. ["GDPR", "CCPA", "資金決済法"]
     data_residency: str | None = None      # ISO code; defaults to jurisdiction if None
+    # Market availability — where the API can legitimately be USED by buyers.
+    # Distinct from `jurisdiction` which is the seller's governing law.
+    # - served_markets: allowlist. If set, only these countries can subscribe.
+    #                   Empty list = worldwide (developer accepts risk).
+    # - excluded_markets: blocklist, evaluated after served_markets.
+    # - restriction_reason: short note shown on the store listing to explain why.
+    served_markets: list[str] = field(default_factory=list)
+    excluded_markets: list[str] = field(default_factory=list)
+    restriction_reason: str | None = None
     short_description: str = ""
     docs_url: str = ""
     support_contact: str = ""
@@ -123,6 +135,14 @@ class AppManifest:
             )
         self.currency = "USD"
 
+        if not self.jurisdiction:
+            raise ValueError(
+                "AppManifest.jurisdiction is REQUIRED. Every API listed on "
+                "the Agent API Store must explicitly declare its country of "
+                "origin (the country whose law governs the offering) as an "
+                "ISO 3166-1 alpha-2 code, e.g. 'US', 'JP', 'GB', 'DE', 'SG'. "
+                "No default is applied — you must make an informed choice."
+            )
         if not _JURISDICTION_PATTERN.match(self.jurisdiction):
             raise ValueError(
                 f"AppManifest.jurisdiction must be ISO 3166-1 alpha-2 "
@@ -132,6 +152,33 @@ class AppManifest:
             raise ValueError(
                 f"AppManifest.data_residency must be ISO 3166-1 alpha-2 "
                 f"(optionally -subregion), got: {self.data_residency!r}"
+            )
+        for code in self.served_markets:
+            if not _JURISDICTION_PATTERN.match(code):
+                raise ValueError(
+                    f"AppManifest.served_markets entries must be ISO 3166-1 "
+                    f"alpha-2 codes, got: {code!r}"
+                )
+        for code in self.excluded_markets:
+            if not _JURISDICTION_PATTERN.match(code):
+                raise ValueError(
+                    f"AppManifest.excluded_markets entries must be ISO 3166-1 "
+                    f"alpha-2 codes, got: {code!r}"
+                )
+        if self.restriction_reason is not None and len(self.restriction_reason) > 500:
+            raise ValueError(
+                "AppManifest.restriction_reason must be <= 500 characters"
+            )
+        # Encourage explanation when markets are restricted
+        if (self.served_markets or self.excluded_markets) and not self.restriction_reason:
+            # Not a hard error — the platform may still accept — but developers
+            # are strongly encouraged to explain the restriction.
+            import warnings as _w
+            _w.warn(
+                "AppManifest has served_markets or excluded_markets set but "
+                "no restriction_reason. Subscribers will see a blocked/filtered "
+                "listing without context. Consider adding restriction_reason.",
+                stacklevel=2,
             )
 
 

--- a/siglume_app_sdk.py
+++ b/siglume_app_sdk.py
@@ -108,15 +108,11 @@ class AppManifest:
     jurisdiction: str = ""                 # must be explicitly set; ISO 3166-1 alpha-2 (e.g. "US", "JP", "US-CA")
     applicable_regulations: list[str] = field(default_factory=list)  # e.g. ["GDPR", "CCPA", "資金決済法"]
     data_residency: str | None = None      # ISO code; defaults to jurisdiction if None
-    # Market availability — where the API can legitimately be USED by buyers.
-    # Distinct from `jurisdiction` which is the seller's governing law.
-    # - served_markets: allowlist. If set, only these countries can subscribe.
-    #                   Empty list = worldwide (developer accepts risk).
-    # - excluded_markets: blocklist, evaluated after served_markets.
-    # - restriction_reason: short note shown on the store listing to explain why.
-    served_markets: list[str] = field(default_factory=list)
-    excluded_markets: list[str] = field(default_factory=list)
-    restriction_reason: str | None = None
+    # NOTE: The SDK intentionally does NOT model served_markets / excluded_markets.
+    # Whether this API is valid for a buyer's country/use-case (e.g. seismic
+    # calculation under JP vs US building codes) is the buyer's judgment,
+    # not something the platform enforces. The platform surfaces `jurisdiction`
+    # as a flag icon so buyers can make informed decisions.
     short_description: str = ""
     docs_url: str = ""
     support_contact: str = ""
@@ -152,33 +148,6 @@ class AppManifest:
             raise ValueError(
                 f"AppManifest.data_residency must be ISO 3166-1 alpha-2 "
                 f"(optionally -subregion), got: {self.data_residency!r}"
-            )
-        for code in self.served_markets:
-            if not _JURISDICTION_PATTERN.match(code):
-                raise ValueError(
-                    f"AppManifest.served_markets entries must be ISO 3166-1 "
-                    f"alpha-2 codes, got: {code!r}"
-                )
-        for code in self.excluded_markets:
-            if not _JURISDICTION_PATTERN.match(code):
-                raise ValueError(
-                    f"AppManifest.excluded_markets entries must be ISO 3166-1 "
-                    f"alpha-2 codes, got: {code!r}"
-                )
-        if self.restriction_reason is not None and len(self.restriction_reason) > 500:
-            raise ValueError(
-                "AppManifest.restriction_reason must be <= 500 characters"
-            )
-        # Encourage explanation when markets are restricted
-        if (self.served_markets or self.excluded_markets) and not self.restriction_reason:
-            # Not a hard error — the platform may still accept — but developers
-            # are strongly encouraged to explain the restriction.
-            import warnings as _w
-            _w.warn(
-                "AppManifest has served_markets or excluded_markets set but "
-                "no restriction_reason. Subscribers will see a blocked/filtered "
-                "listing without context. Consider adding restriction_reason.",
-                stacklevel=2,
             )
 
 


### PR DESCRIPTION
# Require origin-country (`jurisdiction`) declaration; enforce USD-only currency

## Summary

Introduces a required `jurisdiction` declaration on every `AppManifest` and
payment/action-tier `ToolManual`, and tightens `currency` to `"USD"` on
`AppManifest` (matching the existing `const "USD"` on `ToolManual`). No
defaults are applied to `jurisdiction` — developers must make an explicit
choice.

**Why now:** a recent platform audit found legacy listings had slipped
through with `currency="JPY"` because neither the SDK nor the registration
endpoint was validating the field. Similarly, without a required
jurisdiction field, every listing implicitly inherited a US default,
which is the kind of invisible decision that causes compliance incidents
later. This PR forces both to be explicit at the earliest possible point
(adapter construction), with the platform as a second enforcement gate.

## Motivation

- **Origin transparency for buyers.** Every API Store listing now renders
  a country-flag icon derived from `jurisdiction`. Buyers see at a glance
  where the API is "from" and can judge fitness for their own jurisdiction
  and use case.
- **Single source of truth on currency.** Stripe Connect destination
  charges, the 93.4% / 6.6% revenue split, and the $5.00/month minimum
  all operate on USD. Non-USD submissions are now rejected at both the
  SDK and the platform.
- **No silent defaults.** Compliance regimes differ by country;
  defaulting to `"US"` when a developer forgot to set the field is worse
  than raising a clear error that forces a decision.

## What's in scope

- `AppManifest.jurisdiction` — **required**, ISO 3166-1 alpha-2
  (optionally with sub-region, e.g. `"US-CA"`). No default.
- `AppManifest.currency` — narrowed to the literal `"USD"`. Non-USD
  raises `ValueError` at construction.
- `AppManifest.applicable_regulations` — optional, advisory list (e.g.
  `["GDPR", "CCPA", "資金決済法"]`).
- `AppManifest.data_residency` — optional ISO code for where user data
  is stored; defaults to `jurisdiction` if unset.
- `ToolManual.jurisdiction` — required for `action` / `payment` tiers
  (matches the existing currency/settlement requirement for payment).
- `ToolManual.legal_notes` — optional free-form note surfaced on the
  approval prompt.
- New doc: [`docs/jurisdiction-and-compliance.md`](docs/jurisdiction-and-compliance.md)
  covering the what/why/how including an FX/JP example and flag-icon
  rendering notes.

## Explicitly out of scope

The first draft of this PR also included `served_markets` /
`excluded_markets` / `restriction_reason` — platform-enforced allowlists
and blocklists for buyer countries. These were removed in the final
commit after feedback: whether an API is valid in the buyer's country
is inherently case-by-case (concrete example: a seismic-calculation API
built to US IBC codes is probably not valid for a JP structural engineer
filing under 建築基準法, but may still be useful as a reference or
comparative input — only the buyer knows). The platform surfaces origin
clearly; the buyer judges fitness.

## Breaking changes

- **`AppManifest.jurisdiction` becomes required.** Existing code like
  `AppManifest(capability_key="x", name="X")` now raises `ValueError`.
  Migration: add `jurisdiction="US"` (or your correct origin country).
- **`AppManifest.currency` is now a `"USD"` literal in TS.** Consumers
  passing a variable-typed string may need to narrow. Python rejects
  non-USD at construction.

All four in-tree `examples/` adapters were updated to declare
`jurisdiction="US"` explicitly.

## Validation layering

1. **SDK construction** (`__post_init__` / `to_dict`) — catches
   typos and missing values at adapter build time with a clear message.
2. **JSON schemas** (`schemas/app-manifest.schema.json`,
   `schemas/tool-manual.schema.json`) — `const "USD"` for currency,
   `pattern: ^[A-Z]{2}(-[A-Z0-9]{1,3})?$` for jurisdiction / data_residency.
3. **Platform registration** — rejects non-USD with
   `CURRENCY_NOT_SUPPORTED` (422) and missing jurisdiction with
   `JURISDICTION_REQUIRED` (422).

## Test plan

- [x] Smoke test: `AppManifest(jurisdiction="US")` accepted
- [x] Smoke test: missing `jurisdiction` raises `ValueError`
- [x] Smoke test: `jurisdiction="us-ca"` lowercase — malformed rejected
- [x] Smoke test: `jurisdiction="US-CA"` sub-region accepted
- [x] Smoke test: `currency="JPY"` raises `ValueError`
- [x] Smoke test: `currency="usd"` normalized to `"USD"`
- [x] Smoke test: `ToolManual` with `permission_class=ACTION` requires
  `jurisdiction` on `to_dict()`
- [x] All four in-tree `examples/` adapters updated to declare
  `jurisdiction` explicitly
- [x] JSON schemas updated and consistent with Python / TS
- [ ] Reviewer check: does any downstream code construct `AppManifest`
  without passing `jurisdiction`? (Search for usages that may need
  migration alongside this PR.)

## Commit layout

Four focused commits for easier review:

1. `Add jurisdiction declaration to AppManifest and ToolManual` — the
   feature addition with the three auxiliary fields.
2. `Enforce USD-only currency on AppManifest` — tightens the currency
   contract that was already `const "USD"` on ToolManual.
3. `Require explicit jurisdiction; add served_markets / excluded_markets` —
   removes the silent US default; introduces the buyer-country
   allowlist/blocklist that commit 4 walks back.
4. `Simplify: jurisdiction is origin-declaration only (buyer judges fitness)` —
   walks back the buyer-country enforcement in favor of origin-declaration
   only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
