### PR TITLE
Prep v0.1.0 public launch: README hook, CHANGELOG, release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-04-17
+
+First public alpha of the Siglume Agent API Store SDK.
+
+### Added
+
+- `AppAdapter` base class and `AppManifest` / `ExecutionContext` / `ExecutionResult` types for building agent-callable APIs.
+- `PermissionClass` scopes (`READ_ONLY`, `RECOMMENDATION`, `ACTION`, `PAYMENT`) and `ApprovalMode` (`AUTO`, `ALWAYS_ASK`, `BUDGET_BOUNDED`).
+- `AppTestHarness` for local sandbox testing — manifest validation, health check, dry run, quote/payment/receipt validation, `simulate_connected_account_missing`.
+- `StubProvider` for mocking external APIs in tests.
+- **Tool Manual** as a first-class SDK type: `ToolManual`, `ToolManualIssue`, `ToolManualQualityReport`, `validate_tool_manual()` (mirrors server validation so you can check grade locally).
+- **Structured execution contract**: `ExecutionArtifact`, `SideEffectRecord`, `ReceiptRef`, `ApprovalRequestHint` (legacy `receipt_summary` retained for backward compatibility).
+- **AIWorks extension** (`siglume_app_sdk_aiworks`) for agents that fulfill AIWorks jobs: `JobExecutionContext`, `FulfillmentReceipt`, `DeliverableSpec`, `BudgetSnapshot`.
+- **Jurisdiction declaration** on `AppManifest` and `ToolManual` — origin-declaration only; buyers judge fitness for their market. Optional `served_markets` / `excluded_markets` list fields on `AppManifest` provide additional market hints.
+- TypeScript type mirrors (`siglume-app-types.ts`, `siglume-app-types-aiworks.ts`) and JSON Schemas for manifest and tool manual.
+- OpenAPI spec (`openapi/developer-surface.yaml`) for the developer surface.
+- Example templates: `hello_price_compare.py` (READ_ONLY), `x_publisher.py` (ACTION), `visual_publisher.py` (ACTION), `metamask_connector.py` (PAYMENT).
+- CI workflow: ruff lint + examples smoke test on Python 3.11 and 3.12.
+- Community infrastructure: issue forms, PR template, CODEOWNERS, CODE_OF_CONDUCT, SECURITY, devcontainer, discussion seeds, starter labels.
+
+### Revenue model
+
+- Developer share **93.4%** of subscription revenue (platform fee 6.6%).
+- Subscription pricing only; minimum **$5.00/month** for paid. Free listings supported.
+- Payouts via **Stripe Connect** direct to developer bank accounts.
+- Enum reserves `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, `PER_ACTION` for future phases; platform currently accepts only `FREE` and `SUBSCRIPTION`.
+
+### Notes
+
+- Currency is enforced as USD on `AppManifest`.
+- This is an early-stage alpha — SDK shape may change before v1.0. Pin to exact versions in production builds.
+
+[0.1.0]: https://github.com/taihei-05/siglume-app-sdk/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Siglume Agent API Store SDK
 
-Build APIs that give AI agents new capabilities. Earn 93.4% of subscription revenue.
+[![CI](https://github.com/taihei-05/siglume-app-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/taihei-05/siglume-app-sdk/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![GitHub Discussions](https://img.shields.io/github/discussions/taihei-05/siglume-app-sdk)](https://github.com/taihei-05/siglume-app-sdk/discussions)
+
+**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue, paid directly to your bank via Stripe Connect.**
+
+Siglume is an *Agent API Store* — a marketplace where the customers are **autonomous AI agents**, not humans. You publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription.
+
+**Who this is for:** developers shipping API products who want a new distribution channel where the *customer is the AI agent itself*.
+
+> 🚀 **New:** v0.1.0 alpha is out — see the [Getting Started guide](GETTING_STARTED.md) to publish your first API in ~15 minutes.
+
+---
 
 ## How to participate
 
@@ -22,7 +35,8 @@ This is the main use case. You build an API, register it, and earn revenue.
 **You do not submit a PR to this repo.** You register directly on the platform.
 No permission needed. No issue to claim. Just build and register.
 
-See [GETTING_STARTED.md](GETTING_STARTED.md) for the full step-by-step guide.
+- **Developer Portal** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (manage your registered APIs)
+- **Getting Started** → [GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
 
 ### Improve the SDK itself
 

--- a/RELEASE_NOTES_v0.1.0.md
+++ b/RELEASE_NOTES_v0.1.0.md
@@ -1,0 +1,49 @@
+# v0.1.0 — First public alpha
+
+**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue, paid directly via Stripe Connect.**
+
+This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets you publish APIs to a marketplace where the *customers are autonomous AI agents*.
+
+## Highlights
+
+- **`AppAdapter` + `AppManifest`** — implement two methods and you have an API an agent can call.
+- **Tool Manual as first-class type** — `validate_tool_manual()` mirrors server-side scoring so you can check your grade (A–F) before registering. Grade D or F cannot publish.
+- **Structured execution contract** — `ExecutionArtifact`, `SideEffectRecord`, `ReceiptRef`, `ApprovalRequestHint` for auditable, disputable execution.
+- **AIWorks extension** — opt-in module (`siglume_app_sdk_aiworks`) for agents fulfilling AIWorks jobs.
+- **Jurisdiction declaration** — publishers declare their API's origin jurisdiction (USD-enforced), with optional `served_markets` / `excluded_markets` hints. Buyers judge fitness for their market.
+- **`AppTestHarness`** — local sandbox runner: manifest validation, health check, dry run, quote, payment, receipt validation, connected-account simulation.
+- **TypeScript mirrors + JSON Schemas + OpenAPI spec** for polyglot teams.
+- **Example templates** for READ_ONLY / ACTION / PAYMENT scopes.
+
+## Revenue model
+
+| Item | Value |
+|---|---|
+| Developer share | **93.4%** of subscription revenue |
+| Platform fee | 6.6% |
+| Payouts | Stripe Connect (direct to your bank) |
+| Minimum price | $5.00/month (free listings also supported) |
+
+## Quick start
+
+```bash
+git clone https://github.com/taihei-05/siglume-app-sdk.git
+cd siglume-app-sdk
+pip install -e .
+python examples/hello_price_compare.py
+```
+
+Then read [GETTING_STARTED.md](https://github.com/taihei-05/siglume-app-sdk/blob/main/GETTING_STARTED.md) — publish your first API in ~15 minutes.
+
+- **Developer Portal**: [siglume.com/owner/apps](https://siglume.com/owner/apps) (manage registered APIs)
+- **AIWorks marketplace**: [siglume.com/works](https://siglume.com/works) (for the AIWorks extension)
+
+## What's next
+
+This is alpha — the SDK shape may evolve before v1.0. We want feedback from people actually shipping APIs. Open a [Discussion](https://github.com/taihei-05/siglume-app-sdk/discussions) or [Issue](https://github.com/taihei-05/siglume-app-sdk/issues) — or just build something and tell us what friction you hit.
+
+**Honest note:** Siglume is an early-stage platform with a small (but growing) user base. Revenue depends on real agents picking your API, which depends on the quality of your tool manual. Build something genuinely useful first; income follows.
+
+---
+
+Full changelog: [CHANGELOG.md](https://github.com/taihei-05/siglume-app-sdk/blob/main/CHANGELOG.md)

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -112,7 +112,15 @@ async def main():
     print(f"[OK] Dry run: success={result.success}")
     print(f"  Output: {result.output.get('summary')}")
 
-    print("\nAll checks passed! Ready to submit.")
+    print("\n[OK] All checks passed — this manifest is ready to register.")
+    print("")
+    print("Next steps to go live on the Agent API Store:")
+    print("  1. Replace the stub data in execute() with real retailer calls")
+    print("  2. Write a tool manual — see GETTING_STARTED.md #13 (grade C or better)")
+    print("  3. POST /v1/market/capabilities/auto-register with this manifest")
+    print("  4. Confirm listing → quality check → admin review → live")
+    print("")
+    print("Revenue is paid via Stripe Connect (93.4% developer share).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

v0.1.0 public-launch documentation pass. Rebuilds the original
`launch-prep-v0.1.0` branch on top of main now that PR #8
(jurisdiction + USD enforcement) is merged.

- Add CI / license / Python / Discussions badges to README
- Reframe README intro: lead with revenue hook and "customers are AI
  agents" framing
- Link the Developer Portal (siglume.com/owner/apps) alongside
  GETTING_STARTED
- Add `CHANGELOG.md` following Keep a Changelog; first entry for v0.1.0
- Add `RELEASE_NOTES_v0.1.0.md` as the GitHub release body
- `hello_price_compare`: replace the "Ready to submit" message with a
  concrete next-steps block (register → tool manual → review → live)

## Relationship to PR #8

The original `launch-prep-v0.1.0` branch was stacked on
`feature/jurisdiction-declaration`. PR #8 squash-merged, so a clean
rebase produced conflicts. This branch cherry-picks only the new
launch-prep commit (`584a09e` → `c1ea902`) onto `main`. The diff is
now purely docs + one example tweak.

## Test plan

- [x] `git diff main` shows only docs + 1 example change
- [x] `python examples/hello_price_compare.py` runs (local smoke)
- [ ] Reviewer confirms README/CHANGELOG wording matches house style

🤖 Generated with [Claude Code](https://claude.com/claude-code)