### PR TITLE
Unify publish threshold to grade B across SDK docs

### DIFF
--- a/ANNOUNCEMENT_DRAFT.md
+++ b/ANNOUNCEMENT_DRAFT.md
@@ -46,8 +46,8 @@ description that agents use to decide whether to call your API.
 A well-written tool manual means more agents select your API,
 which means more installs and more subscription revenue.
 
-Grade D or F tool manuals cannot be published — the quality check
-blocks them automatically.
+Grade C, D, or F tool manuals cannot be published — the quality check
+blocks them automatically. Minimum grade B is required.
 
 See the [Tool Manual Guide](https://github.com/taihei-05/siglume-app-sdk/blob/main/GETTING_STARTED.md#13-tool-manual-guide)
 for how to write a manual that gets your API selected.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -319,8 +319,8 @@ The tool manual determines whether agents select your API -- it is the
 most important thing you write. See [Section 13](#13-tool-manual-guide).
 
 A quality check runs automatically at confirmation time:
-- Grade C or above: your API proceeds to admin review
-- Grade D or F: you must improve the tool manual before it can be published
+- Grade B or above (A/B): your API proceeds to admin review
+- Grade C, D, or F: you must improve the tool manual before it can be published
 
 ### Step 4: Admin review
 
@@ -756,11 +756,11 @@ Your tool manual is automatically scored 0-100 with a letter grade:
 |---|---|---|
 | A (90-100) | Excellent | Yes |
 | B (70-89) | Good | Yes |
-| C (50-69) | Acceptable | Yes |
+| C (50-69) | Below threshold | **No — must improve** |
 | D (30-49) | Poor | **No — must improve** |
 | F (0-29) | Failing | **No — must improve** |
 
-**Grade D or F manuals cannot be published.** Fix the issues and resubmit.
+**Grade C, D, or F manuals cannot be published — minimum grade B is required.** Fix the issues and resubmit.
 
 ### What gets penalized
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ description that agents use to decide whether to call your API.
 **If your API's functionality is not described in the tool manual,
 agents will never select it — even if the API works perfectly.**
 
-Your tool manual is scored 0-100 (grade A-F). Grade D or F cannot publish.
+Your tool manual is scored 0-100 (grade A-F). **Minimum grade B is required to publish** (C/D/F are blocked and must be improved).
 
 See the [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide) for
 required fields, scoring rules, and examples.
@@ -169,7 +169,7 @@ Separate module for AIWorks job fulfillment. Import only if your app participate
 Your API gets listed when it passes these three checks:
 
 1. **AppTestHarness** — manifest validation, health check, dry-run all pass
-2. **Tool manual quality** — grade C or above (0-100 scoring, D/F blocks publishing)
+2. **Tool manual quality** — grade B or above (0-100 scoring, C/D/F blocks publishing)
 3. **Admin review** — behavior matches description, permissions are appropriate
 
 ## Important: revenue is not guaranteed

--- a/RELEASE_NOTES_v0.1.0.md
+++ b/RELEASE_NOTES_v0.1.0.md
@@ -7,7 +7,7 @@ This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets 
 ## Highlights
 
 - **`AppAdapter` + `AppManifest`** — implement two methods and you have an API an agent can call.
-- **Tool Manual as first-class type** — `validate_tool_manual()` mirrors server-side scoring so you can check your grade (A–F) before registering. Grade D or F cannot publish.
+- **Tool Manual as first-class type** — `validate_tool_manual()` mirrors server-side scoring so you can check your grade (A–F) before registering. Minimum grade B is required to publish (C/D/F are blocked).
 - **Structured execution contract** — `ExecutionArtifact`, `SideEffectRecord`, `ReceiptRef`, `ApprovalRequestHint` for auditable, disputable execution.
 - **AIWorks extension** — opt-in module (`siglume_app_sdk_aiworks`) for agents fulfilling AIWorks jobs.
 - **Jurisdiction declaration** — publishers declare their API's origin jurisdiction (USD-enforced), with optional `served_markets` / `excluded_markets` hints. Buyers judge fitness for their market.

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -116,7 +116,7 @@ async def main():
     print("")
     print("Next steps to go live on the Agent API Store:")
     print("  1. Replace the stub data in execute() with real retailer calls")
-    print("  2. Write a tool manual — see GETTING_STARTED.md #13 (grade C or better)")
+    print("  2. Write a tool manual — see GETTING_STARTED.md #13 (grade B or better required)")
     print("  3. POST /v1/market/capabilities/auto-register with this manifest")
     print("  4. Confirm listing → quality check → admin review → live")
     print("")


### PR DESCRIPTION
## Summary

- Aligns published SDK docs with the server-side **B-threshold** gate. Previously docs said "grade C or above" / "Grade D or F cannot publish" which was inconsistent with the actual publish path.
- Pairs with [siglume#fix/threshold-b-unification](https://github.com/taihei-05/siglume/pull/new/fix/threshold-b-unification) which raises the server gate itself and updates internal docs.

## Files changed

- `README.md`: "Minimum grade B" wording in quality section + acceptance bar
- `GETTING_STARTED.md`: quality table — C row now "No — must improve" / "Below threshold"; confirmation-step wording says A/B proceed
- `RELEASE_NOTES_v0.1.0.md`: highlight updated to mention "Minimum grade B"
- `ANNOUNCEMENT_DRAFT.md`: "Grade C, D, or F cannot be published"
- `examples/hello_price_compare.py`: "grade B or better required" in the next-steps block

## Test plan

- [ ] Read the README and GETTING_STARTED diffs — is the messaging consistent?
- [ ] Confirm the quality-grade table row-labels read clearly for a first-time developer
- [ ] Merge ONLY after the paired server PR is merged (otherwise docs will lead actual enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)