### PR TITLE
docs: PyPI is live — add pip install + badge + Developer Portal URL fix

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -42,7 +42,13 @@ You build APIs by subclassing `AppAdapter`. The SDK handles manifest validation,
 ### Install and run
 
 ```bash
-# Clone the SDK (PyPI package coming soon)
+# Install from PyPI
+pip install siglume-api-sdk
+```
+
+Or clone the repo to browse the examples:
+
+```bash
 git clone https://github.com/taihei-05/siglume-api-sdk.git
 cd siglume-api-sdk
 pip install -e .
@@ -50,8 +56,6 @@ pip install -e .
 # Run the example API
 python examples/hello_price_compare.py
 ```
-
-> **Note:** `pip install siglume-api-sdk` will be available on PyPI in a future release. Use the local install for now.
 
 ### Project structure
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Siglume Agent API Store SDK
 
+[![PyPI](https://img.shields.io/pypi/v/siglume-api-sdk.svg)](https://pypi.org/project/siglume-api-sdk/)
 [![CI](https://github.com/taihei-05/siglume-api-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/taihei-05/siglume-api-sdk/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
@@ -35,7 +36,8 @@ This is the main use case. You build an API, register it, and earn revenue.
 **You do not submit a PR to this repo.** You register directly on the platform.
 No permission needed. No issue to claim. Just build and register.
 
-- **Developer Portal** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (manage your registered APIs)
+- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (create / edit / submit your APIs)
+- **API Store (buyer view)** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
 - **Getting Started** → [GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
 
 ### Improve the SDK itself
@@ -88,6 +90,14 @@ required fields, scoring rules, and examples.
 ---
 
 ## Quick start
+
+Install from PyPI:
+
+```bash
+pip install siglume-api-sdk
+```
+
+Or clone the repo to browse the examples:
 
 ```bash
 git clone https://github.com/taihei-05/siglume-api-sdk.git


### PR DESCRIPTION
## Summary

`siglume-api-sdk 0.1.0` is now live on PyPI:
https://pypi.org/project/siglume-api-sdk/0.1.0/

Updates docs to use `pip install` and fixes an unrelated but important URL bug in README.

## What changed

### README.md
- Added PyPI version badge at top
- Quick start now leads with `pip install siglume-api-sdk`; git clone path kept as an alternative for browsing examples
- **Fix:** Developer Portal link was pointing to `/owner/apps` (the buyer-side API Store). Corrected to `/owner/publish` (the seller surface where developers create / edit / submit APIs)
- Added an explicit "API Store (buyer view)" bullet for `/owner/apps` so the two surfaces are distinguishable

### GETTING_STARTED.md
- Removed "(PyPI package coming soon)" comment in Quick Start code block
- Removed "PyPI coming soon" note below the code block
- Added real `pip install siglume-api-sdk` command

## Test plan

- [ ] Visual review of README — PyPI badge renders, install section reads cleanly
- [ ] Click both Developer Portal and API Store links from README on the rendered GitHub page
- [ ] In a clean venv: `pip install siglume-api-sdk && python -c "from siglume_api_sdk import AppAdapter; print('OK')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)