### PR TITLE
Fix demo-assets README: script path matches stated 'from the SDK root' cwd

### DIFF
--- a/docs/assets/demo/README.md
+++ b/docs/assets/demo/README.md
@@ -3,5 +3,10 @@
 Replace `siglume-owner-publish-demo.gif` with the captured 8-10 second README
 loop after you record the full demo.
 
-Use `../../../scripts/make-demo-gif.ps1` from the SDK root to export the GIF from
-your MP4 source.
+From the SDK root, run:
+
+```powershell
+powershell -File .\scripts\make-demo-gif.ps1 -InputFile .\siglume-demo-90s.mp4
+```
+
+The script writes the GIF back to this directory at `siglume-owner-publish-demo.gif`, so the README picks it up automatically.


### PR DESCRIPTION
Codex review on the (closed) PR #3 flagged an inconsistency — README says 'from the SDK root' but gave a path (`../../../scripts/...`) that only resolves from `docs/assets/demo/`. Now uses `.\scripts\make-demo-gif.ps1` (correct from the SDK root) and shows a full copy-pasteable snippet. Same bug will be fixed in the main repo mirror via a follow-up sync PR.