### PR TITLE
Fix 3 server-parity gaps in validate_tool_manual() (Codex P1)

### DIFF
--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -484,6 +484,52 @@ _PLATFORM_INJECTED_FIELDS = frozenset({
 
 _COMPOSITION_KEYWORDS = frozenset({"oneOf", "anyOf", "allOf"})
 
+# Forbidden keys that must not appear at any nesting depth in input_schema.
+# Mirrors server `_check_forbidden_key` sweep; patternProperties is the
+# headline case because loose property globs defeat schema validation.
+_INPUT_SCHEMA_FORBIDDEN_KEYS = frozenset({"patternProperties"})
+
+
+def _check_schema_forbidden_recursive(
+    schema: Any,
+    root_field: str,
+    err_fn,
+    *,
+    path: str = "",
+) -> None:
+    """Recurse into a JSON Schema rejecting composition keywords and
+    forbidden keys (patternProperties) at any nesting level.
+
+    Server parity: matches `_check_composition_keywords` and
+    `_check_forbidden_key` in
+    `agent_sns.application.capability_runtime.tool_manual_validator`.
+    """
+    if not isinstance(schema, dict):
+        return
+
+    for kw in _COMPOSITION_KEYWORDS:
+        if kw in schema:
+            loc = f"{root_field}.{path}.{kw}" if path else f"{root_field}.{kw}"
+            err_fn("INPUT_SCHEMA",
+                   f"Composition keyword '{kw}' is not allowed in beta{' at ' + path if path else ''}",
+                   loc)
+
+    for forbidden in _INPUT_SCHEMA_FORBIDDEN_KEYS:
+        if forbidden in schema:
+            loc = f"{root_field}.{path}.{forbidden}" if path else f"{root_field}.{forbidden}"
+            err_fn("INPUT_SCHEMA",
+                   f"'{forbidden}' is not allowed{' at ' + path if path else ''}",
+                   loc)
+
+    for key, val in schema.items():
+        if key == "properties" and isinstance(val, dict):
+            for pname, pdef in val.items():
+                sub_path = f"{path}.{pname}" if path else pname
+                _check_schema_forbidden_recursive(pdef, root_field, err_fn, path=sub_path)
+        elif key == "items" and isinstance(val, dict):
+            sub_path = f"{path}.items" if path else "items"
+            _check_schema_forbidden_recursive(val, root_field, err_fn, path=sub_path)
+
 
 def validate_tool_manual(
     manual: dict[str, Any] | ToolManual,
@@ -586,24 +632,45 @@ def validate_tool_manual(
                  "permission_class")
 
     # ── action/payment extra fields ──
+    # Mirror the server validator in agent_sns.application.capability_runtime
+    # .tool_manual_validator: schema fields accept {} as "present", string
+    # fields are validated as non-empty strings, and bools are validated
+    # separately. Using truthiness across all of them over-rejects valid
+    # manuals (e.g. preview_schema = {}) and diverges from publish-time
+    # gating — see Codex review finding.
+    def _require_str(fld: str, ctx: str) -> None:
+        val = manual.get(fld)
+        if val is None:
+            _err("MISSING_FIELD", f"'{fld}' is required for permission_class='{ctx}'", fld)
+        elif not isinstance(val, str) or len(val.strip()) == 0:
+            _err("INVALID_TYPE", f"'{fld}' must be a non-empty string", fld)
+
+    def _require_schema(fld: str, ctx: str) -> None:
+        val = manual.get(fld)
+        if val is None:
+            _err("MISSING_FIELD", f"'{fld}' is required for permission_class='{ctx}'", fld)
+        elif not isinstance(val, dict):
+            _err("INVALID_TYPE", f"'{fld}' must be a JSON Schema object", fld)
+
     if pc in ("action", "payment"):
-        for fld in ["approval_summary_template", "preview_schema",
-                     "idempotency_support", "side_effect_summary"]:
-            if not manual.get(fld):
-                _err("MISSING_FIELD",
-                     f"'{fld}' is required for permission_class='{pc}'", fld)
-        if manual.get("idempotency_support") is not True:
+        _require_str("approval_summary_template", pc)
+        _require_schema("preview_schema", pc)
+        _require_str("side_effect_summary", pc)
+        if "idempotency_support" not in manual:
+            _err("MISSING_FIELD",
+                 f"'idempotency_support' is required for permission_class='{pc}'",
+                 "idempotency_support")
+        elif manual.get("idempotency_support") is not True:
             _err("IDEMPOTENCY_REQUIRED",
                  "idempotency_support must be true for action/payment",
                  "idempotency_support")
 
     if pc == "payment":
-        for fld in ["quote_schema", "currency", "settlement_mode",
-                     "refund_or_cancellation_note"]:
-            if not manual.get(fld):
-                _err("MISSING_FIELD",
-                     f"'{fld}' is required for permission_class='payment'", fld)
-        if manual.get("currency") and manual["currency"] != "USD":
+        _require_schema("quote_schema", "payment")
+        _require_str("currency", "payment")
+        _require_str("settlement_mode", "payment")
+        _require_str("refund_or_cancellation_note", "payment")
+        if isinstance(manual.get("currency"), str) and manual["currency"] != "USD":
             _err("INVALID_CURRENCY", "currency must be 'USD'", "currency")
         sm = manual.get("settlement_mode")
         valid_sm = {"stripe_checkout", "stripe_payment_intent"}
@@ -620,13 +687,12 @@ def validate_tool_manual(
         if inp.get("additionalProperties") is not False:
             _err("INPUT_SCHEMA",
                  "additionalProperties must be false", "input_schema")
-        # composition keywords forbidden
-        for kw in _COMPOSITION_KEYWORDS:
-            if kw in inp:
-                _err("INPUT_SCHEMA",
-                     f"Composition keyword '{kw}' is not allowed in beta",
-                     f"input_schema.{kw}")
-        # platform-injected fields
+        # Composition keywords and patternProperties are forbidden at ANY nesting
+        # level, matching the server's _check_composition_keywords /
+        # _check_forbidden_key recursive sweep. A top-level-only check was
+        # letting nested violations through, producing false confidence.
+        _check_schema_forbidden_recursive(inp, "input_schema", _err)
+        # platform-injected fields (top-level properties only; matches server)
         props = inp.get("properties", {})
         if isinstance(props, dict):
             for pf in _PLATFORM_INJECTED_FIELDS & set(props):
@@ -648,7 +714,11 @@ def validate_tool_manual(
             _err("OUTPUT_SCHEMA",
                  "output_schema must include a 'summary' property",
                  "output_schema.properties")
-        # payment-specific output checks
+        # payment-specific output checks — match server validate_output_schema
+        # which requires BOTH amount_usd AND currency in properties (not just
+        # amount_usd). Previous SDK check only enforced amount_usd in properties
+        # while the server rejected missing currency, leading to a pass-local
+        # / fail-server divergence.
         if pc == "payment":
             if isinstance(out_req, list):
                 if "amount_usd" not in out_req:
@@ -663,6 +733,10 @@ def validate_tool_manual(
                 if "amount_usd" not in oprops:
                     _err("OUTPUT_SCHEMA",
                          "Payment output_schema must include 'amount_usd' in properties",
+                         "output_schema.properties")
+                if "currency" not in oprops:
+                    _err("OUTPUT_SCHEMA",
+                         "Payment output_schema must include 'currency' in properties",
                          "output_schema.properties")
 
     ok = not any(i.severity == "error" for i in issues)


### PR DESCRIPTION
Three Codex P1 findings from the mirror-sync PR, all about SDK validator drifting from server `tool_manual_validator`: (1) truthiness vs presence for schema fields, (2) missing currency-in-properties for payment output_schema, (3) non-recursive composition/patternProperties check in input_schema. Each fix mirrored the server's helper logic; smoke-tested with 4 manuals covering pass and fail paths.