### PR TITLE
docs: polish Dev Container section (brand casing, missing article)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ pip install -e .
 ## Dev Container (optional)
 
 This repository includes a `.devcontainer/` configuration.
-Opening this project in Vs Code or Github Codespaces
-automatically detects the configuration and sets up
+Opening this project in VS Code or GitHub Codespaces
+automatically detects the configuration and sets up a
 ready-to-use development environment.
 
 The container uses Python 3.11 and installs the SDK


### PR DESCRIPTION
Tiny follow-up on @ayushi-wq's #24: fix 'Vs Code' -> 'VS Code', 'Github' -> 'GitHub', and a missing article. Content otherwise preserved.