### PR TITLE
Pivot Phase A: retire Stripe Connect narrative, introduce on-chain settlement docs

### DIFF
--- a/ANNOUNCEMENT_DRAFT.md
+++ b/ANNOUNCEMENT_DRAFT.md
@@ -21,11 +21,11 @@ you register it, and after admin review it goes live.
 When an agent owner subscribes to your API, you receive **93.4%** of
 the subscription revenue. The platform fee is **6.6%**.
 
-- You set the price (minimum $5.00/month for subscriptions)
-- Stripe processes payments and sends revenue directly to your bank account
+- You set the price (minimum $5.00/month equivalent for subscriptions)
+- Settlement is migrating to on-chain embedded smart wallet (platform covers gas, auto-debit subscriptions). See PAYMENT_MIGRATION.md for status.
 - Siglume never holds your funds
 
-Both free and paid subscription listings are available. Developers earn 93.4% of subscription revenue via Stripe Connect.
+Both free and paid subscription listings are available. Free listings are fully live; paid subscription publishing is paused briefly while the on-chain cutover lands.
 
 ## What kind of APIs can you build?
 

--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -14,17 +14,17 @@ The API Store is a marketplace. When an agent owner subscribes to your API,
 **you receive 93.4% of the subscription revenue.** The platform fee is 6.6%.
 
 ```
-Agent owner subscribes to your API ($9.99/month)
-  → Stripe processes payment
-  → Stripe fee:     -$0.59
+Agent owner subscribes to your API ($9.99/month equivalent)
   → Platform fee:   -$0.66 (6.6%)
-  → You receive:     $8.74/month → direct to your bank account
+  → You receive:     ~$9.33/month, settled on-chain to your embedded wallet
 ```
 
 This is not a contract or outsourcing arrangement. You earn revenue when real users
 choose to install and subscribe to your API. Better APIs earn more.
 
-Both free and subscription APIs are supported. Use `price_model="free"` to start, or `price_model="subscription"` with `price_value_minor=999` for a $9.99/month API. Set up Stripe Connect to receive subscription revenue directly.
+> 🔄 **Settlement is migrating.** The platform is moving from Stripe Connect payouts to fully on-chain settlement (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for current status.
+
+Both free and subscription APIs are supported. Use `price_model="free"` to start, or `price_model="subscription"` with `price_value_minor=999` for a $9.99/month API. Paid listings are briefly paused while the on-chain settlement path is cut over.
 
 ## How to publish your API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ First public alpha of the Siglume Agent API Store SDK.
 
 - Developer share **93.4%** of subscription revenue (platform fee 6.6%).
 - Subscription pricing only; minimum **$5.00/month** for paid. Free listings supported.
-- Payouts via **Stripe Connect** direct to developer bank accounts.
+- Payouts via **Stripe Connect** at v0.1.0 time of cut; being migrated to on-chain embedded-wallet settlement — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md). The `SettlementMode` enum values (`stripe_checkout`, `stripe_payment_intent`) will change in a later release when the on-chain contract lands.
 - Enum reserves `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, `PER_ACTION` for future phases; platform currently accepts only `FREE` and `SUBSCRIPTION`.
 
 ### Notes

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -388,7 +388,7 @@ Setting `AUTO` on an `ACTION` or `PAYMENT` API will fail manifest validation.
 
 ### Connected accounts
 
-If your API needs OAuth tokens or API keys from the agent owner (e.g., X/Twitter credentials, Stripe keys), declare them in `required_connected_accounts`. The owner will be prompted to connect these accounts during installation.
+If your API needs OAuth tokens or API keys from the agent owner (e.g., X/Twitter credentials, a third-party provider API key), declare them in `required_connected_accounts`. The owner will be prompted to connect these accounts during installation.
 
 ---
 
@@ -413,7 +413,7 @@ Declare the account type in `required_connected_accounts`. The agent owner conne
 Use `price_model="free"` for free APIs. For subscription APIs, use `price_model="subscription"` with `price_value_minor` set to your monthly price in cents (e.g., 999 for $9.99/month). Minimum subscription price is $5.00/month (500 cents). The following pricing models are available:
 
 - **Free** (`price_model="free"`): Anyone can install. You can convert to subscription pricing at any time.
-- **Subscription** (`price_model="subscription"`): Monthly billing. Fully operational. Developer receives 93.4% each month via Stripe Connect.
+- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement is migrating from Stripe Connect to on-chain embedded-wallet auto-debit — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md). **New paid publishes are paused during the cutover**; free listings (see above) remain fully live.
 
 The SDK enum `PriceModel` also defines `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are **reserved values for future phases** — they are not accepted by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
 
@@ -649,72 +649,41 @@ json={"source_code": code, "i18n": {...}, "price_model": "subscription", "price_
 
 - **Platform fee: 6.6%**
 - **Developer receives: 93.4%**
-- Currency: USD only
-- Payments are processed by Stripe. Siglume never holds your funds.
+- Pricing: USD-denominated (actual settlement currency post-cutover will be announced with the on-chain cutover; see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md))
+- Siglume never holds your funds.
 
-Example for a $9.99/month subscription:
+Example for a $9.99/month-equivalent subscription:
 
-```
-Buyer pays:           $9.99
-Stripe fee:          -$0.59
-Siglume fee (6.6%):  -$0.66
-You receive:          $8.74/month → direct to your bank account
+```text
+Buyer pays:             $9.99
+Siglume fee (6.6%):    -$0.66
+You receive:            ~$9.33/month, settled directly to your wallet
+                        (gas fees covered by the platform)
 ```
 
 ### Setting up payouts (subscription APIs only)
 
-If you choose `price_model="subscription"`, you must register a Stripe Connect account before your API can be published.
+> 🔄 **This section is migrating.** The Stripe Connect onboarding flow documented below is being replaced with an on-chain embedded-wallet flow. Paid subscription **publish** is paused during the cutover. If you want to publish a paid API today, track [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for when the new flow opens. Free listings (`price_model="free"`) are unaffected and can be published now.
 
-**Step 1: Create your Stripe Connect account**
+Historical Stripe-Connect-based flow (being retired):
 
-```bash
-curl -X POST https://siglume.com/v1/market/developer/stripe-connect \
-  -H "Authorization: Bearer YOUR_TOKEN"
-```
+1. `POST /v1/market/developer/stripe-connect` returned an onboarding URL.
+2. Developer completed Stripe identity + bank-account verification once.
+3. `/v1/market/developer/stripe-connect/status` reported `ready: true`.
+4. Subsequent `confirm-auto-register` calls for `price_model="subscription"` went through.
 
-This returns an `onboarding_url`. Open it in your browser and complete:
-- Identity verification (name, address)
-- Bank account for payouts
+The replacement on-chain flow will:
 
-You only need to do this once.
+- Create an embedded smart wallet attached to the developer's Siglume account (no external wallet app needed).
+- Skip per-country bank-verification steps (the wallet is the payout destination).
+- Have the platform cover gas fees end-to-end, so developers never hold the gas token.
+- Use session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades).
 
-**Step 2: Check your status**
-
-```bash
-curl https://siglume.com/v1/market/developer/stripe-connect/status \
-  -H "Authorization: Bearer YOUR_TOKEN"
-```
-
-When `ready: true`, you can publish subscription APIs.
-
-**Step 3: Submit your API**
-
-Now when you call `confirm-auto-register`, it will pass the Stripe check and submit for review.
-
-### Full flow for a subscription API
-
-```
-Your AI:
-  1. Call auto-register with price_model="subscription", price_value_minor=999
-  2. Call confirm → rejected: "Stripe Connect account required"
-
-You (one time only):
-  3. Call POST /v1/market/developer/stripe-connect
-  4. Complete Stripe verification in browser
-
-Your AI:
-  5. Call confirm again → submitted for review
-  6. Admin approves → published in store
-
-After that:
-  - Buyers subscribe → Stripe charges them monthly
-  - 93.4% goes to your bank account automatically
-  - You do nothing — Stripe handles everything
-```
+The new onboarding endpoint, request/response shapes, and SDK enum updates (`SettlementMode` values) will land in a coordinated SDK release; watch the repo's Releases page.
 
 ### Free APIs need no payment setup
 
-If `price_model="free"`, skip all Stripe steps. Your API can be published immediately after admin review.
+If `price_model="free"`, skip the payout setup entirely. Your API can be published immediately after admin review — this path is unaffected by the migration.
 
 ---
 

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -1,0 +1,54 @@
+# Payment Migration: Stripe Connect → On-Chain Smart Wallet
+
+**Status:** in progress — server-side implementation underway
+**Last updated:** 2026-04-18
+
+The Siglume Agent API Store is retiring its Stripe Connect payout stack and moving to **fully on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
+
+## The new model
+
+| Aspect | New behavior |
+|---|---|
+| Settlement | On-chain (wallet-to-wallet) |
+| Developer wallet | **Embedded smart wallet** created for you — no external wallet needed |
+| Gas | **Covered by the platform** — developers and buyers never touch gas tokens |
+| Subscription mechanism | **Auto-debit** via session-key-bound transfers; no manual renewals |
+| Login | Unchanged — Siglume login/OAuth keeps working; wallet is attached to the existing account |
+| Stripe dependency | **None.** The new stack is independent of Stripe (including Stripe Crypto) |
+
+The headline numbers are unchanged: **developer share remains 93.4%**, platform fee is **6.6%**, minimum subscription price is **$5/month equivalent** (the exact on-chain currency will be announced when the server cutover lands).
+
+## What still works today
+
+- Everything in the **READ_ONLY** and **ACTION** permission classes — publishing, registering, executing, receipts, tool-manual validation.
+- **Free** listings (`price_model="free"`) — unaffected by the payment change.
+- SDK types, validators, and examples for non-payment flows — stable.
+
+## What is paused / changing
+
+- **`price_model="subscription"` publish flow** — the onboarding step that required a Stripe Connect account is being replaced. Until the on-chain equivalent lands, new paid subscription publishes are paused server-side. Existing free listings can still be registered.
+- **`SettlementMode` enum values** (`stripe_checkout`, `stripe_payment_intent`) — will be superseded by on-chain values in an upcoming SDK release. The enum is frozen on current values until the server contract stabilises; a follow-up SDK release will change them.
+- **`PAYMENT` permission class examples** — `examples/metamask_connector.py` will be rewritten to demonstrate the new embedded-wallet + gas-sponsored flow once the server contract is finalised.
+- Any doc text that reads "Stripe Connect" as the live mechanism — being rewritten to describe the on-chain flow.
+
+## Why the pivot
+
+The current beta of the SDK talks about Stripe Connect as the only settlement path. Moving to on-chain:
+
+- Removes the per-country Stripe Connect onboarding friction (developers anywhere with a Siglume account can receive revenue without bank-account paperwork).
+- Removes the dependency on Stripe's policy surface for AI-agent transactions.
+- Matches the automatability story — agents subscribe to APIs, so settlement that doesn't need human intervention (auto-debit from session-key-bound transfers) fits better than Stripe checkout flows that assume a human at a browser.
+
+Embedded wallets + gas sponsorship mean this is **not** a "bring your own MetaMask" pivot. Developers and buyers will not see chain mechanics unless they look.
+
+## For SDK users, right now
+
+1. **If your API is READ_ONLY / ACTION / free:** nothing to do. Keep building. The SDK's public API, validators, and examples are unchanged for your flow.
+2. **If you were about to publish a paid subscription API:** wait for the next SDK release. The `SettlementMode` enum will change and you will want to re-register with the new values. The alternative — registering now with Stripe values that are about to be retired — will force re-registration later.
+3. **If you already published a paid subscription API on a previous SDK version:** platform-side migration tooling is part of Codex's current work. No action required from you.
+
+## Tracking
+
+- Server-side implementation: tracked by Codex internally (main-repo `siglume` branch).
+- SDK-side type / enum changes: tracked as a follow-up issue in this repo (linked from the release notes of the SDK version that lands the changes).
+- This doc will be updated when the server cutover is live.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![GitHub Discussions](https://img.shields.io/github/discussions/taihei-05/siglume-api-sdk)](https://github.com/taihei-05/siglume-api-sdk/discussions)
 
-**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue, paid directly to your bank via Stripe Connect.**
+**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue.**
+
+> ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
 
 Siglume is an *Agent API Store* — a marketplace where the customers are **autonomous AI agents**, not humans. You publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription.
 
@@ -15,12 +17,12 @@ Siglume is an *Agent API Store* — a marketplace where the customers are **auto
 <p align="left">
   <img
     src="./docs/assets/demo/siglume-owner-publish-demo.gif"
-    alt="Placeholder for 90s demo: auto-register an API, review it in /owner/publish, let an agent select it, and verify Stripe Connect payout setup"
+    alt="Placeholder for 90s demo: auto-register an API, review it in /owner/publish, let an agent select it, and verify payout setup"
     width="960"
   />
 </p>
 
-> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → Stripe Connect setup) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
+> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → payout setup) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
 > 🚀 **New:** v0.1.0 alpha is out — see the [Getting Started guide](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 
@@ -40,7 +42,7 @@ This is the main use case. You build an API, register it, and earn revenue.
 3. Register: POST /v1/market/capabilities/auto-register
 4. Write a tool manual (this determines if agents select your API)
 5. Confirm → quality check → admin review → listed in the API Store
-6. Agent owners subscribe → you earn 93.4% of revenue via Stripe Connect
+6. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
 ```
 
 **You do not submit a PR to this repo.** You register directly on the platform.
@@ -71,12 +73,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 |---|---|
 | **Developer share** | 93.4% of subscription revenue |
 | **Platform fee** | 6.6% |
-| **Payment processor** | Stripe Connect (direct to your bank account) |
-| **Minimum price** | $5.00/month for subscription APIs |
-| **Free APIs** | Also supported — no payment setup needed |
+| **Settlement** | On-chain to an embedded wallet (migrating from Stripe Connect — see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md)) |
+| **Gas fees** | Covered by the platform — developers and buyers never touch gas tokens |
+| **Minimum price** | $5.00/month equivalent for subscription APIs |
+| **Free APIs** | Also supported — no wallet setup required for free listings |
 
-Both free and paid subscription APIs are supported.
-Stripe Connect payments are fully operational.
+Both free and paid subscription APIs are supported. Free listings are fully live today; paid subscription publishing is paused briefly while the on-chain settlement path is cut over.
 
 > **Note:** The SDK `PriceModel` enum includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`,
 > and `PER_ACTION`. These are **reserved for future phases** and are not accepted

--- a/RELEASE_NOTES_v0.1.0.md
+++ b/RELEASE_NOTES_v0.1.0.md
@@ -1,6 +1,8 @@
 # v0.1.0 — First public alpha
 
-**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue, paid directly via Stripe Connect.**
+**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue.**
+
+> ⚠️ **Payment stack is migrating** after v0.1.0: Stripe Connect → on-chain settlement via embedded smart wallet (platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md).
 
 This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets you publish APIs to a marketplace where the *customers are autonomous AI agents*.
 
@@ -21,7 +23,7 @@ This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets 
 |---|---|
 | Developer share | **93.4%** of subscription revenue |
 | Platform fee | 6.6% |
-| Payouts | Stripe Connect (direct to your bank) |
+| Payouts | Stripe Connect at v0.1.0; migrating to on-chain embedded-wallet settlement ([details](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md)) |
 | Minimum price | $5.00/month (free listings also supported) |
 
 ## Quick start

--- a/announcements/POST_HACKERNEWS.md
+++ b/announcements/POST_HACKERNEWS.md
@@ -1,5 +1,7 @@
 # Hacker News
 
+> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement paragraph per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
+
 Title: Show HN: API Store for AI Agents – Python SDK for building agent extensions
 
 ---

--- a/announcements/POST_REDDIT.md
+++ b/announcements/POST_REDDIT.md
@@ -1,5 +1,7 @@
 # Reddit Post
 
+> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement paragraph per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
+
 Subreddit: r/SideProject (or r/MachineLearning, r/Python)
 Title: We built an API store for AI agents — SDK is public, looking for the first developers
 

--- a/announcements/POST_X_TWITTER.md
+++ b/announcements/POST_X_TWITTER.md
@@ -1,5 +1,7 @@
 # X/Twitter 投稿スレッド
 
+> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement line per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
+
 コピペしてそのまま投稿できます。5ツイートのスレッドです。
 
 ---

--- a/announcements/POST_ZENN.md
+++ b/announcements/POST_ZENN.md
@@ -1,5 +1,7 @@
 # Zenn 記事
 
+> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement paragraph per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
+
 タイトル: AIエージェント用のAPI Store、ベータ公開しました。開発者募集中
 emoji: 🤖
 type: tech

--- a/announcements/README.md
+++ b/announcements/README.md
@@ -9,24 +9,40 @@ Launch and community-recruitment copy for the public Siglume Agent API Store SDK
 - `GITHUB_ISSUE_CONTENT.md`
   Rich body copy for the current seeded GitHub issues and discussions.
 
+> ⚠️ **Drafts are stale on the payment story.** Every POST\_\*.md in this
+> folder still says "payments live via Stripe Connect". That claim is
+> being retired: Siglume is moving to on-chain embedded-wallet
+> settlement (platform-covered gas, auto-debit subscriptions). **Do
+> not post any of these drafts as-is** until the `Current Beta
+> Positioning` block below is re-applied to each file. The SDK's
+> [`PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) is the source of
+> truth during the cutover.
+
 ## Current Beta Positioning
 
 Use these assets with the current public beta message:
 
 - The API Store supports both free and paid subscription listings.
 - Developers can create, submit, publish, license, and install APIs.
-- Payments and payouts are live via Stripe Connect.
-- Current economics:
+- **Settlement** is migrating from Stripe Connect to on-chain embedded
+  smart wallet. Free listings remain fully live; paid subscription
+  publish is paused briefly for the cutover. See
+  [`PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md).
+- Current economics (unchanged):
   - Developer share: 93.4 percent
   - Platform fee: 6.6 percent
 
 ## Publishing Notes
 
 - Prefer honest wording over hype.
-- Paid subscription monetization is live via Stripe Connect.
+- **Do not claim "Stripe Connect payments are live"** — that line is
+  being retired. Use "settlement migrating to on-chain embedded
+  wallet, free listings live, paid publish paused during cutover"
+  for any re-draft.
 - "Agent-driven sales" is planned functionality, not yet live.
 - Link back to:
   - `README.md`
   - `GETTING_STARTED.md`
   - `API_IDEAS.md`
   - `COMMUNITY_LAUNCH.md`
+  - `PAYMENT_MIGRATION.md`

--- a/docs/demo-capture-guide.md
+++ b/docs/demo-capture-guide.md
@@ -13,8 +13,11 @@ The current beta separates buyer and seller flows:
 - `/owner/receipts` is the execution audit trail
 
 For the current beta, do not present live payout settlement as already
-available. Show Stripe Connect payout setup or connected state instead. Paid
-monetization is still documented as a later phase.
+available. The payment stack is migrating from Stripe Connect to on-chain
+embedded-wallet settlement (see `PAYMENT_MIGRATION.md`) — during the
+transition, show payout **setup / connected state** (whichever the UI
+currently renders on `/owner/publish` → `Settings`), not a live payout event.
+Paid monetization is still documented as a later phase.
 
 ## Recommended demo flow
 
@@ -30,8 +33,9 @@ because viewers can understand the job-to-be-done in a single glance.
 5. Open `/owner/installed-tools` and create an execution intent for the app.
 6. Open `/owner/receipts` and show the receipt summary, approval state, and
    step details if available.
-7. Return to `/owner/publish`, open the `Settings` tab, and show the Stripe
-   Connect setup or connected state.
+7. Return to `/owner/publish`, open the `Settings` tab, and show the current
+   payout setup or connected state (legacy Stripe Connect card or the new
+   embedded-wallet card — whichever the UI renders during the migration).
 
 Optional: if you want a public-store establishing shot, prepend a 2-3 second
 cut of `/owner/apps` before the seller flow. Do not use `/owner/apps` as the
@@ -114,14 +118,14 @@ Voiceover:
 ### 82s-90s
 
 Screen:
-Return to `/owner/publish`, switch to `Settings`, and show the Stripe Connect
-section.
+Return to `/owner/publish`, switch to `Settings`, and show the payout section
+(Stripe Connect card or on-chain embedded-wallet card, whichever is current).
 
 On-screen text:
 `6. Verify payout setup`
 
 Voiceover:
-`When paid monetization is enabled, this is where payout readiness connects through Stripe Connect.`
+`When paid monetization is enabled, this is where your payout wallet connects. The platform is transitioning to on-chain settlement with gas covered; see PAYMENT_MIGRATION.md for the cutover timeline.`
 
 ## Short README GIF
 
@@ -130,7 +134,7 @@ three beats:
 
 1. `/owner/publish` overview
 2. `Sandbox` result or `/owner/installed-tools` execute click
-3. `/owner/receipts` or Stripe Connect setup state
+3. `/owner/receipts` or payout setup state
 
 This keeps the README lightweight while still proving the flow.
 
@@ -144,7 +148,7 @@ This keeps the README lightweight while still proving the flow.
 - Use `125%-150%` browser zoom so text stays readable.
 - Move the cursor slowly and disable notifications.
 - Blur personal data, external account identifiers, and anything tied to a
-  real Stripe destination.
+  real payout destination (bank account or wallet address).
 
 ## Export the README GIF
 
@@ -174,7 +178,7 @@ docs/assets/demo/siglume-owner-publish-demo.gif
   <a href="https://www.loom.com/share/REPLACE_WITH_YOUR_90S_VIDEO_URL">
     <img
       src="./docs/assets/demo/siglume-owner-publish-demo.gif"
-      alt="Demo: auto-register an API, review it in the developer portal, let an agent select it, and verify Stripe Connect payout setup"
+      alt="Demo: auto-register an API, review it in the developer portal, let an agent select it, and verify payout setup"
       width="960"
     />
   </a>

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -10,11 +10,23 @@ The `jurisdiction` field is also the basis for the country-flag icon the
 Agent API Store renders next to each listing — an instant visual cue of
 where the API is "from".
 
+> 🔄 **Payment-stack migration notice.** This document still references
+> Stripe Connect in several places. The platform is transitioning to
+> on-chain embedded-wallet settlement; the compliance surface there
+> differs (e.g. country-scoped payout rails are replaced by wallet-based
+> settlement). See [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for
+> the current cutover state. The **jurisdiction declaration requirement
+> itself is unchanged** — consumer-protection, tax, and data-residency
+> obligations continue to apply regardless of the settlement mechanism.
+
 ## Why this is required
 
-- **Payments**: Stripe Connect destination charges and refund rules vary by
-  country; a US-jurisdiction API settles under US Card-Act-style rules, a
-  JP-jurisdiction API under 資金決済法.
+- **Payments**: the legacy Stripe Connect payout rails had per-country
+  destination-charge and refund rules (a US-jurisdiction API settled
+  under US Card-Act-style rules, a JP-jurisdiction API under 資金決済法).
+  On-chain settlement shifts the mechanics, but cross-border consumer
+  protection, chargeback equivalents, and refund-note obligations still
+  track the declared jurisdiction.
 - **Consumer protection**: CA residents get CCPA, EU residents get GDPR,
   JP residents get 特定商取引法. The platform surfaces this so owners can
   evaluate risk before subscribing.
@@ -111,7 +123,7 @@ manual = ToolManual(
     approval_summary_template="Charge ${amount} to {card}?",
     preview_schema={...},
     idempotency_support=True,
-    side_effect_summary="Creates a Stripe payment intent for the owner.",
+    side_effect_summary="Debits the owner's connected wallet via the platform's payment adapter.",
     quote_schema={...},
     currency="USD",
     settlement_mode=SettlementMode.STRIPE_PAYMENT_INTENT,
@@ -132,8 +144,11 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
   time.
 - **JSON schemas** (`schemas/app-manifest.schema.json`,
   `schemas/tool-manual.schema.json`) enforce `pattern: ^[A-Z]{2}(-[A-Z0-9]{1,3})?$`.
-- **Platform-side**: the review step checks the declared jurisdiction against
-  the developer's Stripe Connect onboarding country. Mismatches surface as a
+- **Platform-side**: the review step checks the declared jurisdiction for
+  consistency with the developer's payout setup (historically the Stripe
+  Connect onboarding country; during the on-chain migration this will move
+  to a wallet/account-level declaration — see
+  [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md)). Mismatches surface as a
   quality-report warning.
 
 ## Applicable regulations
@@ -160,8 +175,9 @@ dollars. This is enforced:
 - The platform's registration endpoint rejects non-USD payloads with a 422
   (`CURRENCY_NOT_SUPPORTED`).
 
-Why: Stripe Connect destination charges, platform-fee accounting, the 93.4% /
-6.6% revenue split, and the $5.00/month minimum for subscription APIs all
+Why: the payout rail (Stripe Connect today, on-chain embedded wallet after
+cutover), platform-fee accounting, the 93.4% / 6.6% revenue split, and the
+$5.00/month minimum for subscription APIs all
 operate in USD. Mixing currencies would fragment payouts and break the fee
 model.
 
@@ -189,5 +205,7 @@ A: Changing it is a breaking change to your terms of service. Create a new
 version (bump `version` in the manifest) and re-submit for review.
 
 **Q: What if I don't know what to put?**
-A: Use the country where your Stripe Connect account is registered. That's
-where you're invoicing from, so that's your jurisdiction.
+A: Use the country where you are a legal resident for tax and invoicing
+purposes. That's your jurisdiction. (Historically the answer was tied to
+your Stripe Connect onboarding country; with the on-chain migration this
+becomes a direct self-declaration rather than inferred from payout rails.)

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -120,7 +120,9 @@ async def main():
     print("  3. POST /v1/market/capabilities/auto-register with this manifest")
     print("  4. Confirm listing -> quality check -> admin review -> live")
     print("")
-    print("Revenue is paid via Stripe Connect (93.4% developer share).")
+    print("Revenue share: 93.4% developer / 6.6% platform.")
+    print("Settlement: migrating from Stripe Connect to on-chain embedded wallet")
+    print("(gas covered by the platform). See PAYMENT_MIGRATION.md for details.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions, independent of Stripe Crypto). Server-side implementation is in progress (Codex). This PR is **Phase A**: SDK-side doc edits that are safe to land without waiting for the final server contract.

## Phase A (this PR)

- **NEW** `PAYMENT_MIGRATION.md` — single source of truth for what changes, what's still live (READ_ONLY / ACTION / free), what's paused (paid publish), and why.
- **README / CHANGELOG / RELEASE_NOTES** — Stripe Connect claims annotated as migrating; `SettlementMode` enum retirement flagged.
- **GETTING_STARTED** — Stripe Connect onboarding section replaced with migration notice + historical summary + on-chain replacement sketch. Paid publish explicitly marked paused; free flow unchanged.
- **API_IDEAS** — revenue breakdown example rewritten to drop Stripe fee, mention on-chain.
- **ANNOUNCEMENT_DRAFT** — Stripe bullet replaced.
- **docs/jurisdiction-and-compliance** — migration notice; Stripe-specific paragraphs neutralised while keeping the jurisdiction-declaration requirement itself.
- **docs/demo-capture-guide** — 90s Settings beat drops Stripe Connect references.
- **examples/hello_price_compare.py** — closing print lines describe new settlement.
- **announcements/** — `README.md` + all 4 POST_\*.md drafts blocked with "STALE DRAFT — DO NOT POST AS-IS" notices until the settlement paragraph is re-drafted.

## Phase B (NOT in this PR — waits on Codex)

- `SettlementMode` enum values across `siglume_api_sdk.py`, `siglume-api-types.ts`, `schemas/tool-manual.schema.json`, `openapi/developer-surface.yaml`, and the `valid_sm` set in `validate_tool_manual()`.
- New `AppManifest` / `ToolManual` fields for on-chain config (wallet / chain / token, etc.).
- `examples/metamask_connector.py` rewrite (new embedded-wallet + gas-sponsored + auto-debit shape).

Phase B will be its own PR cut as **v0.2.0** (SDK release with public enum changes). A separate tracking issue will coordinate with Codex's server work.

## Test plan

- [x] Grep shows 0 "live via Stripe Connect" claims in README / CHANGELOG / RELEASE_NOTES / ANNOUNCEMENT_DRAFT / API_IDEAS / hello_price_compare / demo-capture-guide / GETTING_STARTED (pricing section)
- [x] Announcement drafts flagged at top; `announcements/README.md` calls them stale
- [x] `PAYMENT_MIGRATION.md` is the only place a reader needs to check for current state
- [ ] Visual review of README for tone consistency
- [ ] Confirm no claim "on-chain settlement is live today" — everything is phrased as migrating

🤖 Generated with [Claude Code](https://claude.com/claude-code)