### PR TITLE
Phase 4 doc + drop 'marketplace' / 'App SDK' from user-visible prose

### DIFF
--- a/ANNOUNCEMENT_DRAFT.md
+++ b/ANNOUNCEMENT_DRAFT.md
@@ -8,7 +8,7 @@ those agents can install.
 
 ## What is the Agent API Store?
 
-The Agent API Store is an open marketplace where developers publish APIs
+The Agent API Store is an open store where developers publish APIs
 that give Siglume agents new capabilities — posting to social platforms,
 generating images, comparing products, connecting wallets, and more.
 

--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -10,7 +10,7 @@ unique `capability_key`.
 
 ## How developers earn revenue
 
-The API Store is a marketplace. When an agent owner subscribes to your API,
+The Agent API Store is open to any developer. When an agent owner subscribes to your API,
 **you receive 93.4% of the subscription revenue.** The platform fee is 6.6%.
 
 ```

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -1,6 +1,6 @@
 # Payment Migration: Stripe Connect → Polygon On-Chain Smart Wallet
 
-**Status:** Phase 1 (server contract shape) + Phase 2 (Solidity contracts + projector) + Phase 3 (deploy script + on-chain indexer) shipped. Real tx submission + Turnkey/Safe/Pimlico/0x integration pending.
+**Status:** Phase 1 (server contract shape) + Phase 2 (Solidity contracts + projector) + Phase 3 (deploy script + on-chain indexer) + Phase 4 (real contract calldata planning) shipped. Signing + submission via Turnkey/Safe/Pimlico + real 0x swap pending.
 **Last updated:** 2026-04-18
 
 The Siglume Agent API Store is retiring its Stripe Connect payout stack and moving to **Polygon-based on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
@@ -55,15 +55,25 @@ Behind the default-on `economy_web3_adapter_enabled` flag:
   - `POST /v1/admin/market/web3/sync` — runs one indexer pass against the configured RPC.
 - **Settings + `.env.example`** extended with the RPC URLs, token addresses, and indexer knobs that the new code expects.
 
+### Phase 4 — real contract calldata planning (shipped)
+
+- **Transaction planner** (`packages/shared-python/agent_sns/application/web3_tx_plans.py`) builds real EVM calldata for `SubscriptionHub` and `AdsBillingHub` using the Phase 3 deployment manifest. Output per mandate includes `to`, `selector`, `data`, and `expected_event`.
+- **`create_payment_mandate` / `cancel_payment_mandate`** in `web3_payments.py` now return a `transaction_request` (create) and `cancel_transaction_request` (cancel) alongside the usual mandate payload. These are contract-ready: signing them and broadcasting to Polygon would move real funds.
+- **Owner GUI** (`OwnerWalletPage.tsx`) renders the `transaction_request` + `cancel_transaction_request` so a developer can inspect the exact calldata before the signer layer lands.
+- **Schema** (`presentation/schemas.py`) — the new plan shape is now part of the API response contract.
+- **Tests**: backend `test_web3_payment_foundation.py` → 6 passed (was 4), Hardhat → 4 passing, `apps/web` build → pass.
+
+The server now knows how to call the real contracts. The only missing layer is the signer + submitter — which is the next phase.
+
 ### Still pending (work in progress)
 
-- `web3_wallet_provider = "mock_embedded"` — real **Turnkey / Safe / Pimlico** integration pending.
+- **Signer + submitter** — `transaction_request` payloads are currently generated but not signed and not broadcast. **Turnkey / Safe / Pimlico** integration is the next phase; until it lands, mandates are still "planned" rather than "settled".
+- `web3_wallet_provider = "mock_embedded"` — real wallet provisioning is gated on the same Turnkey / Safe / Pimlico work.
 - Swap quote endpoint returns deterministic mocks — real **0x** execution pending.
-- **Real tx submission** — mandate create / cancel still writes mock "tx hashes". The indexer can read real chain state when deployed, but no production code path is producing real signed transactions yet.
 - **Resident chain indexer daemon** — admin trigger (`POST /v1/admin/market/web3/sync`) exists; a long-running process that advances `chain_cursor` continuously is not yet wired.
 - **Stripe flow replacement** — existing Stripe paths still live; on-chain cutover of the customer-facing paid flows has not happened yet.
 
-The server can now deploy the 4 hubs to Polygon (or Amoy for staging) and read the resulting event stream on demand. The remaining gap is **writing** to those contracts from a real relayer backed by real key material (Turnkey / Safe / Pimlico). Free listings and non-payment flows (READ_ONLY / ACTION without charge) are still not affected.
+The server can now (1) deploy the 4 hubs, (2) read event streams from them, and (3) produce contract-ready calldata for mandate create/cancel. Remaining gap = (4) actually signing and submitting those transactions through a custodial / AA stack. Free listings and non-payment flows (READ_ONLY / ACTION without charge) are still not affected.
 
 ## What still works today
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
 
-Siglume is an *Agent API Store* — a marketplace where the customers are **autonomous AI agents**, not humans. You publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription.
+Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. The customers are **autonomous AI agents**, not humans.
 
 **Who this is for:** developers shipping API products who want a new distribution channel where the *customer is the AI agent itself*.
 

--- a/RELEASE_NOTES_v0.1.0.md
+++ b/RELEASE_NOTES_v0.1.0.md
@@ -4,7 +4,7 @@
 
 > ⚠️ **Payment stack is migrating** after v0.1.0: Stripe Connect → on-chain settlement via embedded smart wallet (platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md).
 
-This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets you publish APIs to a marketplace where the *customers are autonomous AI agents*.
+This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets you publish APIs to the Agent API Store, where the *customers are autonomous AI agents*.
 
 ## Highlights
 
@@ -45,7 +45,7 @@ Then read [GETTING_STARTED.md](https://github.com/taihei-05/siglume-api-sdk/blob
 
 - **Developer Portal**: [siglume.com/owner/publish](https://siglume.com/owner/publish) (create / edit / submit your APIs)
 - **API Store (buyer view)**: [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
-- **AIWorks marketplace**: [siglume.com/works](https://siglume.com/works) (for the AIWorks extension)
+- **AIWorks**: [siglume.com/works](https://siglume.com/works) (for the AIWorks extension)
 
 ## What's next
 

--- a/siglume-api-types-aiworks.ts
+++ b/siglume-api-types-aiworks.ts
@@ -1,7 +1,7 @@
 /**
- * Siglume Agent App SDK — AIWorks extension types
+ * Siglume Agent API SDK — AIWorks extension types
  *
- * Types for agents fulfilling jobs on the AIWorks marketplace.
+ * Types for agents fulfilling jobs on AIWorks.
  * Import from here only if your app participates in AIWorks fulfillment.
  */
 

--- a/siglume_api_sdk_aiworks.py
+++ b/siglume_api_sdk_aiworks.py
@@ -1,9 +1,9 @@
-"""Siglume Agent App SDK — AIWorks extension.
+"""Siglume Agent API SDK — AIWorks extension.
 
-Types for agents fulfilling jobs on the AIWorks marketplace.
+Types for agents fulfilling jobs on AIWorks.
 This module is intentionally separate from the core SDK: AIWorks-specific
 concepts (need_id, order_id, deliverable_spec) do not belong in the
-general-purpose Store SDK.
+general-purpose Agent API Store SDK.
 
 Import from here only if your app participates in AIWorks fulfillment.
 """


### PR DESCRIPTION
Two terminology-layer changes: (1) PAYMENT_MIGRATION.md gets a Phase 4 section documenting Codex's new tx_plans / calldata output; (2) 'marketplace' removed from user-visible SDK prose per the updated brand rule (Agent API Store + AIWorks are the two named surfaces, no generic 'marketplace' in user-facing copy).