### PR TITLE
release(v0.2.0): SettlementMode expands to polygon_mandate + embedded_wallet_charge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2026-04-18
+
+The on-chain migration's first SDK-visible phase. `SettlementMode` gains two Polygon-aware values.
+
+### Changed (breaking for producers)
+
+- **`SettlementMode` enum expanded** from `{stripe_checkout, stripe_payment_intent}` to `{stripe_checkout, stripe_payment_intent, polygon_mandate, embedded_wallet_charge}`. Consumers reading `SettlementMode` are unaffected; code that exhaustively matches on the enum or passes producer-side values will need updating. The expansion is a breaking change in semver terms (new value means `isinstance(sm, SettlementMode)` behaves differently downstream), hence the major-in-zerover bump to 0.2.0.
+- `validate_tool_manual()` now accepts the two new values on `settlement_mode`. Tool manuals declaring `polygon_mandate` or `embedded_wallet_charge` will validate; the same tool manual on v0.1.x would fail `INVALID_SETTLEMENT_MODE`.
+- TypeScript `SettlementMode` union, JSON Schema `settlement_mode.enum`, and OpenAPI `settlement_mode.enum` all mirror the expansion.
+
+### What is and isn't live yet
+
+- **Live now (server-side)**: metadata / validator / approval propagation. Tool manuals declaring the new modes validate, flow through the resolver, appear in dry-run preview, approval snapshot, `intent.plan_jsonb`, and the installed-tools API. The Owner Installed Tools page surfaces `settlement_mode` / `settlement_currency` / `settlement_network` / `accepted_payment_tokens`.
+- **Not yet live**: the payment-permission tool execution itself actually settling on Web3. The execution path that would `charge()` via a Polygon mandate or embedded-wallet drain is a subsequent phase; today declaring the new mode is a *metadata* commitment, not a runtime change.
+
+### Migration
+
+- **If your tool manual declares `payment` class**: no action required unless you want to opt into the new modes. Existing `stripe_checkout` / `stripe_payment_intent` declarations continue to validate.
+- **If you want to opt in**: set `settlement_mode="polygon_mandate"` for subscription-style auto-debit against an on-chain mandate, or `"embedded_wallet_charge"` for a one-shot charge against the user's embedded smart wallet. Currency remains USD; `accepted_payment_tokens` (USDC / JPYC on Polygon) and `settlement_network` ("polygon" / "polygon-amoy") are the adjacent fields the platform consumes.
+- **TypeScript consumers**: exhaustive switch / match on `SettlementMode` will now surface a type error on the two new values. Extend your cases or narrow the type at the boundary.
+
+### Context
+
+- Builds on the Phase 31 live completion on Polygon Amoy (2026-04-18). See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log, including the real `userOpHash` / `tx_hash` from the first on-chain completion.
+- `ONE_TIME` / `BUNDLE` / `USAGE_BASED` / `PER_ACTION` remain reserved on `PriceModel`; no price-model change in v0.2.0.
+- Payouts are now Polygon on-chain settlement (Turnkey-backed embedded smart wallets + Pimlico-sponsored gas) as of the Amoy live completion. Stripe Connect is retired for subscription purchases on platforms where the seller has a verified Polygon payout wallet.
+
 ## [0.1.0] — 2026-04-17
 
 First public alpha of the Siglume Agent API Store SDK.
@@ -37,4 +64,5 @@ First public alpha of the Siglume Agent API Store SDK.
 - Currency is enforced as USD on `AppManifest`.
 - This is an early-stage alpha — SDK shape may change before v1.0. Pin to exact versions in production builds.
 
+[0.2.0]: https://github.com/taihei-05/siglume-api-sdk/releases/tag/v0.2.0
 [0.1.0]: https://github.com/taihei-05/siglume-api-sdk/releases/tag/v0.1.0

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -1,6 +1,6 @@
 # Payment Migration: Stripe Connect → Polygon On-Chain Smart Wallet
 
-**Status:** Phases 1–32 shipped. Phase 32 completes Codex's stated priority #2 — **the resident Web3 indexer daemon is now running** with heartbeat / stale detection, runner ID, cycle counting, and admin-visible state. Local daemon PID `11056` (`runner_id=web3-indexer-afa01f3f1e7d`) is actively catching up from `synced_to_block=36833713` to `latest=36839286` with a 2,000-block batch, and the Admin Settlement Ops page surfaces `daemon_state / runner / heartbeat_seconds / stale_after_seconds`. Phase 31's real Amoy completion (`userOpHash=0xaa55cbae...`, `tx_hash=0xa04699ff...`, block `36829663`) stands. **Codex has explicitly stated the next workstream is Axis 2 migration design — which is the SDK v0.2.0 breaking-release trigger.** Drafting on the SDK side can begin in parallel. SDK v0.2.0 is still unreleased; `SettlementMode` / `VALID_SETTLEMENT_MODES` / `_VALID_PRICE_MODELS` remain unchanged.
+**Status:** Phases 1–33 shipped. **Phase 33 fires the SDK v0.2.0 breaking trigger.** Server `VALID_SETTLEMENT_MODES` expanded from `{stripe_checkout, stripe_payment_intent}` to `{stripe_checkout, stripe_payment_intent, polygon_mandate, embedded_wallet_charge}`, threaded through the tool runtime (resolver → dry-run preview → approval snapshot → `intent.plan_jsonb` → installed-tools API) and surfaced on the Owner Installed Tools page. SDK v0.2.0 is being released alongside this phase to mirror the enum expansion (`siglume_api_sdk.py` / `siglume-api-types.ts` / `tool-manual.schema.json` / `developer-surface.yaml` all updated). **Important scope note**: Phase 33 delivers metadata / validator / approval propagation for Axis 2. The payment-permission tool execution itself does not yet actually settle via Polygon — declaring `polygon_mandate` or `embedded_wallet_charge` is a metadata commitment that the platform validates and propagates, but the runtime charge path is a subsequent phase.
 **Last updated:** 2026-04-18
 
 The Siglume Agent API Store is retiring its Stripe Connect payout stack and moving to **Polygon-based on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
@@ -584,11 +584,55 @@ Codex's stated priority #2 from 2026-04-17 delivered: the standing indexer daemo
 
 **SDK-side impact: none yet.** Daemon runtime and admin surface are platform-internal; no AppManifest / ToolManual contract change. The *next* phase — Axis 2 design — is where SDK contract finally moves.
 
+### Phase 33 — Axis 2 first vertical: `SettlementMode` expands, SDK v0.2.0 cut 🎯 (shipped 2026-04-18)
+
+**The SDK v0.2.0 breaking trigger has fired.** Server `VALID_SETTLEMENT_MODES` is no longer frozen at `{stripe_checkout, stripe_payment_intent}` — it now accepts `polygon_mandate` and `embedded_wallet_charge`. The SDK mirror (`packages/contracts/sdk/`) and the public SDK repo (`siglume-api-sdk`) both carry the same expansion in this phase.
+
+**Shipped (server side):**
+
+- **`SettlementMode` enum expanded on the server**: `polygon_mandate`, `embedded_wallet_charge` added
+- **Tool runtime threading** — `settlement_mode` / `settlement_currency` / `settlement_network` / `accepted_payment_tokens` flow from `tool_manual_validator.py` → `installed_tool_resolver.py` → `capability_gateway.py` → `tool_use_runtime.py` → `tool_use_api.py` through dry-run preview, approval snapshot, `intent.plan_jsonb`, and the installed-tools API response
+- **Owner Installed Tools page** (`OwnerInstalledToolsPage.tsx`) displays settlement rail and accepted tokens per installed tool
+- **Tests**: `test_tool_use_axis2.py` + `test_web3_payment_foundation.py` → 23 passed combined, `apps/web` build pass, `py_compile` pass
+
+**Shipped (SDK side, v0.2.0 cut):**
+
+- `siglume_api_sdk.py`: `SettlementMode` enum and `validate_tool_manual()` whitelist both expanded
+- `siglume-api-types.ts`: TypeScript union extended
+- `schemas/tool-manual.schema.json`: JSON Schema `settlement_mode.enum` extended
+- `openapi/developer-surface.yaml`: OpenAPI `settlement_mode.enum` extended
+- `pyproject.toml`: version bumped `0.1.0 → 0.2.0`
+- `CHANGELOG.md`: v0.2.0 entry with migration guide
+- `RELEASE_NOTES_v0.2.0.md`: full release notes
+
+**Important scope note from Codex (explicit):**
+
+> 今回入ったのは Axis 2 の metadata / validator / approval propagation です。payment permission の tool 実行そのものが、もう Web3 で本当に settle するところまではまだ入っていません。
+
+Phase 33 makes the new modes **declarable and propagatable** — a tool manual with `settlement_mode="polygon_mandate"` validates on v0.2.0, flows through the approval surfaces, and appears in the installed-tools API. But the actual runtime path where `charge()` fires against a Polygon mandate or embedded-wallet drain is a subsequent phase. For today: declaring the new mode is a metadata commitment the platform honors (it will validate, resolve, preview, approve), not a runtime behavior change.
+
+**Significance (SDK-facing):**
+
+- v0.2.0 is the first SDK release where declining to upgrade is a real signal. Developers who want to opt into Polygon settlement must upgrade to v0.2.0; staying on v0.1.x means the validator will reject `polygon_mandate` / `embedded_wallet_charge` before the platform ever sees the manifest.
+- Existing `stripe_checkout` / `stripe_payment_intent` tool manuals continue to validate and run unchanged — no forced migration; the two new values are additive opt-in paths.
+- The Phase 9 note ("paid subscription publish is unpaused for sellers with a verified Polygon payout wallet") — which moved from "mock-backed" to "real-Polygon-backed" at Phase 31 — is now additionally backed by a matching SDK contract.
+
+**Codex confirmed unchanged:**
+
+- `_VALID_PRICE_MODELS` still frozen at `{free, subscription}`; `USAGE_BASED` / `PER_ACTION` remain reserved
+- Payment-permission tool runtime still dispatches through Stripe for now when `stripe_*` is declared; Polygon-mode runtime dispatch is the next phase (Phase 34+)
+
+**What the SDK v0.2.0 release does not include (deliberate):**
+
+- `examples/metamask_connector.py` is still the old "bring your own MetaMask + direct-sign" stub. That rewrite is scheduled for when the runtime Web3 dispatch lands — otherwise the example would demo a value the platform doesn't yet actually execute.
+- No new fields on `ToolManual` beyond the enum value expansion. `accepted_payment_tokens` / `settlement_currency` / `settlement_network` are *server-side* metadata the platform derives and surfaces — SDK still declares only `settlement_mode` on the tool manual.
+
 ### Still pending (work in progress)
 
 - ~~**Real Turnkey + Pimlico + Amoy end-to-end validation**~~ — **DONE in Phase 31** (2026-04-18). First real userOp landed on Polygon Amoy: `userOpHash=0xaa55cbae...`, `tx_hash=0xa04699ff...`, block 36829663. Telemetry fields captured live values.
 - ~~**Resident (standing) indexer daemon**~~ — **DONE in Phase 32** (2026-04-18). Running with heartbeat / stale detection; local runner `web3-indexer-afa01f3f1e7d` catching up from lag 5561 blocks at 2000/cycle.
-- **Axis 2 migration design** — Codex's explicit next workstream. This is the SDK v0.2.0 trigger: when server `VALID_SETTLEMENT_MODES` gains a Web3 value, SDK must follow synchronously. Draft work on the SDK side can start in parallel now.
+- ~~**Axis 2 migration design**~~ — **first vertical DONE in Phase 33** (2026-04-18). `SettlementMode` gained `polygon_mandate` + `embedded_wallet_charge`; SDK v0.2.0 cut to mirror. Metadata / validator / approval propagation live. Runtime dispatch to Polygon settlement remains for a follow-up phase.
+- **Payment-permission tool runtime dispatch to Polygon** — declared `polygon_mandate` / `embedded_wallet_charge` in a tool manual is honored through approval and snapshot surfaces today, but execution-time `charge()` does not yet fire an on-chain Polygon settlement. Next phase.
 - **Tool-execution Axis 2 migration** — still the actual SDK v0.2.0 trigger. Whenever `VALID_SETTLEMENT_MODES` on the server gains a Web3 value, SDK must follow synchronously. Not yet in Codex's roadmap.
 - **Replace `amoy.json` placeholder manifest** — dev-only, covers `subscription_hub` + `ads_billing_hub` + `works_escrow_hub` + `fee_vault`. Must be replaced with real addresses before any chain exposure (prerequisite for the Amoy end-to-end run above).
 - **0x real swap execution** — swap quote endpoint still returns deterministic mocks.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → payout setup) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> 🚀 **New:** v0.1.0 alpha is out — see the [Getting Started guide](GETTING_STARTED.md) to publish your first API in ~15 minutes.
+> 🚀 **v0.2.0 is out** — `SettlementMode` now accepts `polygon_mandate` and `embedded_wallet_charge` alongside the Stripe values. See [RELEASE_NOTES_v0.2.0.md](./RELEASE_NOTES_v0.2.0.md) for what landed, why, and the migration guide.
+>
+> See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 
 ---
 
@@ -205,7 +207,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is an early-stage project (v0.1.0, alpha) with a growing but still
+This is an early-stage project (v0.2.0, alpha) with a growing but still
 small user base. The SDK and platform are actively evolving. Start with
 a small read-only API to learn the flow.
 

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -1,0 +1,77 @@
+# v0.2.0 — SettlementMode adds Polygon-aware values
+
+**2026-04-18**
+
+The Stripe Connect → Polygon on-chain migration's first SDK-visible release. `SettlementMode` now accepts two new values: `polygon_mandate` and `embedded_wallet_charge`.
+
+> **What this is:** a metadata / contract expansion. Tool manuals declaring the new modes validate end-to-end through the resolver, dry-run preview, approval snapshot, `intent.plan_jsonb`, and the installed-tools API.
+>
+> **What this is not (yet):** the payment-permission tool execution itself actually settling on Web3. That is a subsequent phase. Declaring the new modes today is a metadata commitment, not a runtime change.
+
+## The expanded enum
+
+```python
+class SettlementMode(str, Enum):
+    STRIPE_CHECKOUT = "stripe_checkout"
+    STRIPE_PAYMENT_INTENT = "stripe_payment_intent"
+    POLYGON_MANDATE = "polygon_mandate"            # NEW in v0.2.0
+    EMBEDDED_WALLET_CHARGE = "embedded_wallet_charge"  # NEW in v0.2.0
+```
+
+```ts
+export type SettlementMode =
+  | "stripe_checkout"
+  | "stripe_payment_intent"
+  | "polygon_mandate"
+  | "embedded_wallet_charge";
+```
+
+JSON Schema and OpenAPI enums updated to match.
+
+## Semantics
+
+| Value | When to use |
+|---|---|
+| `polygon_mandate` | Subscription-style auto-debit against an on-chain mandate (Siglume's platform-sponsored ERC-4337 Safe + Pimlico paymaster stack). Recurring, session-key-scoped. |
+| `embedded_wallet_charge` | One-shot charge against the user's embedded smart wallet. Discrete payment at tool-execution time. |
+| `stripe_checkout` | Existing Stripe-hosted checkout flow. Unchanged. |
+| `stripe_payment_intent` | Existing Stripe payment intent flow. Unchanged. |
+
+## Migration
+
+**If you do nothing:** your existing `stripe_checkout` / `stripe_payment_intent` tool manuals continue to validate and run exactly as before. No action required.
+
+**If you want to opt into Web3 settlement:**
+
+1. Set `settlement_mode="polygon_mandate"` (or `"embedded_wallet_charge"`) on your `ToolManual`.
+2. Keep `currency="USD"`; the on-chain side resolves to USDC / JPYC via the user's smart wallet.
+3. Declare `accepted_payment_tokens` (USDC / JPYC) and `settlement_network` ("polygon" or "polygon-amoy") as adjacent metadata.
+4. Re-run `validate_tool_manual()` — the new values are whitelisted.
+
+**TypeScript consumers:** exhaustive `switch` / `match` on `SettlementMode` will now surface a type error on the two new values. Extend cases or narrow the type at the boundary.
+
+## Semver rationale
+
+The enum expansion is technically a breaking change in semver — consumers that exhaustively pattern-match, or platforms expecting the old restricted set, will observe different behavior. In zerover, that justifies the minor bump to `0.2.0`.
+
+## Context — the migration this is part of
+
+v0.2.0 is the first SDK-visible output of the broader Stripe Connect → Polygon on-chain migration. The full phase log, including the real on-chain completion on 2026-04-18 (userOpHash `0xaa55cbae...`, tx_hash `0xa04699ff...` on Polygon Amoy block 36829663), lives in [PAYMENT_MIGRATION.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md).
+
+The two-axis model this migration has been operating under:
+
+- **Axis 1 — subscription purchase** (Plan / Partner / API Store / AIWorks escrow / Ads): migrated to Polygon server-side. Does not cross the SDK contract; no SDK change required.
+- **Axis 2 — tool-execution settlement**: gated by `SettlementMode`. **This is the axis that moved in v0.2.0.** The enum expansion is the trigger.
+
+## What remains reserved
+
+- `PriceModel.USAGE_BASED` / `PER_ACTION` still reserved. Current platform accepts only `FREE` / `SUBSCRIPTION`.
+- The Polygon-aware `SettlementMode` values are *accepted* by the platform but not yet *dispatched to Web3 settlement at execution time*. Follow-up phase.
+
+## Feedback
+
+If the migration guide or enum semantics are unclear, open a [Discussion](https://github.com/taihei-05/siglume-api-sdk/discussions) or [Issue](https://github.com/taihei-05/siglume-api-sdk/issues).
+
+---
+
+Full changelog: [CHANGELOG.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/CHANGELOG.md)

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -1290,7 +1290,7 @@ components:
         # Conditional: required for payment only
         quote_schema: { type: object }
         currency: { type: string, enum: [USD], description: "Must be USD" }
-        settlement_mode: { type: string, enum: [stripe_checkout, stripe_payment_intent] }
+        settlement_mode: { type: string, enum: [stripe_checkout, stripe_payment_intent, polygon_mandate, embedded_wallet_charge] }
         refund_or_cancellation_note: { type: string, minLength: 1 }
 
     ErrorResponse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = {text = "MIT"}

--- a/schemas/tool-manual.schema.json
+++ b/schemas/tool-manual.schema.json
@@ -125,7 +125,7 @@
     },
     "settlement_mode": {
       "type": "string",
-      "enum": ["stripe_checkout", "stripe_payment_intent"],
+      "enum": ["stripe_checkout", "stripe_payment_intent", "polygon_mandate", "embedded_wallet_charge"],
       "description": "Required for payment. How the payment is settled."
     },
     "refund_or_cancellation_note": {

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -178,7 +178,11 @@ export interface CapabilityBinding {
  */
 export type ToolManualPermissionClass = "read_only" | "action" | "payment";
 
-export type SettlementMode = "stripe_checkout" | "stripe_payment_intent";
+export type SettlementMode =
+  | "stripe_checkout"
+  | "stripe_payment_intent"
+  | "polygon_mandate"
+  | "embedded_wallet_charge";
 
 export interface ToolManual {
   // Required (all permission classes)

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -361,6 +361,8 @@ class ToolManualPermissionClass(str, Enum):
 class SettlementMode(str, Enum):
     STRIPE_CHECKOUT = "stripe_checkout"
     STRIPE_PAYMENT_INTENT = "stripe_payment_intent"
+    POLYGON_MANDATE = "polygon_mandate"
+    EMBEDDED_WALLET_CHARGE = "embedded_wallet_charge"
 
 
 @dataclass
@@ -697,7 +699,12 @@ def validate_tool_manual(
         if isinstance(manual.get("currency"), str) and manual["currency"] != "USD":
             _err("INVALID_CURRENCY", "currency must be 'USD'", "currency")
         sm = manual.get("settlement_mode")
-        valid_sm = {"stripe_checkout", "stripe_payment_intent"}
+        valid_sm = {
+            "stripe_checkout",
+            "stripe_payment_intent",
+            "polygon_mandate",
+            "embedded_wallet_charge",
+        }
         if isinstance(sm, str) and sm not in valid_sm:
             _err("INVALID_SETTLEMENT_MODE",
                  f"settlement_mode must be one of {sorted(valid_sm)}",


### PR DESCRIPTION
## Summary

**Axis 2 trigger fired.** Server `VALID_SETTLEMENT_MODES` expanded from `{stripe_checkout, stripe_payment_intent}` to include `polygon_mandate` and `embedded_wallet_charge`. SDK mirrors the expansion in v0.2.0.

## Changes

- `siglume_api_sdk.py`: `SettlementMode` enum + `validate_tool_manual()` whitelist expanded
- `siglume-api-types.ts`: TypeScript union extended
- `schemas/tool-manual.schema.json`: JSON Schema enum extended
- `openapi/developer-surface.yaml`: OpenAPI enum extended
- `pyproject.toml`: `0.1.0` → `0.2.0`
- `CHANGELOG.md`: v0.2.0 entry with migration guide
- `RELEASE_NOTES_v0.2.0.md`: release notes
- `README.md`: banner + project-status version bumped
- `PAYMENT_MIGRATION.md`: Phase 33 logged

## Important scope note (from Codex)

Phase 33 delivers **metadata / validator / approval propagation** for Axis 2. Payment-permission tool execution does **not yet actually settle via Polygon at runtime** — declaring `polygon_mandate` / `embedded_wallet_charge` is a metadata commitment validated and propagated through dry-run preview, approval snapshot, `intent.plan_jsonb`, and installed-tools API. Runtime charge dispatch is a follow-up phase.

## Migration

- **Do nothing**: existing `stripe_*` tool manuals continue to validate and run unchanged
- **Opt into Web3**: set `settlement_mode="polygon_mandate"` (subscription auto-debit) or `"embedded_wallet_charge"` (one-shot charge), re-run `validate_tool_manual()`
- **TypeScript**: exhaustive `switch` / `match` on `SettlementMode` will now surface type errors on the 2 new values — extend cases or narrow

## Test plan

- [x] Server-side tests per Codex: 23 passed combined, apps/web build pass, py_compile pass
- [ ] SDK local verification: `pip install -e .` + import the new enum value
- [ ] After merge: tag v0.2.0 + PyPI upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)