### PR TITLE
docs: sync 'paused' status — paid-subscription publish is open (Phase 31 on-chain proven)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -413,7 +413,7 @@ Declare the account type in `required_connected_accounts`. The agent owner conne
 Use `price_model="free"` for free APIs. For subscription APIs, use `price_model="subscription"` with `price_value_minor` set to your monthly price in cents (e.g., 999 for $9.99/month). Minimum subscription price is $5.00/month (500 cents). The following pricing models are available:
 
 - **Free** (`price_model="free"`): Anyone can install. You can convert to subscription pricing at any time.
-- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement is migrating from Stripe Connect to on-chain embedded-wallet auto-debit — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md). **New paid publishes are paused during the cutover**; free listings (see above) remain fully live.
+- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon on-chain embedded-wallet auto-debit (proven end-to-end on Amoy 2026-04-18 — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md)). Register with a Polygon payout address at `/owner/publish`; buyers purchase via Web3 mandate, access grants are automatic.
 
 The SDK enum `PriceModel` also defines `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are **reserved values for future phases** — they are not accepted by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
 
@@ -663,7 +663,7 @@ You receive:            ~$9.33/month, settled directly to your wallet
 
 ### Setting up payouts (subscription APIs only)
 
-> 🔄 **This section is migrating.** The Stripe Connect onboarding flow documented below is being replaced with an on-chain embedded-wallet flow. Paid subscription **publish** is paused during the cutover. If you want to publish a paid API today, track [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for when the new flow opens. Free listings (`price_model="free"`) are unaffected and can be published now.
+> ✅ **Payouts now run on Polygon.** Paid subscription publish is **open** — proven end-to-end on Polygon Amoy (2026-04-18). Register at `/owner/publish` with a Polygon payout address; buyers purchase via Web3 mandate, access grants land automatically. The Stripe Connect onboarding flow shown below is retained only for reference during migration — new publishes use the Polygon path. See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log and real on-chain metrics.
 
 Historical Stripe-Connect-based flow (being retired):
 

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -710,16 +710,16 @@ The migration has two distinct axes. Phase 9 completes **one of them** (subscrip
 
 - Everything in the **READ_ONLY** and **ACTION** permission classes — publishing, registering, executing, receipts, tool-manual validation.
 - **Free** listings (`price_model="free"`) — unaffected by the payment change.
-- **Paid subscription publish** (`price_model="subscription"`) — **no longer paused** for sellers with a verified Polygon payout wallet (as of Phase 9). Buyers purchase via Web3 mandate under the mock provider; access grants land automatically.
-- **`PAYMENT` permission class tools** — authorable today using `settlement_mode="stripe_checkout"` or `"stripe_payment_intent"`. Axis 2 has not moved.
+- **Paid subscription publish** (`price_model="subscription"`) — publish is **open**. Phase 9 unpaused it under the mock provider; Phase 31 proved it end-to-end on real Polygon Amoy (userOpHash `0xaa55cbae...`, tx_hash `0xa04699ff...`). Register with a Polygon payout address at `/owner/publish`; buyers purchase via Web3 mandate, access grants land automatically.
+- **`PAYMENT` permission class tools** — authorable with any of the four `SettlementMode` values. `stripe_*` continues to work unchanged. `embedded_wallet_charge` is fully runtime-backed on Polygon (Phase 34). `polygon_mandate` authorizes on-chain at tool-auth time; recurring-charge dispatch is a follow-up phase.
 - SDK types, validators, and examples for non-payment flows — stable.
-- The existing SDK v0.1.x — no breaking change required yet.
+- **SDK v0.2.0** — current release, adds `polygon_mandate` + `embedded_wallet_charge` to `SettlementMode`.
 
-## What is paused / changing
+## What is changing
 
-- **`SettlementMode` enum values** (`stripe_checkout`, `stripe_payment_intent`) — still frozen in SDK v0.1.x. Codex has **not** added a Web3 value to `VALID_SETTLEMENT_MODES`. A coordinated server+SDK update will add on-chain values when Axis 2 migrates — that is the SDK v0.2.0 trigger.
-- **`examples/metamask_connector.py`** — the current "bring your own MetaMask + direct-sign transaction" stub does **not** match the new embedded-smart-wallet + platform-gas model. It will be rewritten once the real wallet integration is available and the Axis 2 migration is specified.
-- Any doc text that reads "Stripe Connect" as the live mechanism — being rewritten as this migration progresses.
+- **`examples/metamask_connector.py`** — the current "bring your own MetaMask + direct-sign transaction" stub does **not** match the embedded-smart-wallet + platform-gas model used by `polygon_mandate` / `embedded_wallet_charge`. Scheduled for rewrite once the recurring-charge dispatcher for `polygon_mandate` lands, so the example can demo a complete authorize → charge cycle.
+- **Relayer-driven recurring-charge dispatch** — `polygon_mandate` currently covers the authorize step. The scheduler that fires the periodic charge userOp against an authorized mandate is the next Web3 workstream.
+- Any residual doc text that reads "Stripe Connect" as the live mechanism for subscription purchases — being rewritten as encountered.
 
 ## Why Polygon, specifically
 
@@ -733,8 +733,9 @@ Embedded wallets + gas sponsorship mean this is **not** a "bring your own MetaMa
 ## For SDK users, right now
 
 1. **If your API is READ_ONLY / ACTION / free:** nothing to do. Keep building. The SDK's public API, validators, and examples are unchanged for your flow.
-2. **If you were about to publish a paid subscription API:** wait until the real wallet integration lands. The registration flow is already available at `/owner/publish` but accepts only Polygon addresses (not bank accounts), so Stripe-Connect-expecting onboarding scripts will fail. A coordinated SDK release will add the final types once Turnkey/Safe/Pimlico integrations are live.
-3. **If you already published a paid subscription API on a previous SDK version:** platform-side migration tooling is part of Codex's current work. No action required from you.
+2. **If you want to publish a paid subscription API:** go ahead. Paid-subscription publish is **no longer paused** as of Phase 9 (mock-backed) and proven on-chain as of Phase 31 (real Polygon Amoy completion, userOpHash `0xaa55cbae...`). Register via `/owner/publish`, providing a Polygon payout address instead of a bank account. Buyers purchase via Web3 mandate; access grants land automatically. The registration flow no longer depends on Stripe Connect.
+3. **If you want a payment-permission tool that charges on Polygon:** upgrade to SDK v0.2.0 (`pip install siglume-api-sdk>=0.2.0`) and declare `settlement_mode="polygon_mandate"` (subscription-style auto-debit) or `"embedded_wallet_charge"` (one-shot charge). `embedded_wallet_charge` is fully runtime-backed as of Phase 34; `polygon_mandate` authorizes on-chain at tool-auth time with recurring-charge dispatch in a follow-up phase.
+4. **If you already published a paid subscription API on a previous SDK version:** platform-side migration tooling is in place. No action required — existing `stripe_*` tool manuals continue to validate and run unchanged.
 
 ## Tracking
 


### PR DESCRIPTION
## Summary

Addresses Codex bot review on PR #24 / PR #40 (Phase 9 doc inconsistency): top of PAYMENT_MIGRATION.md said paid-subscription publish was unpaused, but later sections still said "wait for real wallet integration" or "paused."

After Phase 31 (real Polygon Amoy completion) and Phase 33 (SDK v0.2.0 cut), the unpause claim is fully backed. This PR propagates the updated status to the stale sections.

## Changes

**PAYMENT_MIGRATION.md** — "For SDK users, right now" + "What still works today" + "What is changing" all brought current. Added v0.2.0 upgrade guidance, cited Phase 31 on-chain tx, clarified `metamask_connector` rewrite trigger.

**GETTING_STARTED.md** — Subscription price model section and Payout setup section now describe the Polygon flow as primary. Stripe section kept only as migration reference.

## Test plan

- [x] Doc-only
- [x] `grep -n "paused\|wait until"` returns only historical references in phase logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)