### PR TITLE
docs: fix release-materials accuracy issues surfaced by Codex review

### DIFF
--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -680,10 +680,9 @@ For SDK developers, the v0.2.0 enum is now genuinely live — declaring `polygon
 - ~~**Axis 2 migration design**~~ — **first vertical DONE in Phase 33** (2026-04-18). `SettlementMode` gained `polygon_mandate` + `embedded_wallet_charge`; SDK v0.2.0 cut to mirror. Metadata / validator / approval propagation live. Runtime dispatch to Polygon settlement remains for a follow-up phase.
 - ~~**Payment-permission tool runtime dispatch to Polygon**~~ — **DONE in Phase 34** (2026-04-18). `embedded_wallet_charge` fully runtime-backed; `polygon_mandate` on-chain authorization happens at tool-authorization time.
 - **Relayer-driven recurring charge orchestration for `polygon_mandate`** — the authorized mandate is created on-chain at tool-authorization time, but the scheduler that periodically fires the actual charge userOp against the authorized mandate is a follow-up phase. Codex's explicit next workstream after Phase 34.
-- **Tool-execution Axis 2 migration** — still the actual SDK v0.2.0 trigger. Whenever `VALID_SETTLEMENT_MODES` on the server gains a Web3 value, SDK must follow synchronously. Not yet in Codex's roadmap.
-- **Replace `amoy.json` placeholder manifest** — dev-only, covers `subscription_hub` + `ads_billing_hub` + `works_escrow_hub` + `fee_vault`. Must be replaced with real addresses before any chain exposure (prerequisite for the Amoy end-to-end run above).
+- ~~**Replace `amoy.json` placeholder manifest**~~ — **DONE** with the Phase 31 hardhat deploy (2026-04-18). Real Amoy addresses for `FeeVault` / `SubscriptionHub` / `AdsBillingHub` / `WorksEscrowHub` + Mock USDC / JPYC are now in the manifest (see Phase 31 section for the address table).
 - **0x real swap execution** — swap quote endpoint still returns deterministic mocks.
-- **Resident chain indexer daemon** — admin trigger (`POST /v1/admin/market/web3/sync`) exists; a long-running process that advances `chain_cursor` continuously is not yet wired. (Phase 17's per-receipt refresh button is an owner-pull alternative for the same resolve step.)
+- **Mainnet (Polygon 137) cutover** — Amoy flow is proven end-to-end; mainnet deploy + production paymaster funding is the remaining chain-side workstream.
 
 Free listings and non-payment flows (READ_ONLY / ACTION without charge) remain unaffected throughout the migration.
 

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -45,8 +45,9 @@ JSON Schema and OpenAPI enums updated to match.
 
 1. Set `settlement_mode="polygon_mandate"` (or `"embedded_wallet_charge"`) on your `ToolManual`.
 2. Keep `currency="USD"`; the on-chain side resolves to USDC / JPYC via the user's smart wallet.
-3. Declare `accepted_payment_tokens` (USDC / JPYC) and `settlement_network` ("polygon" or "polygon-amoy") as adjacent metadata.
-4. Re-run `validate_tool_manual()` — the new values are whitelisted.
+3. Re-run `validate_tool_manual()` — the new values are whitelisted.
+
+That's the full SDK-side change. The tool manual stays the same shape; only the `settlement_mode` value is new. **Do not** add `accepted_payment_tokens` or `settlement_network` as tool-manual fields — those are server-side metadata that the platform derives from the seller's payout wallet configuration, and the ToolManual schema (`additionalProperties: false`) will reject them.
 
 **TypeScript consumers:** exhaustive `switch` / `match` on `SettlementMode` will now surface a type error on the two new values. Extend cases or narrow the type at the boundary.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,9 @@ Get a project-scoped API token from <https://pypi.org/manage/account/token/> (se
 
 ### Option A: Persistent `.pypirc` (recommended, set up once)
 
-Create `~/.pypirc` (on Windows: `%USERPROFILE%\.pypirc`, e.g. `D:\Users\<you>\.pypirc`):
+Create `~/.pypirc` (on Windows: `%USERPROFILE%\.pypirc`, e.g. `D:\Users\<you>\.pypirc`).
+
+**Important**: do not put an inline `# comment` on the `password` line — `configparser` reads the whole line (including `#`) as the value, so twine would submit a bogus token and uploads would fail with auth errors. Put any comment on its own line above the password.
 
 ```ini
 [distutils]
@@ -55,12 +57,19 @@ index-servers =
 
 [pypi]
 username = __token__
-password = pypi-AgENdGVzdC5weXBpLm9yZwIk...  # paste full token
+# paste the full pypi-... token on the line below, nothing else on that line
+password = pypi-AgENdGVzdC5weXBpLm9yZwIk...
 ```
 
 After this, every release is just:
 
 ```bash
+# bash / WSL / macOS
+py -3.11 -m twine upload dist/*
+```
+
+```powershell
+# PowerShell (Windows)
 py -3.11 -m twine upload dist\*
 ```
 


### PR DESCRIPTION
Addresses Codex bot reviews on PR #64 and PR #65.

- **RELEASE_NOTES_v0.2.0.md**: migration guide referenced unsupported ToolManual fields (`accepted_payment_tokens`, `settlement_network`) which the schema's `additionalProperties=false` would reject. Clarified these are server-side.
- **RELEASING.md (P1)**: .pypirc example had inline `# comment` on password line — configparser reads inline `#` as value, causing auth failure. Moved comment above.
- **RELEASING.md (P2)**: bash block used `dist\*` which bash escapes. Split into bash (`dist/*`) and PowerShell (`dist\*`) blocks.

AppManifest default version finding skipped — that's the user's API version, not SDK version.