### PR TITLE
Added hello_echo example and update README example templates table 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,22 @@ source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -e .
 ```
 
+## Dev Container (optional)
+
+This repository includes a `.devcontainer/` configuration.
+Opening this project in Vs Code or Github Codespaces
+automatically detects the configuration and sets up
+ready-to-use development environment.
+
+The container uses Python 3.11 and installs the SDK
+in editable mode automatically. Recommended VS Code
+extensions such as Python, Pylance, and YAML support
+are also included.
+
+Use the Dev Container if you want a quick, zero-setup
+environment. You can still use the local virtual
+environment setup above if you prefer manual setup.
+
 ## Making SDK Changes
 
 1. Create a feature branch from `main`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Use them as a starting point for your own API.
 
 | Example | Permission | Description |
 |---|---|---|
+| [hello_echo.py](./examples/hello_echo.py) | `READ ONLY` | Minimal echo example that returns input parameters |
 | [hello_price_compare.py](./examples/hello_price_compare.py) | `READ_ONLY` | Compare product prices across retailers |
 | [x_publisher.py](./examples/x_publisher.py) | `ACTION` | Post agent content to X with approval |
 | [visual_publisher.py](./examples/visual_publisher.py) | `ACTION` | Generate images and publish social posts |

--- a/examples/hello_echo.py
+++ b/examples/hello_echo.py
@@ -1,0 +1,90 @@
+"""Sample Agent API: Hello Echo.
+
+A minimal read-only API that demonstrates returning input parameters in the output.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (
+    AppAdapter,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    AppCategory,
+    ExecutionContext,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    StubProvider,
+)
+
+
+class HelloEchoApp(AppAdapter):
+    """A simple echo app that returns the input parameters."""
+
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="hello-echo",
+            name="Hello Echo",
+            job_to_be_done="Return the input parameters in the output",
+            category=AppCategory.COMMERCE,  
+            permission_class=PermissionClass.READ_ONLY,
+            approval_mode=ApprovalMode.AUTO,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="A simple echo API",
+            example_prompts=[
+                "Echo this input",
+                "Return the parameters I send you",
+                "What did I just say to you?",
+            ],
+            compatibility_tags=["utility", "echo", "demo"],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+       
+
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "input_received": ctx.input_params,
+            },
+            units_consumed=1,
+        )
+
+    def supported_task_types(self) -> list[str]:
+        return ["echo_input"]
+
+
+
+
+async def main():
+    app = HelloEchoApp()
+    harness = AppTestHarness(app)
+
+    issues = harness.validate_manifest()
+    if issues:
+        print(f"Manifest issues: {issues}")
+        return
+    print("[OK] Manifest valid")
+
+    health = await harness.health()
+    print(f"[OK] Health: {health.healthy}")
+
+    result = await harness.dry_run(task_type="compare_prices")
+    print(f"[OK] Dry run: success={result.success}")
+    print("\n[OK] Echo example ready.")
+
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## Changes

- Added a minimal `hello_echo.py` example using AppAdapter.
- This example demonstrates a simple read-only API that returns input parameters as output.
- Updated the README example-templates table by adding `hello_echo.py` as the first entry.


## Checklist

- [x] Tests pass locally
- [x] Code formatted with black/ruff
- [x] Documentation updated if needed

> **Note:** This repo is for SDK improvements only.
> To publish your own API, use the auto-register endpoint — see [GETTING_STARTED.md](GETTING_STARTED.md).
