### PR TITLE
feat(release): add PyPI Trusted Publisher (OIDC) workflow + doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release to PyPI
+
+# Triggered when a tag matching v* is pushed (e.g. v0.2.1, v0.3.0).
+# Uses PyPI Trusted Publisher (OIDC) — no API token needed once the
+# publisher is configured on the PyPI side.
+#
+# SETUP (one-time, PyPI-side — operator task):
+#   1. Sign in to https://pypi.org/manage/account/publishing/
+#   2. Add a new pending publisher with:
+#      - PyPI project name: siglume-api-sdk
+#      - GitHub org: taihei-05
+#      - Repository name: siglume-api-sdk
+#      - Workflow filename: release.yml
+#      - Environment name: pypi (matches the `environment:` below)
+#   3. Create a GitHub environment named "pypi" with (optional) protection rules:
+#      https://github.com/taihei-05/siglume-api-sdk/settings/environments/new
+#      - Required reviewers: taihei-05
+#      - Deployment branches: Protected branches only
+#
+# After setup, publishing is: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+# No token, no `.pypirc` needed. See RELEASING.md for the full flow.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Allow manual dispatch for hotfixes or re-runs
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and publish (e.g. v0.2.1)'
+        required: true
+
+permissions:
+  # Minimal: only what Trusted Publisher needs.
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    # The environment name must match what was configured in the
+    # pending publisher on PyPI.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/siglume-api-sdk/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+
+      - name: Verify version in pyproject.toml matches tag
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          # Strip leading 'v' from tag to compare with pyproject version
+          TAG_VERSION="${TAG#v}"
+          PYPROJECT_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          echo "Tag version:       $TAG_VERSION"
+          echo "pyproject version: $PYPROJECT_VERSION"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match pyproject.toml version '$PYPROJECT_VERSION'"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Inspect build artifacts
+        run: |
+          ls -lh dist/
+          echo "---"
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - name: Publish to PyPI via OIDC
+        # pypa/gh-action-pypi-publish@release/v1 implements PEP 740 /
+        # Trusted Publisher. No API token needed — GitHub OIDC proves
+        # that this workflow ran on the registered repo/branch/workflow.
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # `attestations: true` produces PEP 740 digital attestations for
+        # each artifact, published alongside the release on PyPI.
+        with:
+          attestations: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,6 +48,59 @@ Inspect the sdist manifest (`tar -tzf dist/*.tar.gz`) — it should contain `LIC
 
 ## Publish to PyPI
 
+There are three ways to publish. In decreasing order of recommendation:
+
+- **Option 0 (strongest): GitHub Actions Trusted Publisher (OIDC)** — no token anywhere, just push a tag
+- **Option A: Persistent `.pypirc`** — convenience, accept a longer-lived token on disk
+- **Option B: Per-release env vars** — strictest token rotation, most manual friction
+
+### Option 0: Trusted Publisher via GitHub Actions (recommended for all production releases)
+
+The `.github/workflows/release.yml` in this repo is already configured to publish via OIDC when a tag matching `v*` is pushed. After one-time setup on the PyPI side, you never handle a token again.
+
+**One-time setup on PyPI:**
+
+1. Sign in to <https://pypi.org/manage/account/publishing/>
+2. **Add a pending publisher** with:
+   - PyPI project name: `siglume-api-sdk`
+   - GitHub org: `taihei-05`
+   - Repository name: `siglume-api-sdk`
+   - Workflow filename: `release.yml`
+   - Environment name: `pypi`
+3. Optional but recommended — create a GitHub environment:
+   - <https://github.com/taihei-05/siglume-api-sdk/settings/environments/new>
+   - Name: `pypi`
+   - Protection: required reviewer (yourself), deployment branch rule = protected branches only
+4. Once the pending publisher is registered, the next tag push triggers the workflow.
+
+**Every subsequent release:**
+
+```bash
+# bash / WSL / macOS
+git tag -a vX.Y.Z -m "Release vX.Y.Z — <headline>"
+git push origin vX.Y.Z
+```
+
+```powershell
+# PowerShell (Windows)
+git tag -a vX.Y.Z -m "Release vX.Y.Z — <headline>"
+git push origin vX.Y.Z
+```
+
+That's it. The GitHub Actions workflow:
+- Verifies the tag matches `pyproject.toml` version (fails loudly if not)
+- Builds sdist + wheel
+- Runs `twine check`
+- Publishes via OIDC with PEP 740 attestations
+
+You can monitor the run at <https://github.com/taihei-05/siglume-api-sdk/actions>. If it fails, the workflow is rerunnable — fix the cause, re-push the tag (force if needed: `git push --force origin vX.Y.Z`).
+
+**Revoke the local `.pypirc` token once OIDC is live.** It is no longer needed, and keeping it invites the attack surface the 5-agent review flagged.
+
+---
+
+### Options A / B: token-based (for bootstrapping before OIDC is set up, or local testing)
+
 Get a project-scoped API token from <https://pypi.org/manage/account/token/> (see [SECURITY.md](./SECURITY.md#release-token-hygiene)).
 
 **Two ways to pass the token** — pick one:


### PR DESCRIPTION
Addresses 5-agent security review: replace long-lived .pypirc token with GitHub OIDC. Workflow triggers on tag push, verifies version match, builds + publishes via OIDC with PEP 740 attestations. RELEASING.md updated with Option 0 (Trusted Publisher) as primary. Operator still needs to configure pending publisher on PyPI side one-time.