### PR TITLE
fix(ts): add preview_quality_score to client shape for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-19
+
+Patch release for two Codex auto-review P2 fixes across the v0.3 surface.
+
+### Fixed
+
+- Added `preview_quality_score(tool_manual)` to the TypeScript `SiglumeClientShape`
+  so TS consumers can call the same preview-quality method that Python
+  `SiglumeClient` already exposes without custom interface patching.
+- Documented the paired backend hotfix where
+  `POST /v1/market/tool-manuals/preview-quality` now returns an `INVALID_PAYLOAD`
+  4xx envelope instead of a 500 when the request body contains malformed JSON.
+
 ## [0.3.0] — 2026-04-19
 
 First workflow-complete SDK release. Developers can now scaffold, validate, test,

--- a/RELEASE_NOTES_v0.3.1.md
+++ b/RELEASE_NOTES_v0.3.1.md
@@ -1,0 +1,35 @@
+# v0.3.1 - Codex auto-review hotfixes
+
+**2026-04-19**
+
+v0.3.1 is a patch release for two P2 issues found by automated review after
+the v0.3.0 cut. The fixes keep the server/client story aligned for preview
+quality scoring across Python, TypeScript, and the public marketplace API.
+
+## Fixed
+
+- **TypeScript client shape parity**: `SiglumeClientShape` now declares
+  `preview_quality_score(tool_manual)` with a `ToolManualQualityReport` return
+  type, matching the Python `SiglumeClient` surface added in v0.3.0.
+- **Malformed JSON handling on preview-quality**: the paired backend hotfix now
+  maps malformed JSON bodies on
+  `POST /v1/market/tool-manuals/preview-quality` to an `INVALID_PAYLOAD` 4xx
+  envelope instead of a 500.
+
+## Compatibility
+
+This release is additive and patch-safe.
+
+- No removed fields.
+- No required-field flips.
+- No enum changes.
+- No change to USD-only, jurisdiction, or permission-class rules.
+
+## Upgrade
+
+```bash
+pip install --upgrade siglume-api-sdk==0.3.1
+```
+
+TypeScript users that model the client surface through `SiglumeClientShape`
+can now call `preview_quality_score(...)` without local interface extensions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -621,7 +621,7 @@ class SiglumeClient:
             headers={
                 "Authorization": f"Bearer {self.api_key}",
                 "Accept": "application/json",
-                "User-Agent": "siglume-api-sdk/0.3.0-dev",
+                "User-Agent": "siglume-api-sdk/0.3.1",
             },
         )
         self._pending_confirmations: dict[str, dict[str, Any]] = {}

--- a/siglume_api_sdk_client.ts
+++ b/siglume_api_sdk_client.ts
@@ -1,3 +1,5 @@
+import type { ToolManual, ToolManualQualityReport } from "./siglume-api-types";
+
 export interface EnvelopeMeta {
   request_id?: string | null;
   trace_id?: string | null;
@@ -178,6 +180,7 @@ export interface SupportCaseRecord {
 export interface SiglumeClientShape {
   auto_register(...args: unknown[]): Promise<AutoRegistrationReceipt> | AutoRegistrationReceipt;
   confirm_registration(...args: unknown[]): Promise<RegistrationConfirmation> | RegistrationConfirmation;
+  preview_quality_score(tool_manual: ToolManual): Promise<ToolManualQualityReport> | ToolManualQualityReport;
   submit_review(listingId: string): Promise<AppListingRecord> | AppListingRecord;
   list_my_listings(...args: unknown[]): Promise<CursorPage<AppListingRecord>> | CursorPage<AppListingRecord>;
   get_listing(listingId: string): Promise<AppListingRecord> | AppListingRecord;


### PR DESCRIPTION
## Summary
- add preview_quality_score(tool_manual) to TypeScript SiglumeClientShape
- bump the Python package version to 0.3.1 and add patch release notes
- align the Python client User-Agent with the shipped patch version

## Validation
- py -3.11 -m pytest
- py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts/contract_sync.py
- py -3.11 scripts/contract_sync.py
- npx -y -p typescript@5.6.3 tsc --noEmit siglume_api_sdk_client.ts siglume-api-types.ts