### PR TITLE
fix(grader): flag non-string items in usage/result/error hints

### DIFF
--- a/siglume_api_sdk/tool_manual_grader.py
+++ b/siglume_api_sdk/tool_manual_grader.py
@@ -268,7 +268,13 @@ def score_tool_manual_offline(tool_manual: Any) -> Any:
 
     validation_errors = [issue for issue in validation_issues if getattr(issue, "severity", "error") == "error"]
     validation_warnings = [issue for issue in validation_issues if getattr(issue, "severity", "error") != "error"]
-    publishable = bool(validation_ok) and quality["grade"] in {"A", "B"}
+    has_critical_quality_issue = any(
+        getattr(issue, "severity", "warning") == "critical"
+        for issue in quality["issues"]
+    )
+    # v0.4 hardens the local gate ahead of the current platform scorer so
+    # malformed hint payloads cannot still look publishable in offline checks.
+    publishable = bool(validation_ok) and quality["grade"] in {"A", "B"} and not has_critical_quality_issue
 
     return ToolManualQualityReport(
         overall_score=quality["overall_score"],
@@ -705,7 +711,7 @@ def _score_output_schema_completeness(manual: dict[str, Any], issues: list[Any],
 
 def _score_hints(manual: dict[str, Any], issues: list[Any], issue_cls: Any) -> int:
     score = 10
-    for field_name in ("usage_hints", "result_hints"):
+    for field_name in ("usage_hints", "result_hints", "error_hints"):
         hints = manual.get(field_name)
         if not isinstance(hints, list):
             issues.append(
@@ -732,7 +738,23 @@ def _score_hints(manual: dict[str, Any], issues: list[Any], issue_cls: Any) -> i
             score -= 3
             continue
 
-        short_count = sum(1 for item in hints if isinstance(item, str) and len(item) < 10)
+        short_count = 0
+        for index, item in enumerate(hints):
+            if not isinstance(item, str):
+                issues.append(
+                    _issue(
+                        issue_cls,
+                        "description_quality",
+                        "critical",
+                        f"{field_name} items must be strings",
+                        field=f"{field_name}[{index}]",
+                        suggestion="Replace non-string hint items with short plain-language guidance",
+                    )
+                )
+                score -= 10
+                continue
+            if len(item) < 10:
+                short_count += 1
         if short_count > 0:
             issues.append(
                 _issue(

--- a/tests/test_tool_manual_grader_parity.py
+++ b/tests/test_tool_manual_grader_parity.py
@@ -344,3 +344,28 @@ def test_score_tool_manual_offline_penalizes_malformed_field_types() -> None:
 
     assert hints_report.overall_score <= 95
     assert any(issue.field == "usage_hints" for issue in hints_report.issues)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_item"),
+    [
+        ("usage_hints", 123),
+        ("result_hints", {"bad": True}),
+        ("error_hints", 456),
+    ],
+)
+def test_score_tool_manual_offline_penalizes_non_string_hint_items(
+    field_name: str,
+    bad_item: object,
+) -> None:
+    manual = _clone_base()
+    manual[field_name] = [bad_item]
+
+    report = score_tool_manual_offline(manual)
+
+    assert report.overall_score == 90
+    assert report.publishable is False
+    assert any(
+        issue.field == f"{field_name}[0]" and issue.severity == "critical"
+        for issue in report.issues
+    )


### PR DESCRIPTION
﻿## Summary
- flag non-string items in `usage_hints`, `result_hints`, and `error_hints`
- apply an offline-score penalty and mark malformed hint payloads as not publishable
- add three regression tests covering integer/dict hint items across all hint lists

## Test plan
- [x] `py -3.11 -m pytest` -> 45 passed (before: 42)
- [x] `py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\\contract_sync.py` -> passed
- [x] `py -3.11 scripts\\contract_sync.py` -> passed
- [x] reviewer agent (Hilbert): no critical / warning

## Notes
- This intentionally hardens the public offline grader ahead of the current platform scorer. Platform parity for malformed hints will follow in a separate task.
