### PR TITLE
feat(ts-sdk): add TypeScript runtime package (PR-E)

### DIFF
--- a/siglume-api-sdk-ts/.gitignore
+++ b/siglume-api-sdk-ts/.gitignore
@@ -1,0 +1,4 @@
+dist
+coverage
+node_modules
+*.tgz

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -1,0 +1,5 @@
+# @siglume/api-sdk
+
+TypeScript runtime for building, testing, and registering Siglume developer apps.
+
+This package is prepared in the public SDK repo and ships with the v0.4 release line.

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,0 +1,3049 @@
+{
+  "name": "@siglume/api-sdk",
+  "version": "0.4.0-dev.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@siglume/api-sdk",
+      "version": "0.4.0-dev.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "jiti": "^2.4.2"
+      },
+      "bin": {
+        "siglume": "dist/bin/siglume.cjs"
+      },
+      "devDependencies": {
+        "@types/node": "^20.16.5",
+        "@vitest/coverage-v8": "^2.1.8",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@siglume/api-sdk",
+  "version": "0.4.0-dev.0",
+  "description": "TypeScript runtime for building and testing Siglume developer apps",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./cli": {
+      "types": "./dist/cli/index.d.ts",
+      "import": "./dist/cli/index.js",
+      "require": "./dist/cli/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "siglume": "./dist/bin/siglume.cjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --coverage",
+    "pack:check": "npm pack --json",
+    "smoke:node": "node ./dist/bin/siglume.cjs --help"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "jiti": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@vitest/coverage-v8": "^2.1.8",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/siglume-api-sdk-ts/src/bin/siglume.ts
+++ b/siglume-api-sdk-ts/src/bin/siglume.ts
@@ -1,0 +1,6 @@
+import { runCli } from "../cli/index";
+
+void (async () => {
+  const exitCode = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+})();

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -1,0 +1,173 @@
+import { Command } from "commander";
+
+import { SiglumeProjectError } from "../errors";
+import { renderJson } from "../utils";
+import {
+  createSupportCaseReport,
+  getUsageReport,
+  runHarness,
+  runRegistration,
+  scoreProject,
+  validateProject,
+  writeInitTemplate,
+} from "./project";
+import type { CliProjectDependencies } from "./project";
+
+export interface CliRunDependencies extends CliProjectDependencies {
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+}
+
+function emit(output: ((line: string) => void) | undefined, line: string): void {
+  (output ?? console.log)(line);
+}
+
+export async function runCli(argv: string[], deps: CliRunDependencies = {}): Promise<number> {
+  const stdout = deps.stdout;
+  const stderr = deps.stderr ?? console.error;
+  const program = new Command()
+    .name("siglume")
+    .description("Siglume developer CLI")
+    .showHelpAfterError()
+    .exitOverride();
+
+  program
+    .command("init")
+    .option("--template <template>", "starter template", "echo")
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("[path]", ".", "destination")
+    .action(async (path: string, options: { template: string; json?: boolean }) => {
+      const template = options.template as "echo" | "price-compare" | "publisher" | "payment";
+      const files = await writeInitTemplate(template, path);
+      const payload = { ok: true, template, files };
+      if (options.json) {
+        emit(stdout, renderJson(payload));
+        return;
+      }
+      emit(stdout, `Initialized Siglume starter template '${template}'.`);
+      files.forEach((filePath) => emit(stdout, `- ${filePath}`));
+    });
+
+  program
+    .command("validate")
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("[path]", ".", "project path")
+    .action(async (path: string, options: { json?: boolean }) => {
+      const report = await validateProject(path, deps);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+      } else {
+        emit(stdout, report.ok ? "Validation passed." : "Validation failed.");
+        emit(stdout, `Adapter: ${report.adapter_path}`);
+      }
+      if (!report.ok) {
+        throw new SiglumeProjectError("Validation failed.");
+      }
+    });
+
+  program
+    .command("test")
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("[path]", ".", "project path")
+    .action(async (path: string, options: { json?: boolean }) => {
+      const report = await runHarness(path);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+      } else {
+        emit(stdout, report.ok ? "Harness passed." : "Harness failed.");
+        emit(stdout, `Adapter: ${report.adapter_path}`);
+      }
+      if (!report.ok) {
+        throw new SiglumeProjectError("Harness failed.");
+      }
+    });
+
+  program
+    .command("score")
+    .option("--remote", "use the platform preview scorer", false)
+    .option("--offline", "use the local parity scorer without network access", false)
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("[path]", ".", "project path")
+    .action(async (path: string, options: { remote?: boolean; offline?: boolean; json?: boolean }) => {
+      const mode = options.offline ? "offline" : "remote";
+      const report = await scoreProject(path, mode, deps);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+      } else {
+        const quality = report.quality as { grade: string; overall_score: number };
+        emit(stdout, report.ok ? "Score passed." : "Score failed.");
+        emit(stdout, `${mode === "remote" ? "Remote" : "Offline"} quality: ${quality.grade} (${quality.overall_score}/100)`);
+      }
+      if (!report.ok) {
+        throw new SiglumeProjectError("Score failed.");
+      }
+    });
+
+  program
+    .command("register")
+    .option("--confirm", "confirm the draft registration immediately", false)
+    .option("--submit-review", "submit the draft for review if --confirm is not used", false)
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("[path]", ".", "project path")
+    .action(async (path: string, options: { confirm?: boolean; submitReview?: boolean; json?: boolean; ["submit-review"]?: boolean }) => {
+      const report = await runRegistration(path, { confirm: options.confirm, submit_review: options.submitReview }, deps);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+      } else {
+        const receipt = report.receipt as { listing_id: string; status: string };
+        emit(stdout, "Draft listing created.");
+        emit(stdout, `listing_id: ${receipt.listing_id}`);
+        emit(stdout, `status: ${receipt.status}`);
+      }
+    });
+
+  const support = program.command("support").description("Support-case workflows.");
+  support
+    .command("create")
+    .requiredOption("--subject <subject>", "short summary of the issue")
+    .requiredOption("--body <body>", "detailed support case body")
+    .option("--trace-id <trace_id>", "attach a trace_id from a failed API flow")
+    .option("--json", "emit machine-readable JSON", false)
+    .action(async (options: { subject: string; body: string; traceId?: string; ["trace-id"]?: string; json?: boolean }) => {
+      const report = await createSupportCaseReport(
+        { subject: options.subject, body: options.body, trace_id: options.traceId },
+        deps,
+      );
+      if (options.json) {
+        emit(stdout, renderJson(report));
+        return;
+      }
+      const supportCase = report.case as { support_case_id: string; status: string };
+      emit(stdout, "Support case created.");
+      emit(stdout, `case_id: ${supportCase.support_case_id}`);
+      emit(stdout, `status: ${supportCase.status}`);
+    });
+
+  program
+    .command("usage")
+    .option("--capability <capability_key>", "filter by capability_key")
+    .option("--window <period_key>", "pass-through period_key sent to /market/usage", "30d")
+    .option("--json", "emit machine-readable JSON", false)
+    .action(async (options: { capability?: string; window: string; json?: boolean }) => {
+      const report = await getUsageReport({ capability_key: options.capability, window: options.window }, deps);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+        return;
+      }
+      emit(stdout, `Usage events: ${report.count}`);
+    });
+
+  try {
+    await program.parseAsync(argv, { from: "user" });
+    return 0;
+  } catch (error) {
+    if (error instanceof SiglumeProjectError) {
+      emit(stderr, error.message);
+      return 1;
+    }
+    if (error instanceof Error && "code" in error) {
+      return Number((error as { exitCode?: number }).exitCode ?? 0);
+    }
+    throw error;
+  }
+}

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -1,0 +1,682 @@
+import { existsSync } from "node:fs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, extname, join, resolve } from "node:path";
+
+import { createJiti } from "jiti";
+
+import {
+  AppAdapter,
+  AppTestHarness,
+  PermissionClass,
+  score_tool_manual_offline,
+  SettlementMode,
+  SiglumeClient,
+  ToolManualPermissionClass,
+  validate_tool_manual,
+} from "../index";
+import type {
+  AppManifest,
+  ExecutionResult,
+  SiglumeClientShape,
+  ToolManual,
+  ToolManualIssue,
+} from "../index";
+import { SiglumeProjectError } from "../errors";
+import { renderJson, toJsonable } from "../utils";
+
+const TEMPLATE_NAMES = ["echo", "price-compare", "publisher", "payment"] as const;
+type TemplateName = (typeof TEMPLATE_NAMES)[number];
+
+const SUPPORTED_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs"]);
+
+export interface LoadedProject {
+  root_dir: string;
+  adapter_path: string;
+  app: AppAdapter;
+  manifest: AppManifest;
+  tool_manual_path?: string;
+  tool_manual: Record<string, unknown>;
+}
+
+export interface CliProjectDependencies {
+  env?: Record<string, string | undefined>;
+  client_factory?: (api_key: string, base_url?: string) => SiglumeClientShape;
+}
+
+function defaultClientFactory(api_key: string, base_url?: string): SiglumeClientShape {
+  return new SiglumeClient({ api_key, base_url });
+}
+
+async function createClient(deps: CliProjectDependencies = {}, base_url?: string): Promise<SiglumeClientShape> {
+  if (deps.client_factory) {
+    return deps.client_factory(deps.env?.SIGLUME_API_KEY ?? "siglume_test_key", base_url);
+  }
+  return defaultClientFactory(await resolveApiKey(deps.env), base_url);
+}
+
+function toolManualToDict(manual: ToolManual | Record<string, unknown>): Record<string, unknown> {
+  return { ...(toJsonable(manual) as Record<string, unknown>) };
+}
+
+function remoteQualityOk(report: { validation_ok?: boolean; publishable?: boolean | null; grade: string }): boolean {
+  const validationOk = report.validation_ok ?? true;
+  const publishable = report.publishable ?? (report.grade === "A" || report.grade === "B");
+  return Boolean(validationOk) && Boolean(publishable);
+}
+
+export function buildToolManualTemplate(manifest: AppManifest): Record<string, unknown> {
+  const jobText = String(manifest.job_to_be_done || manifest.name || manifest.capability_key.replaceAll("-", " "));
+  const summaryText = String(
+    manifest.short_description || manifest.job_to_be_done || manifest.name || manifest.capability_key.replaceAll("-", " "),
+  );
+  const toolName = manifest.capability_key.replaceAll("-", "_");
+  const summary = manifest.short_description || manifest.job_to_be_done || `Use this tool to ${manifest.capability_key.replaceAll("-", " ")}.`;
+  const manual: Record<string, unknown> = {
+    tool_name: toolName,
+    job_to_be_done: jobText || `Use ${manifest.name} to complete the requested task.`,
+    summary_for_model: summary,
+    trigger_conditions: [
+      `The owner asks for help with ${jobText.toLowerCase()}`,
+      `A workflow needs ${manifest.name} to complete a specific external task`,
+      `The request matches the capability described as ${summaryText}`,
+    ],
+    do_not_use_when: [
+      "The request is unrelated to this tool's documented capability",
+      "A required connected account or required input is missing",
+    ],
+    permission_class: toolManualPermissionClass(manifest.permission_class),
+    dry_run_supported: Boolean(manifest.dry_run_supported),
+    requires_connected_accounts: manifest.required_connected_accounts ?? [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Natural-language request describing what the tool should do.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: {
+          type: "string",
+          description: "A concise summary of the result returned by the tool.",
+        },
+        result: {
+          type: "object",
+          description: "Structured result payload returned by the tool.",
+        },
+      },
+      required: ["summary", "result"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use the result summary to explain the outcome in plain language."],
+    result_hints: ["Highlight the most important result field before showing raw details."],
+    error_hints: ["If execution fails, explain what input or connected account needs attention."],
+  };
+
+  if (manifest.permission_class === PermissionClass.ACTION || manifest.permission_class === PermissionClass.PAYMENT) {
+    manual.approval_summary_template =
+      manifest.permission_class === PermissionClass.ACTION
+        ? `${manifest.name}: {query}`
+        : `${manifest.name}: approve {query} for {amount_minor} {currency}`;
+    manual.preview_schema = {
+      type: "object",
+      properties: {
+        summary: {
+          type: "string",
+          description: "Human-readable preview of what will happen.",
+        },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    };
+    manual.idempotency_support = true;
+    manual.side_effect_summary =
+      manifest.permission_class === PermissionClass.ACTION
+        ? `Using ${manifest.name} may create or modify an external resource.`
+        : `Using ${manifest.name} may initiate a payment or settlement attempt.`;
+    manual.jurisdiction = manifest.jurisdiction;
+  }
+
+  if (manifest.permission_class === PermissionClass.PAYMENT) {
+    manual.output_schema = {
+      type: "object",
+      properties: {
+        summary: {
+          type: "string",
+          description: "A concise summary of the payment or quote result.",
+        },
+        amount_usd: {
+          type: "number",
+          description: "Total amount in USD for the quote or completed payment.",
+        },
+        currency: {
+          type: "string",
+          description: "Currency code for the quoted or charged amount.",
+        },
+        payment_id: {
+          type: "string",
+          description: "Provider or platform payment identifier when execution completes.",
+        },
+      },
+      required: ["summary", "amount_usd", "currency"],
+      additionalProperties: false,
+    };
+    manual.quote_schema = {
+      type: "object",
+      properties: {
+        amount_minor: {
+          type: "integer",
+          description: "Quoted amount in minor currency units.",
+        },
+        currency: {
+          type: "string",
+          description: "Quoted currency code.",
+        },
+      },
+      required: ["amount_minor", "currency"],
+      additionalProperties: false,
+    };
+    manual.currency = "USD";
+    manual.settlement_mode = SettlementMode.STRIPE_CHECKOUT;
+    manual.refund_or_cancellation_note = "Explain the refund or cancellation policy for this payment flow.";
+  }
+
+  return manual;
+}
+
+export async function loadProject(path = "."): Promise<LoadedProject> {
+  const target = resolve(path);
+  const adapter_path = await findAdapterPath(target);
+  const root_dir = resolve(adapter_path, "..");
+  const app = await loadApp(adapter_path);
+  const manifest = await app.manifest();
+  const tool_manual_path = await findToolManualPath(root_dir);
+  const tool_manual = tool_manual_path
+    ? (JSON.parse(await readFile(tool_manual_path, "utf8")) as Record<string, unknown>)
+    : buildToolManualTemplate(manifest);
+
+  return {
+    root_dir,
+    adapter_path,
+    app,
+    manifest,
+    tool_manual_path: tool_manual_path ?? undefined,
+    tool_manual,
+  };
+}
+
+export async function validateProject(path = ".", deps: CliProjectDependencies = {}): Promise<Record<string, unknown>> {
+  const project = await loadProject(path);
+  const manifest_issues = await projectValidationIssues(project);
+  const [tool_manual_valid, tool_manual_issues] = validate_tool_manual(project.tool_manual);
+  const client = await createClient(deps);
+  const remote_quality = await client.preview_quality_score(project.tool_manual);
+
+  return {
+    adapter_path: project.adapter_path,
+    manifest: toJsonable(project.manifest),
+    manifest_issues,
+    tool_manual_path: project.tool_manual_path ?? null,
+    tool_manual: project.tool_manual,
+    tool_manual_valid,
+    tool_manual_issues: tool_manual_issues.map((nextIssue) => toJsonable(nextIssue)),
+    remote_quality: toJsonable(remote_quality),
+    ok: manifest_issues.length === 0 && tool_manual_valid && remoteQualityOk(remote_quality),
+  };
+}
+
+export async function scoreProject(
+  path = ".",
+  mode: "remote" | "offline" = "remote",
+  deps: CliProjectDependencies = {},
+): Promise<Record<string, unknown>> {
+  const project = await loadProject(path);
+  const [tool_manual_valid, tool_manual_issues] = validate_tool_manual(project.tool_manual);
+  const quality =
+    mode === "remote"
+      ? await (await createClient(deps)).preview_quality_score(project.tool_manual)
+      : score_tool_manual_offline(project.tool_manual);
+
+  return {
+    mode,
+    adapter_path: project.adapter_path,
+    tool_manual_path: project.tool_manual_path ?? null,
+    tool_manual_valid,
+    tool_manual_issues: tool_manual_issues.map((nextIssue) => toJsonable(nextIssue)),
+    quality: toJsonable(quality),
+    ok: tool_manual_valid && remoteQualityOk(quality),
+  };
+}
+
+export async function runRegistration(
+  path = ".",
+  options: { confirm?: boolean; submit_review?: boolean } = {},
+  deps: CliProjectDependencies = {},
+): Promise<Record<string, unknown>> {
+  const project = await loadProject(path);
+  const client = await createClient(deps);
+  const receipt = await client.auto_register(project.manifest, project.tool_manual);
+  const result: Record<string, unknown> = { receipt: toJsonable(receipt) };
+  if (options.confirm) {
+    result.confirmation = toJsonable(await client.confirm_registration(receipt.listing_id));
+    if (options.submit_review) {
+      result.submit_review_skipped = true;
+    }
+  } else if (options.submit_review) {
+    result.review = toJsonable(await client.submit_review(receipt.listing_id));
+  }
+  return result;
+}
+
+export async function createSupportCaseReport(
+  options: { subject: string; body: string; trace_id?: string },
+  deps: CliProjectDependencies = {},
+): Promise<Record<string, unknown>> {
+  const client = await createClient(deps);
+  const supportCase = await client.create_support_case(options.subject, options.body, { trace_id: options.trace_id });
+  return { case: toJsonable(supportCase) };
+}
+
+export async function getUsageReport(
+  options: { capability_key?: string; window: string },
+  deps: CliProjectDependencies = {},
+): Promise<Record<string, unknown>> {
+  const client = await createClient(deps);
+  const page = await client.get_usage({ capability_key: options.capability_key, period_key: options.window });
+  const items = page.all_items ? await page.all_items() : page.items;
+  return {
+    window: options.window,
+    capability_key: options.capability_key ?? null,
+    items: items.map((item) => toJsonable(item)),
+    count: items.length,
+  };
+}
+
+export async function runHarness(path = "."): Promise<Record<string, unknown>> {
+  const project = await loadProject(path);
+  return runHarnessForProject(project);
+}
+
+export async function writeInitTemplate(template: TemplateName, destination: string): Promise<string[]> {
+  const root = resolve(destination);
+  await mkdir(root, { recursive: true });
+  const adapter_path = join(root, "adapter.ts");
+  const manifest_path = join(root, "manifest.json");
+  const tool_manual_path = join(root, "tool_manual.json");
+  const readme_path = join(root, "README.md");
+
+  for (const filePath of [adapter_path, manifest_path, tool_manual_path, readme_path]) {
+    if (existsSync(filePath)) {
+      throw new SiglumeProjectError(`${basename(filePath)} already exists in ${root}`);
+    }
+  }
+
+  await writeFile(adapter_path, fallbackTemplateSource(template), "utf8");
+  const manifest = starterManifest(template);
+  await writeFile(manifest_path, renderJson(manifest), "utf8");
+  await writeFile(tool_manual_path, renderJson(buildToolManualTemplate(manifest)), "utf8");
+  await writeFile(readme_path, readmeTemplate(template), "utf8");
+  return [adapter_path, manifest_path, tool_manual_path, readme_path];
+}
+
+async function projectValidationIssues(project: LoadedProject): Promise<string[]> {
+  const harness = new AppTestHarness(project.app);
+  return harness.validate_manifest();
+}
+
+async function runHarnessForProject(project: LoadedProject): Promise<Record<string, unknown>> {
+  const harness = new AppTestHarness(project.app);
+  const manifest_issues = await harness.validate_manifest();
+  const health = await harness.health();
+  const task_type = project.app.supported_task_types()[0] ?? "default";
+  const sample_input = sampleInputFromSchema(project.tool_manual.input_schema);
+
+  const checks: Array<Record<string, unknown>> = [
+    {
+      name: "manifest_validation",
+      ok: manifest_issues.length === 0,
+      details: manifest_issues,
+    },
+    {
+      name: "health",
+      ok: Boolean(health.healthy),
+      details: { healthy: health.healthy, message: health.message ?? "" },
+    },
+  ];
+
+  checks.push(executionCheck("dry_run", await harness.dry_run(task_type, { input_params: sample_input }), harness));
+  if (project.manifest.permission_class === PermissionClass.ACTION || project.manifest.permission_class === PermissionClass.PAYMENT) {
+    checks.push(executionCheck("action", await harness.execute_action(task_type, { input_params: sample_input }), harness));
+  }
+  if (project.manifest.permission_class === PermissionClass.PAYMENT) {
+    checks.push(executionCheck("quote", await harness.execute_quote(task_type, { input_params: sample_input }), harness));
+    checks.push(executionCheck("payment", await harness.execute_payment(task_type, { input_params: sample_input }), harness));
+  }
+  checks.push(
+    executionCheck(
+      "missing_account_simulation",
+      await harness.simulate_connected_account_missing(task_type, { input_params: sample_input }),
+      harness,
+    ),
+  );
+
+  return {
+    adapter_path: project.adapter_path,
+    task_type,
+    sample_input,
+    checks,
+    ok: checks.every((check) => check.ok),
+  };
+}
+
+function executionCheck(name: string, result: ExecutionResult, harness: AppTestHarness): Record<string, unknown> {
+  const receipt_issues = harness.validate_receipt(result);
+  return {
+    name,
+    ok: Boolean(result.success) && receipt_issues.length === 0,
+    details: {
+      success: Boolean(result.success),
+      execution_kind: result.execution_kind,
+      receipt_issues,
+      output: toJsonable(result.output ?? {}),
+    },
+  };
+}
+
+function toolManualPermissionClass(permission_class: AppManifest["permission_class"]): string {
+  switch (permission_class) {
+    case PermissionClass.ACTION:
+      return ToolManualPermissionClass.ACTION;
+    case PermissionClass.PAYMENT:
+      return ToolManualPermissionClass.PAYMENT;
+    default:
+      return ToolManualPermissionClass.READ_ONLY;
+  }
+}
+
+async function findAdapterPath(target: string): Promise<string> {
+  if (existsSync(target) && SUPPORTED_EXTENSIONS.has(extname(target))) {
+    return target;
+  }
+
+  const preferred = join(target, "adapter.ts");
+  if (existsSync(preferred)) {
+    return preferred;
+  }
+
+  const entries = await readdir(target, { withFileTypes: true });
+  const candidates = entries
+    .filter((entry) => entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name)))
+    .map((entry) => join(target, entry.name))
+    .filter((filePath) => basename(filePath) !== "register_via_client.ts");
+
+  if (candidates.length === 0) {
+    throw new SiglumeProjectError(`No adapter TypeScript/JavaScript file found in ${target}`);
+  }
+  if (candidates.length > 1) {
+    throw new SiglumeProjectError(`Multiple adapter files found in ${target}. Pass the adapter file path explicitly.`);
+  }
+  return candidates[0]!;
+}
+
+async function findToolManualPath(root_dir: string): Promise<string | null> {
+  for (const name of ["tool_manual.json", "tool-manual.json"]) {
+    const candidate = join(root_dir, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function loadApp(adapter_path: string): Promise<AppAdapter> {
+  const jiti = createJiti(process.cwd(), { moduleCache: false });
+  const loaded = (await jiti.import(adapter_path)) as Record<string, unknown>;
+  const candidates = [loaded.default, ...Object.values(loaded)];
+  const seen = new Set<unknown>();
+  const matches: AppAdapter[] = [];
+
+  for (const candidate of candidates) {
+    if (candidate === undefined || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (candidate instanceof AppAdapter) {
+      matches.push(candidate);
+      continue;
+    }
+    if (
+      typeof candidate === "function" &&
+      (candidate.prototype instanceof AppAdapter ||
+        (typeof candidate.prototype?.manifest === "function" && typeof candidate.prototype?.execute === "function"))
+    ) {
+      matches.push(new (candidate as new () => AppAdapter)());
+      continue;
+    }
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      "manifest" in candidate &&
+      typeof (candidate as { manifest?: unknown }).manifest === "function" &&
+      "execute" in candidate &&
+      typeof (candidate as { execute?: unknown }).execute === "function"
+    ) {
+      matches.push(candidate as AppAdapter);
+    }
+  }
+
+  if (matches.length === 0) {
+    throw new SiglumeProjectError(`No AppAdapter subclass found in ${adapter_path}`);
+  }
+  if (matches.length > 1) {
+    throw new SiglumeProjectError(`Multiple AppAdapter subclasses found in ${adapter_path}. Keep one per file for CLI workflows.`);
+  }
+  return matches[0]!;
+}
+
+function sampleInputFromSchema(schema: unknown): Record<string, unknown> {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return { query: "Run a representative test request." };
+  }
+  const properties = (schema as Record<string, unknown>).properties;
+  const required = Array.isArray((schema as Record<string, unknown>).required)
+    ? ((schema as Record<string, unknown>).required as unknown[]).filter((item): item is string => typeof item === "string")
+    : [];
+  if (!properties || typeof properties !== "object" || Array.isArray(properties)) {
+    return { query: "Run a representative test request." };
+  }
+  const requiredFields = required.length > 0 ? required : Object.keys(properties);
+  const output: Record<string, unknown> = {};
+  for (const [fieldName, propertySchema] of Object.entries(properties)) {
+    if (requiredFields.includes(fieldName)) {
+      output[fieldName] = sampleValueFromProperty(propertySchema);
+    }
+  }
+  return Object.keys(output).length > 0 ? output : { query: "Run a representative test request." };
+}
+
+function sampleValueFromProperty(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return "sample";
+  }
+  const property = schema as Record<string, unknown>;
+  if ("default" in property) {
+    return property.default;
+  }
+  if (Array.isArray(property.enum) && property.enum.length > 0) {
+    return property.enum[0];
+  }
+  switch (property.type) {
+    case "integer":
+      return 1;
+    case "number":
+      return 1.0;
+    case "boolean":
+      return true;
+    case "array":
+      return [sampleValueFromProperty(property.items)];
+    case "object":
+      if (property.properties && typeof property.properties === "object" && !Array.isArray(property.properties)) {
+        return Object.fromEntries(
+          Object.entries(property.properties as Record<string, unknown>).map(([key, value]) => [key, sampleValueFromProperty(value)]),
+        );
+      }
+      return {};
+    default:
+      return "sample";
+  }
+}
+
+async function resolveApiKey(env: Record<string, string | undefined> = process.env): Promise<string> {
+  const envValue = env.SIGLUME_API_KEY;
+  if (envValue) {
+    return envValue;
+  }
+  const credentialsPath = join(homedir(), ".siglume", "credentials.toml");
+  if (existsSync(credentialsPath)) {
+    const text = await readFile(credentialsPath, "utf8");
+    const topLevel = text.match(/^\s*api_key\s*=\s*["']([^"']+)["']/m);
+    if (topLevel?.[1]) {
+      return topLevel[1].trim();
+    }
+    const defaultSection = text.match(/\[default\]([\s\S]*)/m)?.[1] ?? "";
+    const nested = defaultSection.match(/^\s*api_key\s*=\s*["']([^"']+)["']/m);
+    if (nested?.[1]) {
+      return nested[1].trim();
+    }
+  }
+  throw new SiglumeProjectError("SIGLUME_API_KEY is not set. Export it or add api_key to ~/.siglume/credentials.toml.");
+}
+
+function fallbackTemplateSource(template: TemplateName): string {
+  const className = {
+    echo: "StarterEchoApp",
+    "price-compare": "StarterPriceCompareApp",
+    publisher: "StarterPublisherApp",
+    payment: "StarterPaymentApp",
+  }[template];
+  const permissionClass = {
+    echo: "PermissionClass.READ_ONLY",
+    "price-compare": "PermissionClass.READ_ONLY",
+    publisher: "PermissionClass.ACTION",
+    payment: "PermissionClass.PAYMENT",
+  }[template];
+  const approvalMode = {
+    echo: "ApprovalMode.AUTO",
+    "price-compare": "ApprovalMode.AUTO",
+    publisher: "ApprovalMode.ALWAYS_ASK",
+    payment: "ApprovalMode.ALWAYS_ASK",
+  }[template];
+
+  return [
+    "import {",
+    "  AppAdapter,",
+    "  AppCategory,",
+    "  ApprovalMode,",
+    "  ExecutionResult,",
+    "  PermissionClass,",
+    "  PriceModel,",
+    "} from \"@siglume/api-sdk\";",
+    "",
+    `export default class ${className} extends AppAdapter {`,
+    "  manifest() {",
+    "    return {",
+    `      capability_key: \"${template}-starter\",`,
+    `      name: \"${className}\",`,
+    "      job_to_be_done: \"Describe what this starter API should do.\",",
+    "      category: AppCategory.OTHER,",
+    `      permission_class: ${permissionClass},`,
+    `      approval_mode: ${approvalMode},`,
+    "      dry_run_supported: true,",
+    "      required_connected_accounts: [],",
+    "      price_model: PriceModel.FREE,",
+    "      jurisdiction: \"US\",",
+    "      short_description: \"Starter template generated by siglume init.\",",
+    "      support_contact: \"support@example.com\",",
+    "      docs_url: \"https://example.com/docs\",",
+    "      example_prompts: [\"Describe a realistic prompt for this API.\"],",
+    "      compatibility_tags: [\"starter\"],",
+    "    };",
+    "  }",
+    "",
+    "  async execute(ctx) {",
+    "    return {",
+    "      success: true,",
+    "      execution_kind: ctx.execution_kind,",
+    "      output: {",
+    "        summary: \"Starter execution completed.\",",
+    "        input: ctx.input_params,",
+    "      },",
+    "    };",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function starterManifest(template: TemplateName): AppManifest {
+  const className = {
+    echo: "StarterEchoApp",
+    "price-compare": "StarterPriceCompareApp",
+    publisher: "StarterPublisherApp",
+    payment: "StarterPaymentApp",
+  }[template];
+  const permission_class = {
+    echo: PermissionClass.READ_ONLY,
+    "price-compare": PermissionClass.READ_ONLY,
+    publisher: PermissionClass.ACTION,
+    payment: PermissionClass.PAYMENT,
+  }[template];
+  const approval_mode = {
+    echo: "auto",
+    "price-compare": "auto",
+    publisher: "always-ask",
+    payment: "always-ask",
+  } as const;
+  return {
+    capability_key: `${template}-starter`,
+    name: className,
+    job_to_be_done: "Describe what this starter API should do.",
+    category: "other",
+    permission_class,
+    approval_mode: approval_mode[template],
+    dry_run_supported: true,
+    required_connected_accounts: [],
+    price_model: "free",
+    jurisdiction: "US",
+    short_description: "Starter template generated by siglume init.",
+    support_contact: "support@example.com",
+    docs_url: "https://example.com/docs",
+    example_prompts: ["Describe a realistic prompt for this API."],
+    compatibility_tags: ["starter"],
+  };
+}
+
+function readmeTemplate(template: TemplateName): string {
+  return [
+    "# Siglume Starter",
+    "",
+    `This project was generated with \`siglume init --template ${template}\`.`,
+    "",
+    "Files:",
+    "- `adapter.ts`: your AppAdapter implementation",
+    "- `manifest.json`: serialized AppManifest snapshot",
+    "- `tool_manual.json`: editable ToolManual draft for validation and registration",
+    "",
+    "Suggested workflow:",
+    "",
+    "```bash",
+    "siglume validate .",
+    "siglume test .",
+    "siglume score . --offline",
+    "siglume register . --confirm",
+    "```",
+    "",
+  ].join("\n");
+}

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -1,0 +1,838 @@
+import type {
+  AccessGrantRecord,
+  AppListingRecord,
+  AppManifest,
+  AutoRegistrationReceipt,
+  CapabilityBindingRecord,
+  ConnectedAccountRecord,
+  CursorPage,
+  DeveloperPortalSummary,
+  EnvelopeMeta,
+  GrantBindingResult,
+  RegistrationConfirmation,
+  RegistrationQuality,
+  SandboxSession,
+  SupportCaseRecord,
+  ToolManual,
+  ToolManualIssue,
+  ToolManualQualityReport,
+  UsageEventRecord,
+} from "./types";
+import { SiglumeAPIError, SiglumeClientError, SiglumeNotFoundError } from "./errors";
+import {
+  buildDefaultI18n,
+  buildRegistrationStubSource,
+  coerceMapping,
+  isRecord,
+  parseRetryAfter,
+  sleep,
+  stringOrNull,
+  toJsonable,
+  toRecord,
+} from "./utils";
+
+export const DEFAULT_SIGLUME_API_BASE = "https://api.siglume.com/v1";
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+type FetchLike = typeof fetch;
+
+type RequestOptions = {
+  params?: Record<string, string | number | boolean | undefined | null>;
+  json_body?: Record<string, unknown>;
+};
+
+export interface SiglumeClientOptions {
+  api_key: string;
+  base_url?: string;
+  timeout_ms?: number;
+  max_retries?: number;
+  fetch?: FetchLike;
+}
+
+type PendingConfirmation = {
+  manifest: Record<string, unknown>;
+  tool_manual: Record<string, unknown>;
+};
+
+type RequestMetaTuple = [Record<string, unknown>, EnvelopeMeta];
+
+export interface SiglumeClientShape {
+  auto_register(
+    manifest: AppManifest | Record<string, unknown>,
+    tool_manual: ToolManual | Record<string, unknown>,
+    options?: { source_code?: string; source_url?: string },
+  ): Promise<AutoRegistrationReceipt>;
+  confirm_registration(
+    listing_id: string,
+    options?: { manifest?: AppManifest | Record<string, unknown>; tool_manual?: ToolManual | Record<string, unknown> },
+  ): Promise<RegistrationConfirmation>;
+  preview_quality_score(tool_manual: ToolManual | Record<string, unknown>): Promise<ToolManualQualityReport>;
+  submit_review(listing_id: string): Promise<AppListingRecord>;
+  list_my_listings(options?: { status?: string; limit?: number; cursor?: string }): Promise<CursorPage<AppListingRecord>>;
+  get_listing(listing_id: string): Promise<AppListingRecord>;
+  list_capabilities(options?: {
+    mine?: boolean;
+    status?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CursorPage<AppListingRecord>>;
+  get_developer_portal(): Promise<DeveloperPortalSummary>;
+  create_sandbox_session(options: { agent_id: string; capability_key: string }): Promise<SandboxSession>;
+  get_usage(options?: {
+    capability_key?: string;
+    agent_id?: string;
+    outcome?: string;
+    environment?: string;
+    period_key?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CursorPage<UsageEventRecord>>;
+  list_access_grants(options?: {
+    status?: string;
+    agent_id?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CursorPage<AccessGrantRecord>>;
+  bind_agent_to_grant(
+    grant_id: string,
+    options: { agent_id: string; binding_status?: string },
+  ): Promise<GrantBindingResult>;
+  list_connected_accounts(options?: {
+    provider_key?: string;
+    environment?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CursorPage<ConnectedAccountRecord>>;
+  create_support_case(
+    subject: string,
+    body: string,
+    options?: {
+      trace_id?: string;
+      case_type?: string;
+      capability_key?: string;
+      agent_id?: string;
+      environment?: string;
+    },
+  ): Promise<SupportCaseRecord>;
+  list_support_cases(options?: {
+    capability_key?: string;
+    trace_id?: string;
+    status?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CursorPage<SupportCaseRecord>>;
+}
+
+class CursorPageResult<T> implements CursorPage<T> {
+  items: T[];
+  next_cursor?: string | null;
+  limit?: number | null;
+  offset?: number | null;
+  meta: EnvelopeMeta;
+  private readonly fetchNext?: (cursor: string) => Promise<CursorPageResult<T>>;
+
+  constructor(options: {
+    items: T[];
+    next_cursor?: string | null;
+    limit?: number | null;
+    offset?: number | null;
+    meta: EnvelopeMeta;
+    fetchNext?: (cursor: string) => Promise<CursorPageResult<T>>;
+  }) {
+    this.items = options.items;
+    this.next_cursor = options.next_cursor;
+    this.limit = options.limit;
+    this.offset = options.offset;
+    this.meta = options.meta;
+    this.fetchNext = options.fetchNext;
+  }
+
+  async *pages(): AsyncGenerator<CursorPageResult<T>> {
+    let page: CursorPageResult<T> | undefined = this;
+    while (page) {
+      yield page;
+      if (!page.next_cursor || !page.fetchNext) {
+        return;
+      }
+      page = await page.fetchNext(page.next_cursor);
+    }
+  }
+
+  async all_items(): Promise<T[]> {
+    const items: T[] = [];
+    for await (const page of this.pages()) {
+      items.push(...page.items);
+    }
+    return items;
+  }
+
+  async allItems(): Promise<T[]> {
+    return this.all_items();
+  }
+}
+
+function buildToolManualQualityReport(payload: Record<string, unknown>): ToolManualQualityReport {
+  const qualityBlock = isRecord(payload.quality) ? payload.quality : payload;
+  const issues: ToolManualIssue[] = [];
+  const validation_errors: ToolManualIssue[] = [];
+  const validation_warnings: ToolManualIssue[] = [];
+
+  for (const [bucketName, severity] of [
+    ["errors", "error"],
+    ["warnings", "warning"],
+  ] as const) {
+    const bucket = payload[bucketName];
+    if (!Array.isArray(bucket)) {
+      continue;
+    }
+    for (const item of bucket) {
+      if (!isRecord(item)) {
+        continue;
+      }
+      const nextIssue: ToolManualIssue = {
+        code: String(item.code ?? bucketName.toUpperCase()),
+        message: String(item.message ?? ""),
+        field: stringOrNull(item.field) ?? undefined,
+        severity,
+      };
+      issues.push(nextIssue);
+      if (bucketName === "errors") {
+        validation_errors.push(nextIssue);
+      } else {
+        validation_warnings.push(nextIssue);
+      }
+    }
+  }
+
+  const qualityIssues = qualityBlock.issues;
+  if (Array.isArray(qualityIssues)) {
+    for (const item of qualityIssues) {
+      if (!isRecord(item)) {
+        continue;
+      }
+      issues.push({
+        code: String(item.category ?? item.code ?? "QUALITY_ISSUE"),
+        message: String(item.message ?? ""),
+        field: stringOrNull(item.field) ?? undefined,
+        severity: (String(item.severity ?? "warning") as ToolManualIssue["severity"]),
+        suggestion: stringOrNull(item.suggestion) ?? undefined,
+      });
+    }
+  }
+
+  const suggestions = Array.isArray(qualityBlock.improvement_suggestions)
+    ? qualityBlock.improvement_suggestions.filter((item): item is string => typeof item === "string")
+    : [];
+  const keywordCoverage = Number(qualityBlock.keyword_coverage_estimate ?? qualityBlock.keyword_coverage ?? 0);
+  const overallScore = Number(qualityBlock.overall_score ?? qualityBlock.score ?? 0);
+  const validation_ok = typeof payload.ok === "boolean" ? payload.ok : true;
+  const publishable = typeof qualityBlock.publishable === "boolean"
+    ? qualityBlock.publishable
+    : validation_ok && String(qualityBlock.grade ?? "F") in { A: true, B: true };
+
+  return {
+    overall_score: Number.isFinite(overallScore) ? overallScore : 0,
+    grade: String(qualityBlock.grade ?? "F") as ToolManualQualityReport["grade"],
+    issues,
+    keyword_coverage_estimate: Number.isFinite(keywordCoverage) ? keywordCoverage : 0,
+    improvement_suggestions: suggestions,
+    publishable,
+    validation_ok,
+    validation_errors,
+    validation_warnings,
+  };
+}
+
+function buildUrl(baseUrl: string, path: string, params?: RequestOptions["params"]): string {
+  const url = new URL(`${baseUrl}${path}`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+function parseListing(data: Record<string, unknown>): AppListingRecord {
+  return {
+    listing_id: String(data.listing_id ?? data.id ?? ""),
+    capability_key: String(data.capability_key ?? ""),
+    name: String(data.name ?? ""),
+    status: String(data.status ?? ""),
+    category: stringOrNull(data.category),
+    job_to_be_done: stringOrNull(data.job_to_be_done),
+    permission_class: stringOrNull(data.permission_class),
+    approval_mode: stringOrNull(data.approval_mode),
+    dry_run_supported: Boolean(data.dry_run_supported ?? false),
+    price_model: stringOrNull(data.price_model),
+    price_value_minor: Number(data.price_value_minor ?? 0),
+    currency: String(data.currency ?? "USD"),
+    short_description: stringOrNull(data.short_description),
+    docs_url: stringOrNull(data.docs_url),
+    support_contact: stringOrNull(data.support_contact),
+    review_status: stringOrNull(data.review_status),
+    review_note: stringOrNull(data.review_note),
+    submission_blockers: Array.isArray(data.submission_blockers)
+      ? data.submission_blockers.filter((item): item is string => typeof item === "string")
+      : [],
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseRegistrationQuality(data: Record<string, unknown>): RegistrationQuality {
+  return {
+    overall_score: Number(data.overall_score ?? data.score ?? 0),
+    grade: String(data.grade ?? "F"),
+    issues: Array.isArray(data.issues)
+      ? data.issues.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => ({ ...item }))
+      : [],
+    improvement_suggestions: Array.isArray(data.improvement_suggestions)
+      ? data.improvement_suggestions.filter((item): item is string => typeof item === "string")
+      : [],
+    raw: { ...data },
+  };
+}
+
+function parseUsageEvent(data: Record<string, unknown>): UsageEventRecord {
+  return {
+    usage_event_id: String(data.usage_event_id ?? data.id ?? ""),
+    capability_key: stringOrNull(data.capability_key),
+    agent_id: stringOrNull(data.agent_id),
+    environment: stringOrNull(data.environment),
+    task_type: stringOrNull(data.task_type),
+    units_consumed: Number(data.units_consumed ?? 0),
+    outcome: stringOrNull(data.outcome),
+    execution_kind: stringOrNull(data.execution_kind),
+    permission_class: stringOrNull(data.permission_class),
+    approval_mode: stringOrNull(data.approval_mode),
+    latency_ms: typeof data.latency_ms === "number" ? data.latency_ms : null,
+    trace_id: stringOrNull(data.trace_id),
+    period_key: stringOrNull(data.period_key),
+    created_at: stringOrNull(data.created_at),
+    metadata: toRecord(data.metadata),
+    raw: { ...data },
+  };
+}
+
+function parseAccessGrant(data: Record<string, unknown>): AccessGrantRecord {
+  return {
+    access_grant_id: String(data.access_grant_id ?? data.id ?? ""),
+    capability_listing_id: String(data.capability_listing_id ?? ""),
+    grant_status: String(data.grant_status ?? ""),
+    billing_model: stringOrNull(data.billing_model),
+    agent_id: stringOrNull(data.agent_id),
+    starts_at: stringOrNull(data.starts_at),
+    ends_at: stringOrNull(data.ends_at),
+    bindings: Array.isArray(data.bindings)
+      ? data.bindings.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => ({ ...item }))
+      : [],
+    metadata: toRecord(data.metadata),
+    raw: { ...data },
+  };
+}
+
+function parseBinding(data: Record<string, unknown>): CapabilityBindingRecord {
+  return {
+    binding_id: String(data.binding_id ?? data.id ?? ""),
+    access_grant_id: String(data.access_grant_id ?? ""),
+    agent_id: String(data.agent_id ?? ""),
+    binding_status: String(data.binding_status ?? ""),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseConnectedAccount(data: Record<string, unknown>): ConnectedAccountRecord {
+  return {
+    connected_account_id: String(data.connected_account_id ?? data.id ?? ""),
+    provider_key: String(data.provider_key ?? ""),
+    account_role: String(data.account_role ?? ""),
+    display_name: stringOrNull(data.display_name),
+    environment: stringOrNull(data.environment),
+    connection_status: stringOrNull(data.connection_status),
+    scopes: Array.isArray(data.scopes) ? data.scopes.filter((item): item is string => typeof item === "string") : [],
+    metadata: toRecord(data.metadata),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseSupportCase(data: Record<string, unknown>): SupportCaseRecord {
+  return {
+    support_case_id: String(data.support_case_id ?? data.id ?? ""),
+    case_type: String(data.case_type ?? ""),
+    summary: String(data.summary ?? ""),
+    status: String(data.status ?? ""),
+    capability_key: stringOrNull(data.capability_key),
+    agent_id: stringOrNull(data.agent_id),
+    trace_id: stringOrNull(data.trace_id),
+    environment: stringOrNull(data.environment),
+    resolution_note: stringOrNull(data.resolution_note),
+    metadata: toRecord(data.metadata),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+export class SiglumeClient implements SiglumeClientShape {
+  readonly api_key: string;
+  readonly base_url: string;
+  readonly timeout_ms: number;
+  readonly max_retries: number;
+  private readonly fetchImpl: FetchLike;
+  private readonly pendingConfirmations = new Map<string, PendingConfirmation>();
+
+  constructor(options: SiglumeClientOptions) {
+    if (!options.api_key) {
+      throw new SiglumeClientError("SIGLUME_API_KEY is required.");
+    }
+    this.api_key = options.api_key;
+    this.base_url = (options.base_url ?? DEFAULT_SIGLUME_API_BASE).replace(/\/+$/, "");
+    this.timeout_ms = Math.max(1, options.timeout_ms ?? 15_000);
+    this.max_retries = Math.max(1, Math.trunc(options.max_retries ?? 3));
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  close(): void {}
+
+  async auto_register(
+    manifest: AppManifest | Record<string, unknown>,
+    tool_manual: ToolManual | Record<string, unknown>,
+    options: { source_code?: string; source_url?: string } = {},
+  ): Promise<AutoRegistrationReceipt> {
+    const manifestPayload = coerceMapping(manifest, "manifest");
+    const toolManualPayload = coerceMapping(tool_manual, "tool_manual");
+    const payload: Record<string, unknown> = { i18n: buildDefaultI18n(manifestPayload) };
+    if (options.source_url) {
+      payload.source_url = options.source_url;
+    } else if (options.source_code !== undefined) {
+      payload.source_code = options.source_code;
+    } else {
+      payload.source_code = buildRegistrationStubSource(manifestPayload, toolManualPayload);
+    }
+    for (const fieldName of ["capability_key", "name", "price_model", "price_value_minor"]) {
+      const value = manifestPayload[fieldName];
+      if (value !== undefined && value !== null) {
+        payload[fieldName] = value as string | number;
+      }
+    }
+    const [data, meta] = await this.request("POST", "/market/capabilities/auto-register", { json_body: payload });
+    const listing_id = String(data.listing_id ?? "");
+    if (!listing_id) {
+      throw new SiglumeClientError("Siglume auto-register response did not include listing_id.");
+    }
+    this.pendingConfirmations.set(listing_id, { manifest: manifestPayload, tool_manual: toolManualPayload });
+    return {
+      listing_id,
+      status: String(data.status ?? "draft"),
+      auto_manifest: toRecord(data.auto_manifest),
+      confidence: toRecord(data.confidence),
+      review_url: stringOrNull(data.review_url),
+      trace_id: meta.trace_id,
+      request_id: meta.request_id,
+    };
+  }
+
+  async confirm_registration(
+    listing_id: string,
+    options: { manifest?: AppManifest | Record<string, unknown>; tool_manual?: ToolManual | Record<string, unknown> } = {},
+  ): Promise<RegistrationConfirmation> {
+    const pending = this.pendingConfirmations.get(listing_id);
+    const manifestPayload = options.manifest ? coerceMapping(options.manifest, "manifest") : pending?.manifest ?? {};
+    const toolManualPayload = options.tool_manual ? coerceMapping(options.tool_manual, "tool_manual") : pending?.tool_manual ?? {};
+    const overrides: Record<string, unknown> = {};
+    for (const fieldName of ["name", "job_to_be_done"]) {
+      if (manifestPayload[fieldName]) {
+        overrides[fieldName] = manifestPayload[fieldName];
+      }
+    }
+    if (Object.keys(toolManualPayload).length > 0) {
+      overrides.tool_manual = toolManualPayload;
+    }
+    const payload: Record<string, unknown> = { approved: true };
+    if (Object.keys(overrides).length > 0) {
+      payload.overrides = overrides;
+    }
+    const [data, meta] = await this.request("POST", `/market/capabilities/${listing_id}/confirm-auto-register`, { json_body: payload });
+    this.pendingConfirmations.delete(listing_id);
+    return {
+      listing_id: String(data.listing_id ?? listing_id),
+      status: String(data.status ?? ""),
+      release: toRecord(data.release),
+      quality: parseRegistrationQuality(toRecord(data.quality)),
+      trace_id: meta.trace_id,
+      request_id: meta.request_id,
+      raw: { ...data },
+    };
+  }
+
+  async submit_review(listing_id: string): Promise<AppListingRecord> {
+    const [data] = await this.request("POST", `/market/capabilities/${listing_id}/submit-review`);
+    return parseListing(data);
+  }
+
+  async preview_quality_score(tool_manual: ToolManual | Record<string, unknown>): Promise<ToolManualQualityReport> {
+    const toolManualPayload = coerceMapping(tool_manual, "tool_manual");
+    const [data] = await this.request("POST", "/market/tool-manuals/preview-quality", {
+      json_body: { tool_manual: toolManualPayload },
+    });
+    return buildToolManualQualityReport(data);
+  }
+
+  async list_capabilities(options: {
+    mine?: boolean;
+    status?: string;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<CursorPageResult<AppListingRecord>> {
+    const params = {
+      mine: options.mine,
+      status: options.status,
+      limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 20), 100)),
+      cursor: options.cursor,
+    };
+    const [data, meta] = await this.request("GET", "/market/capabilities", { params });
+    const items = Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseListing)
+      : [];
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
+      items,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : params.limit,
+      offset: typeof data.offset === "number" ? data.offset : null,
+      meta,
+      fetchNext: next_cursor
+        ? (cursor) => this.list_capabilities({ ...options, cursor })
+        : undefined,
+    });
+  }
+
+  async list_my_listings(options: { status?: string; limit?: number; cursor?: string } = {}) {
+    return this.list_capabilities({ ...options, mine: true });
+  }
+
+  async get_listing(listing_id: string): Promise<AppListingRecord> {
+    const [data] = await this.request("GET", `/market/capabilities/${listing_id}`);
+    return parseListing(data);
+  }
+
+  async get_developer_portal(): Promise<DeveloperPortalSummary> {
+    const [data, meta] = await this.request("GET", "/market/developer/portal");
+    return {
+      seller_onboarding: Object.keys(toRecord(data.seller_onboarding)).length > 0 ? toRecord(data.seller_onboarding) : null,
+      platform: toRecord(data.platform),
+      monetization: toRecord(data.monetization),
+      payout_readiness: toRecord(data.payout_readiness),
+      listings: toRecord(data.listings),
+      usage: toRecord(data.usage),
+      support: toRecord(data.support),
+      apps: Array.isArray(data.apps) ? data.apps.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseListing) : [],
+      trace_id: meta.trace_id,
+      request_id: meta.request_id,
+      raw: { ...data },
+    };
+  }
+
+  async create_sandbox_session(options: { agent_id: string; capability_key: string }): Promise<SandboxSession> {
+    const [data, meta] = await this.request("POST", "/market/sandbox/sessions", {
+      json_body: {
+        agent_id: options.agent_id,
+        capability_key: options.capability_key,
+      },
+    });
+    return {
+      session_id: String(data.session_id ?? ""),
+      agent_id: String(data.agent_id ?? ""),
+      capability_key: String(data.capability_key ?? ""),
+      environment: String(data.environment ?? "sandbox"),
+      sandbox_support: stringOrNull(data.sandbox_support),
+      dry_run_supported: Boolean(data.dry_run_supported ?? false),
+      approval_mode: stringOrNull(data.approval_mode),
+      required_connected_accounts: Array.isArray(data.required_connected_accounts) ? data.required_connected_accounts : [],
+      connected_accounts: Array.isArray(data.connected_accounts)
+        ? data.connected_accounts.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => ({ ...item }))
+        : [],
+      stub_providers_enabled: Boolean(data.stub_providers_enabled ?? false),
+      simulated_receipts: Boolean(data.simulated_receipts ?? false),
+      approval_simulator: Boolean(data.approval_simulator ?? false),
+      trace_id: meta.trace_id,
+      request_id: meta.request_id,
+      raw: { ...data },
+    };
+  }
+
+  async get_usage(options: {
+    capability_key?: string;
+    agent_id?: string;
+    outcome?: string;
+    environment?: string;
+    period_key?: string;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<CursorPageResult<UsageEventRecord>> {
+    const params = {
+      capability_key: options.capability_key,
+      agent_id: options.agent_id,
+      outcome: options.outcome,
+      environment: options.environment,
+      period_key: options.period_key,
+      limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 50), 100)),
+      cursor: options.cursor,
+    };
+    const [data, meta] = await this.request("GET", "/market/usage", { params });
+    const items = Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseUsageEvent)
+      : [];
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
+      items,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : params.limit,
+      offset: typeof data.offset === "number" ? data.offset : null,
+      meta,
+      fetchNext: next_cursor
+        ? (cursor) => this.get_usage({ ...options, cursor })
+        : undefined,
+    });
+  }
+
+  async list_access_grants(options: {
+    status?: string;
+    agent_id?: string;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<CursorPageResult<AccessGrantRecord>> {
+    const params = {
+      status: options.status,
+      agent_id: options.agent_id,
+      limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 20), 100)),
+      cursor: options.cursor,
+    };
+    const [data, meta] = await this.request("GET", "/market/access-grants", { params });
+    const items = Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseAccessGrant)
+      : [];
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
+      items,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : params.limit,
+      offset: typeof data.offset === "number" ? data.offset : null,
+      meta,
+      fetchNext: next_cursor
+        ? (cursor) => this.list_access_grants({ ...options, cursor })
+        : undefined,
+    });
+  }
+
+  async bind_agent_to_grant(
+    grant_id: string,
+    options: { agent_id: string; binding_status?: string },
+  ): Promise<GrantBindingResult> {
+    const [data, meta] = await this.request("POST", `/market/access-grants/${grant_id}/bind-agent`, {
+      json_body: {
+        agent_id: options.agent_id,
+        binding_status: options.binding_status ?? "active",
+      },
+    });
+    return {
+      binding: parseBinding(toRecord(data.binding)),
+      access_grant: parseAccessGrant(toRecord(data.access_grant)),
+      trace_id: meta.trace_id,
+      request_id: meta.request_id,
+      raw: { ...data },
+    };
+  }
+
+  async list_connected_accounts(options: {
+    provider_key?: string;
+    environment?: string;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<CursorPageResult<ConnectedAccountRecord>> {
+    const params = {
+      provider_key: options.provider_key,
+      environment: options.environment,
+      limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 50), 100)),
+      cursor: options.cursor,
+    };
+    const [data, meta] = await this.request("GET", "/market/connected-accounts", { params });
+    const items = Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseConnectedAccount)
+      : [];
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
+      items,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : params.limit,
+      offset: typeof data.offset === "number" ? data.offset : null,
+      meta,
+      fetchNext: next_cursor
+        ? (cursor) => this.list_connected_accounts({ ...options, cursor })
+        : undefined,
+    });
+  }
+
+  async create_support_case(
+    subject: string,
+    body: string,
+    options: {
+      trace_id?: string;
+      case_type?: string;
+      capability_key?: string;
+      agent_id?: string;
+      environment?: string;
+    } = {},
+  ): Promise<SupportCaseRecord> {
+    const summary = subject.trim();
+    const details = body.trim();
+    const composedSummary = details ? `${summary}\n\n${details}` : summary;
+    if (!composedSummary) {
+      throw new SiglumeClientError("Support case subject or body is required.");
+    }
+    if (composedSummary.length > 2000) {
+      throw new SiglumeClientError("Support case summary/body must fit within the 2000 character API limit.");
+    }
+    const [data] = await this.request("POST", "/market/support-cases", {
+      json_body: {
+        case_type: options.case_type ?? "app_execution",
+        summary: composedSummary,
+        environment: options.environment ?? "live",
+        capability_key: options.capability_key,
+        agent_id: options.agent_id,
+        trace_id: options.trace_id,
+      },
+    });
+    return parseSupportCase(data);
+  }
+
+  async list_support_cases(options: {
+    capability_key?: string;
+    trace_id?: string;
+    status?: string;
+    limit?: number;
+    cursor?: string;
+  } = {}): Promise<CursorPageResult<SupportCaseRecord>> {
+    const params = {
+      capability_key: options.capability_key,
+      trace_id: options.trace_id,
+      status: options.status,
+      limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 50), 100)),
+      cursor: options.cursor,
+    };
+    const [data, meta] = await this.request("GET", "/market/support-cases", { params });
+    const items = Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseSupportCase)
+      : [];
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
+      items,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : params.limit,
+      offset: typeof data.offset === "number" ? data.offset : null,
+      meta,
+      fetchNext: next_cursor
+        ? (cursor) => this.list_support_cases({ ...options, cursor })
+        : undefined,
+    });
+  }
+
+  private async request(method: string, path: string, options: RequestOptions = {}): Promise<RequestMetaTuple> {
+    const url = buildUrl(this.base_url, path, options.params);
+    const headers = new Headers({
+      Authorization: `Bearer ${this.api_key}`,
+      Accept: "application/json",
+      "User-Agent": "siglume-api-sdk-ts/0.4.0-dev.0",
+    });
+    let body: string | undefined;
+    if (options.json_body) {
+      headers.set("Content-Type", "application/json");
+      body = JSON.stringify(toJsonable(options.json_body));
+    }
+
+    for (let attempt = 0; attempt < this.max_retries; attempt += 1) {
+      const controller = new AbortController();
+      const timeoutHandle = setTimeout(() => controller.abort(), this.timeout_ms);
+      try {
+        const response = await this.fetchImpl(url, {
+          method,
+          headers,
+          body,
+          signal: controller.signal,
+        });
+        clearTimeout(timeoutHandle);
+        const text = response.status === 204 ? "" : await response.text();
+        const parsed = text ? this.safeParseJson(text) : {};
+        const envelope = isRecord(parsed) ? parsed : {};
+        const data = isRecord(envelope.data) ? envelope.data : isRecord(parsed) ? parsed : {};
+        const meta: EnvelopeMeta = isRecord(envelope.meta)
+          ? {
+              request_id: stringOrNull(envelope.meta.request_id),
+              trace_id: stringOrNull(envelope.meta.trace_id),
+            }
+          : {
+              request_id: stringOrNull(response.headers.get("x-request-id")),
+              trace_id: stringOrNull(response.headers.get("x-trace-id")),
+            };
+
+        if (response.ok) {
+          return [data, meta];
+        }
+
+        if (RETRYABLE_STATUS_CODES.has(response.status) && attempt + 1 < this.max_retries) {
+          await sleep(parseRetryAfter(response.headers.get("Retry-After")) ?? (250 * (2 ** attempt)));
+          continue;
+        }
+
+        const errorBlock = isRecord(envelope.error) ? envelope.error : {};
+        const message = String(
+          errorBlock.message ??
+            (isRecord(parsed) ? parsed.message : undefined) ??
+            response.statusText ??
+            "Siglume API request failed.",
+        );
+        const error_code = stringOrNull(errorBlock.code) ?? undefined;
+        if (response.status === 404) {
+          throw new SiglumeNotFoundError(message);
+        }
+        throw new SiglumeAPIError(message, {
+          status_code: response.status,
+          error_code,
+          trace_id: meta.trace_id,
+          request_id: meta.request_id,
+          details: toRecord(errorBlock.details),
+          response_body: parsed,
+        });
+      } catch (error) {
+        clearTimeout(timeoutHandle);
+        if (error instanceof SiglumeAPIError || error instanceof SiglumeNotFoundError) {
+          throw error;
+        }
+        if (attempt + 1 < this.max_retries) {
+          await sleep(250 * (2 ** attempt));
+          continue;
+        }
+        if (error instanceof Error) {
+          throw new SiglumeClientError(error.message);
+        }
+        throw new SiglumeClientError("Siglume request failed.");
+      }
+    }
+    throw new SiglumeClientError("Siglume request failed after retries.");
+  }
+
+  private safeParseJson(text: string): unknown {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return {};
+    }
+  }
+}

--- a/siglume-api-sdk-ts/src/errors.ts
+++ b/siglume-api-sdk-ts/src/errors.ts
@@ -1,0 +1,43 @@
+export class SiglumeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export class SiglumeClientError extends SiglumeError {}
+
+export class SiglumeProjectError extends SiglumeError {}
+
+export class SiglumeValidationError extends SiglumeError {}
+
+export class SiglumeNotFoundError extends SiglumeClientError {}
+
+export class SiglumeAPIError extends SiglumeClientError {
+  status_code: number;
+  error_code?: string;
+  trace_id?: string | null;
+  request_id?: string | null;
+  details: Record<string, unknown>;
+  response_body?: unknown;
+
+  constructor(
+    message: string,
+    options: {
+      status_code: number;
+      error_code?: string;
+      trace_id?: string | null;
+      request_id?: string | null;
+      details?: Record<string, unknown>;
+      response_body?: unknown;
+    },
+  ) {
+    super(message);
+    this.status_code = options.status_code;
+    this.error_code = options.error_code;
+    this.trace_id = options.trace_id;
+    this.request_id = options.request_id;
+    this.details = options.details ?? {};
+    this.response_body = options.response_body;
+  }
+}

--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./client";
+export * from "./errors";
+export * from "./runtime";
+export * from "./tool-manual-grader";
+export * from "./tool-manual-validator";
+export * from "./types";
+export { renderJson as render_json } from "./utils";

--- a/siglume-api-sdk-ts/src/runtime.ts
+++ b/siglume-api-sdk-ts/src/runtime.ts
@@ -1,0 +1,226 @@
+import type {
+  AppManifest,
+  Awaitable,
+  ConnectedAccountRef,
+  ExecutionContext,
+  ExecutionKind,
+  ExecutionResult,
+  HealthCheckResult,
+  ToolManual,
+  ToolManualIssue,
+} from "./types";
+import { ApprovalMode, Environment, PermissionClass } from "./types";
+import { validate_tool_manual } from "./tool-manual-validator";
+
+const CAPABILITY_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+function normalizeExecutionResult(result: ExecutionResult, executionKind: ExecutionKind): ExecutionResult {
+  return {
+    success: Boolean(result.success),
+    output: result.output ?? {},
+    execution_kind: result.execution_kind ?? executionKind,
+    units_consumed: result.units_consumed ?? 1,
+    amount_minor: result.amount_minor ?? 0,
+    currency: result.currency ?? "USD",
+    provider_status: result.provider_status ?? "ok",
+    error_message: result.error_message,
+    fallback_applied: result.fallback_applied ?? false,
+    needs_approval: result.needs_approval ?? false,
+    approval_prompt: result.approval_prompt,
+    receipt_summary: result.receipt_summary ?? {},
+    artifacts: result.artifacts ?? [],
+    side_effects: result.side_effects ?? [],
+    receipt_ref: result.receipt_ref,
+    approval_hint: result.approval_hint,
+  };
+}
+
+export abstract class AppAdapter {
+  abstract manifest(): Awaitable<AppManifest>;
+  abstract execute(ctx: ExecutionContext): Awaitable<ExecutionResult>;
+
+  async health_check(): Promise<HealthCheckResult> {
+    return { healthy: true, message: "" };
+  }
+
+  async on_install(_agent_id: string, _owner_user_id: string): Promise<void> {}
+
+  async on_uninstall(_agent_id: string, _owner_user_id: string): Promise<void> {}
+
+  supported_task_types(): string[] {
+    return ["default"];
+  }
+}
+
+export class StubProvider {
+  provider_key: string;
+
+  constructor(provider_key: string) {
+    this.provider_key = provider_key;
+  }
+
+  async handle(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return {
+      status: "stub_ok",
+      provider: this.provider_key,
+      method,
+      params,
+    };
+  }
+}
+
+export class AppTestHarness {
+  app: AppAdapter;
+  stubs: Record<string, StubProvider>;
+
+  constructor(app: AppAdapter, stubs: Record<string, StubProvider> = {}) {
+    this.app = app;
+    this.stubs = stubs;
+  }
+
+  private async executeWithKind(
+    execution_kind: ExecutionKind,
+    task_type = "default",
+    options: {
+      connected_accounts?: Record<string, ConnectedAccountRef>;
+      input_params?: Record<string, unknown>;
+      trace_id?: string;
+      idempotency_key?: string;
+      request_hash?: string;
+      budget_remaining_minor?: number | null;
+      metadata?: Record<string, unknown>;
+    } = {},
+  ): Promise<ExecutionResult> {
+    const connected_accounts =
+      options.connected_accounts ??
+      Object.fromEntries(
+        Object.keys(this.stubs).map((key) => [
+          key,
+          {
+            provider_key: key,
+            session_token: `stub-token-${key}`,
+            environment: Environment.SANDBOX,
+            scopes: [],
+          },
+        ]),
+      );
+    const ctx: ExecutionContext = {
+      agent_id: "test-agent-001",
+      owner_user_id: "test-owner-001",
+      task_type,
+      environment: Environment.SANDBOX,
+      execution_kind,
+      connected_accounts,
+      input_params: options.input_params ?? {},
+      trace_id: options.trace_id,
+      idempotency_key: options.idempotency_key,
+      request_hash: options.request_hash,
+      budget_remaining_minor: options.budget_remaining_minor ?? null,
+      metadata: options.metadata ?? {},
+    };
+    return normalizeExecutionResult(await this.app.execute(ctx), execution_kind);
+  }
+
+  async dry_run(task_type = "default", options: Parameters<AppTestHarness["executeWithKind"]>[2] = {}) {
+    return this.executeWithKind("dry_run", task_type, options);
+  }
+
+  async execute_action(task_type = "default", options: Parameters<AppTestHarness["executeWithKind"]>[2] = {}) {
+    return this.executeWithKind("action", task_type, options);
+  }
+
+  async execute_quote(task_type = "default", options: Parameters<AppTestHarness["executeWithKind"]>[2] = {}) {
+    return this.executeWithKind("quote", task_type, options);
+  }
+
+  async execute_payment(task_type = "default", options: Parameters<AppTestHarness["executeWithKind"]>[2] = {}) {
+    return this.executeWithKind("payment", task_type, options);
+  }
+
+  async health(): Promise<HealthCheckResult> {
+    return this.app.health_check();
+  }
+
+  async validate_manifest(): Promise<string[]> {
+    const manifest = await this.app.manifest();
+    const issues: string[] = [];
+    if (!manifest.capability_key) {
+      issues.push("capability_key is required");
+    } else if (!CAPABILITY_KEY_RE.test(manifest.capability_key)) {
+      issues.push("capability_key must be lowercase alphanumeric with hyphens (e.g., 'price-compare-helper')");
+    }
+    if (!manifest.name) {
+      issues.push("name is required");
+    }
+    if (!manifest.job_to_be_done) {
+      issues.push("job_to_be_done is required");
+    }
+    if (!manifest.example_prompts || manifest.example_prompts.length === 0) {
+      issues.push("at least one example_prompt is recommended");
+    }
+    if (manifest.permission_class === PermissionClass.ACTION || manifest.permission_class === PermissionClass.PAYMENT) {
+      if (!manifest.dry_run_supported) {
+        issues.push("action/payment apps should support dry_run");
+      }
+      if ((manifest.approval_mode ?? ApprovalMode.AUTO) === ApprovalMode.AUTO) {
+        issues.push("action/payment apps should not use auto approval");
+      }
+    }
+    return issues;
+  }
+
+  validate_tool_manual(manual?: ToolManual | Record<string, unknown>): [boolean, ToolManualIssue[]] {
+    if (!manual) {
+      return [true, []];
+    }
+    return validate_tool_manual(manual);
+  }
+
+  validate_receipt(result: ExecutionResult): string[] {
+    const issues: string[] = [];
+    if (result.execution_kind !== "dry_run") {
+      const hasLegacy = Boolean(result.receipt_summary && Object.keys(result.receipt_summary).length > 0);
+      const hasStructured = Boolean((result.artifacts?.length ?? 0) > 0 || (result.side_effects?.length ?? 0) > 0);
+      if (!hasLegacy && !hasStructured) {
+        issues.push("Non-dry-run execution should include receipt_summary or structured artifacts/side_effects");
+      }
+    }
+
+    if (result.execution_kind === "action" || result.execution_kind === "payment") {
+      if ((result.side_effects?.length ?? 0) === 0 && !result.receipt_summary) {
+        issues.push("Action/payment execution should report side effects");
+      }
+    }
+
+    if (result.needs_approval && !result.approval_prompt && !result.approval_hint) {
+      issues.push("needs_approval=True but no approval_prompt or approval_hint provided");
+    }
+
+    for (const [index, artifact] of (result.artifacts ?? []).entries()) {
+      if (!artifact.artifact_type) {
+        issues.push(`artifacts[${index}].artifact_type is empty`);
+      }
+    }
+
+    for (const [index, sideEffect] of (result.side_effects ?? []).entries()) {
+      if (!sideEffect.action) {
+        issues.push(`side_effects[${index}].action is empty`);
+      }
+      if (!sideEffect.provider) {
+        issues.push(`side_effects[${index}].provider is empty`);
+      }
+    }
+
+    return issues;
+  }
+
+  async simulate_connected_account_missing(
+    task_type = "default",
+    options: Parameters<AppTestHarness["executeWithKind"]>[2] = {},
+  ) {
+    return this.executeWithKind("dry_run", task_type, {
+      ...options,
+      connected_accounts: {},
+    });
+  }
+}

--- a/siglume-api-sdk-ts/src/tool-manual-grader.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-grader.ts
@@ -1,0 +1,616 @@
+import rules from "../../schemas/tool-manual-grader-rules.json";
+
+import { SiglumeClient } from "./client";
+import type { ToolManualIssue, ToolManualQualityReport } from "./types";
+import { validate_tool_manual } from "./tool-manual-validator";
+import { isRecord } from "./utils";
+
+const WORD_RE = /[A-Za-z\u3040-\u9fff]{2,}/gu;
+
+type GraderIssueFactory = (
+  code: string,
+  message: string,
+  options?: { field?: string; severity?: ToolManualIssue["severity"]; suggestion?: string },
+) => ToolManualIssue;
+
+type ManualScoreParts = {
+  trigger_score: number;
+  do_not_use_score: number;
+  summary_score: number;
+  input_schema_score: number;
+  output_schema_score: number;
+  hints_score: number;
+  keyword_count: number;
+};
+
+const ambiguityPhrases = Array.isArray(rules.ambiguity_phrases)
+  ? rules.ambiguity_phrases.map((item) => String(item))
+  : [];
+const marketingFluff = Array.isArray(rules.marketing_fluff)
+  ? rules.marketing_fluff.map((item) => String(item))
+  : [];
+const imperativePrefixes = Array.isArray(rules.imperative_prefixes)
+  ? rules.imperative_prefixes.map((item) => String(item))
+  : [];
+const stopWords = new Set(
+  Array.isArray(rules.stop_words) ? rules.stop_words.map((item) => String(item)) : [],
+);
+const keywordCoverageBands = Array.isArray(rules.keyword_coverage_bands)
+  ? rules.keyword_coverage_bands
+      .filter((item): item is { minimum_keywords: number; score: number } =>
+        isRecord(item) &&
+        typeof item.minimum_keywords === "number" &&
+        typeof item.score === "number",
+      )
+      .map((item) => [item.minimum_keywords, item.score] as const)
+      .sort((left, right) => right[0] - left[0])
+  : [];
+const gradeThresholdSource = isRecord(rules.grade_thresholds) ? (rules.grade_thresholds as Record<string, unknown>) : {};
+const gradeThresholds = ["A", "B", "C", "D"]
+  .map((grade) => [grade, gradeThresholdSource[grade]] as const)
+  .filter((entry): entry is [ToolManualQualityReport["grade"], number] => typeof entry[1] === "number");
+
+function createIssueFactory(): GraderIssueFactory {
+  return (code, message, options = {}) => ({
+    code,
+    message,
+    field: options.field,
+    severity: options.severity ?? "warning",
+    suggestion: options.suggestion,
+  });
+}
+
+function coerceToolManual(tool_manual: unknown): Record<string, unknown> | unknown {
+  if (isRecord(tool_manual) && typeof tool_manual.to_dict === "function") {
+    return tool_manual.to_dict();
+  }
+  return tool_manual;
+}
+
+export async function score_tool_manual_remote(
+  tool_manual: Record<string, unknown>,
+  options: { api_key: string; base_url?: string; fetch?: typeof fetch },
+): Promise<ToolManualQualityReport> {
+  const client = new SiglumeClient({
+    api_key: options.api_key,
+    base_url: options.base_url,
+    fetch: options.fetch,
+  });
+  return client.preview_quality_score(tool_manual);
+}
+
+export function score_tool_manual_offline(tool_manual: unknown): ToolManualQualityReport {
+  const manual = coerceToolManual(tool_manual);
+  const [validation_ok, validation_issues] = validate_tool_manual(manual);
+  const quality = scoreManualQuality(manual);
+  const validation_errors = validation_issues.filter((nextIssue) => nextIssue.severity === "error");
+  const validation_warnings = validation_issues.filter((nextIssue) => nextIssue.severity !== "error");
+  const hasCriticalQualityIssue = quality.issues.some((nextIssue) => nextIssue.severity === "critical");
+
+  return {
+    overall_score: quality.overall_score,
+    grade: quality.grade,
+    issues: [...validation_issues, ...quality.issues],
+    keyword_coverage_estimate: quality.keyword_coverage_estimate,
+    improvement_suggestions: quality.improvement_suggestions,
+    publishable: validation_ok && (quality.grade === "A" || quality.grade === "B") && !hasCriticalQualityIssue,
+    validation_ok,
+    validation_errors,
+    validation_warnings,
+  };
+}
+
+function scoreManualQuality(manual: Record<string, unknown> | unknown): ToolManualQualityReport {
+  const makeIssue = createIssueFactory();
+  if (!isRecord(manual)) {
+    return {
+      overall_score: 0,
+      grade: "F",
+      issues: [makeIssue("ambiguity", "Manual is not a dict", { severity: "critical" })],
+      keyword_coverage_estimate: 0,
+      improvement_suggestions: ["Provide a valid manual dict"],
+    };
+  }
+
+  const issues: ToolManualIssue[] = [];
+  const trigger_score = scoreTriggerConditions(manual, issues, makeIssue);
+  const do_not_use_score = scoreDoNotUseWhen(manual, issues, makeIssue);
+  const summary_score = scoreSummaryForModel(manual, issues, makeIssue);
+  const input_schema_score = scoreInputSchemaDescriptions(manual, issues, makeIssue);
+  const output_schema_score = scoreOutputSchemaCompleteness(manual, issues, makeIssue);
+  const hints_score = scoreHints(manual, issues, makeIssue);
+  const keyword_coverage_estimate = estimateKeywordCoverage(manual);
+  const keyword_score = scoreKeywordCoverage(keyword_coverage_estimate);
+
+  const overall_score = Math.max(
+    0,
+    Math.min(
+      100,
+      trigger_score +
+        do_not_use_score +
+        summary_score +
+        input_schema_score +
+        output_schema_score +
+        hints_score +
+        keyword_score,
+    ),
+  );
+
+  return {
+    overall_score,
+    grade: overallToGrade(overall_score),
+    issues,
+    keyword_coverage_estimate,
+    improvement_suggestions: buildImprovementSuggestions({
+      trigger_score,
+      do_not_use_score,
+      summary_score,
+      input_schema_score,
+      output_schema_score,
+      hints_score,
+      keyword_count: keyword_coverage_estimate,
+    }),
+  };
+}
+
+function scoreTriggerConditions(
+  manual: Record<string, unknown>,
+  issues: ToolManualIssue[],
+  makeIssue: GraderIssueFactory,
+): number {
+  const conditions = manual.trigger_conditions;
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    issues.push(makeIssue("trigger_specificity", "No trigger_conditions provided", { field: "trigger_conditions", severity: "critical" }));
+    return 0;
+  }
+
+  let score = 30;
+  conditions.forEach((condition, index) => {
+    if (typeof condition !== "string") {
+      issues.push(
+        makeIssue("trigger_specificity", "Trigger condition must be a string to be matchable by agents", {
+          field: `trigger_conditions[${index}]`,
+          severity: "warning",
+          suggestion: "Replace non-string trigger conditions with concrete text descriptions",
+        }),
+      );
+      score -= 5;
+      return;
+    }
+
+    const field = `trigger_conditions[${index}]`;
+    const lowered = condition.toLowerCase();
+    if (condition.length < 15) {
+      issues.push(
+        makeIssue("trigger_specificity", `Trigger condition is too short (${condition.length} chars) - be more specific`, {
+          field,
+          severity: "warning",
+          suggestion: "Describe a concrete situation, e.g. 'When the owner asks for a weather forecast for a specific city'",
+        }),
+      );
+      score -= 5;
+    }
+    if (ambiguityPhrases.some((phrase) => lowered.includes(phrase.toLowerCase()))) {
+      issues.push(
+        makeIssue("ambiguity", "Contains vague phrase that agents cannot reliably match on", {
+          field,
+          severity: "warning",
+          suggestion: "Replace with a concrete situation description",
+        }),
+      );
+      score -= 5;
+    }
+    if (marketingFluff.some((fluff) => lowered.includes(fluff.toLowerCase()))) {
+      issues.push(
+        makeIssue("description_quality", "Marketing language in trigger condition reduces selection accuracy", {
+          field,
+          severity: "warning",
+          suggestion: "Use factual, situation-based language instead",
+        }),
+      );
+      score -= 3;
+    }
+    if (imperativePrefixes.some((prefix) => lowered.startsWith(prefix))) {
+      issues.push(
+        makeIssue("trigger_specificity", "Trigger reads as an imperative command rather than a situation description", {
+          field,
+          severity: "suggestion",
+          suggestion: "Rewrite as a situation: 'When the user needs...' or 'The agent encounters...'",
+        }),
+      );
+      score -= 2;
+    }
+  });
+
+  if (conditions.length < 3) {
+    issues.push(
+      makeIssue("trigger_specificity", `Only ${conditions.length} trigger condition(s) - 3+ increases selection chances`, {
+        field: "trigger_conditions",
+        severity: "suggestion",
+      }),
+    );
+    score -= 5;
+  }
+  return Math.max(0, score);
+}
+
+function scoreDoNotUseWhen(
+  manual: Record<string, unknown>,
+  issues: ToolManualIssue[],
+  makeIssue: GraderIssueFactory,
+): number {
+  const items = manual.do_not_use_when;
+  if (!Array.isArray(items) || items.length === 0) {
+    issues.push(
+      makeIssue("description_quality", "No do_not_use_when items - agents need negative conditions to avoid false positives", {
+        field: "do_not_use_when",
+        severity: "warning",
+      }),
+    );
+    return 0;
+  }
+
+  let score = 10;
+  const triggerTexts = Array.isArray(manual.trigger_conditions)
+    ? manual.trigger_conditions.filter((item): item is string => typeof item === "string").map((item) => item.toLowerCase())
+    : [];
+
+  items.forEach((item, index) => {
+    if (typeof item !== "string") {
+      issues.push(
+        makeIssue("description_quality", "do_not_use_when entries must be strings to describe negative cases clearly", {
+          field: `do_not_use_when[${index}]`,
+          severity: "warning",
+        }),
+      );
+      score -= 3;
+      return;
+    }
+
+    const field = `do_not_use_when[${index}]`;
+    const itemWords = new Set(extractWords(item.toLowerCase()));
+    for (const triggerText of triggerTexts) {
+      const triggerWords = new Set(extractWords(triggerText));
+      if (itemWords.size === 0 || triggerWords.size === 0) {
+        continue;
+      }
+      const overlap = [...itemWords].filter((word) => triggerWords.has(word)).length / itemWords.size;
+      if (overlap > 0.6) {
+        issues.push(
+          makeIssue("ambiguity", "This do_not_use_when item closely mirrors a trigger_condition - add a genuinely different negative case", {
+            field,
+            severity: "suggestion",
+          }),
+        );
+        score -= 3;
+        break;
+      }
+    }
+    if (item.length < 10) {
+      issues.push(
+        makeIssue("description_quality", "do_not_use_when item is very short - describe a concrete negative condition", {
+          field,
+          severity: "suggestion",
+        }),
+      );
+      score -= 2;
+    }
+  });
+
+  return Math.max(0, score);
+}
+
+function scoreSummaryForModel(
+  manual: Record<string, unknown>,
+  issues: ToolManualIssue[],
+  makeIssue: GraderIssueFactory,
+): number {
+  const summary = manual.summary_for_model;
+  if (summary === undefined) {
+    issues.push(makeIssue("description_quality", "summary_for_model is missing", { field: "summary_for_model", severity: "warning" }));
+    return 0;
+  }
+  if (typeof summary !== "string") {
+    issues.push(makeIssue("description_quality", "summary_for_model must be a string", { field: "summary_for_model", severity: "warning" }));
+    return 0;
+  }
+  if (summary.length === 0) {
+    issues.push(makeIssue("description_quality", "summary_for_model is empty", { field: "summary_for_model", severity: "warning" }));
+    return 0;
+  }
+
+  let score = 10;
+  const lowered = summary.toLowerCase();
+  let fluffFound = false;
+  for (const fluff of marketingFluff) {
+    if (lowered.includes(fluff.toLowerCase())) {
+      issues.push(
+        makeIssue("description_quality", "Marketing language in summary_for_model - use factual descriptions", {
+          field: "summary_for_model",
+          severity: "warning",
+          suggestion: "Describe what the tool actually does in plain terms",
+        }),
+      );
+      if (!fluffFound) {
+        score -= 3;
+        fluffFound = true;
+      }
+    }
+  }
+  if (summary.length < 20) {
+    issues.push(
+      makeIssue("description_quality", "summary_for_model is very brief - a longer factual description helps agent selection", {
+        field: "summary_for_model",
+        severity: "suggestion",
+      }),
+    );
+    score -= 3;
+  }
+  return Math.max(0, score);
+}
+
+function scoreInputSchemaDescriptions(
+  manual: Record<string, unknown>,
+  issues: ToolManualIssue[],
+  makeIssue: GraderIssueFactory,
+): number {
+  if (!isRecord(manual.input_schema)) {
+    issues.push(makeIssue("schema_completeness", "input_schema must be a JSON Schema object", { field: "input_schema", severity: "warning" }));
+    return 0;
+  }
+  const schemaIssues = checkSchemaDescriptions(manual.input_schema, makeIssue);
+  issues.push(...schemaIssues);
+  if (schemaIssues.length === 0) {
+    return 20;
+  }
+
+  let score = 20;
+  for (const schemaIssue of schemaIssues) {
+    if (schemaIssue.severity === "warning") {
+      score -= 5;
+    } else if (schemaIssue.severity === "suggestion") {
+      score -= 2;
+    }
+  }
+  return Math.max(0, score);
+}
+
+function scoreOutputSchemaCompleteness(
+  manual: Record<string, unknown>,
+  issues: ToolManualIssue[],
+  makeIssue: GraderIssueFactory,
+): number {
+  if (!isRecord(manual.output_schema)) {
+    issues.push(makeIssue("schema_completeness", "output_schema must be a JSON Schema object", { field: "output_schema", severity: "warning" }));
+    return 0;
+  }
+
+  const properties = manual.output_schema.properties;
+  if (!isRecord(properties)) {
+    issues.push(
+      makeIssue("schema_completeness", "output_schema.properties must be an object mapping field names to schema definitions", {
+        field: "output_schema.properties",
+        severity: "warning",
+      }),
+    );
+    return 0;
+  }
+  if (Object.keys(properties).length === 0) {
+    issues.push(makeIssue("schema_completeness", "output_schema has no properties defined", { field: "output_schema", severity: "warning" }));
+    return 0;
+  }
+
+  let undescribed = 0;
+  Object.values(properties).forEach((propertyDefinition) => {
+    if (isRecord(propertyDefinition) && !propertyDefinition.description) {
+      undescribed += 1;
+    }
+  });
+
+  let score = 10;
+  if (undescribed > 0) {
+    issues.push(
+      makeIssue("schema_completeness", `${undescribed} output field(s) lack descriptions`, {
+        field: "output_schema",
+        severity: "suggestion",
+        suggestion: "Add description to each output property so agents know what to expect",
+      }),
+    );
+    score -= Math.min(undescribed * 2, 6);
+  }
+  return Math.max(0, score);
+}
+
+function scoreHints(manual: Record<string, unknown>, issues: ToolManualIssue[], makeIssue: GraderIssueFactory): number {
+  let score = 10;
+  for (const fieldName of ["usage_hints", "result_hints", "error_hints"] as const) {
+    const hints = manual[fieldName];
+    if (!Array.isArray(hints)) {
+      issues.push(
+        makeIssue("description_quality", `${fieldName} must be a list of hint strings`, {
+          field: fieldName,
+          severity: "warning",
+        }),
+      );
+      score -= 5;
+      continue;
+    }
+    if (hints.length === 0) {
+      issues.push(
+        makeIssue("description_quality", `${fieldName} is empty - hints help agents use the tool correctly`, {
+          field: fieldName,
+          severity: "suggestion",
+        }),
+      );
+      score -= 3;
+      continue;
+    }
+
+    let shortCount = 0;
+    hints.forEach((item, index) => {
+      if (typeof item !== "string") {
+        issues.push(
+          makeIssue("description_quality", `${fieldName} items must be strings`, {
+            field: `${fieldName}[${index}]`,
+            severity: "critical",
+            suggestion: "Replace non-string hint items with short plain-language guidance",
+          }),
+        );
+        score -= 10;
+        return;
+      }
+      if (item.length < 10) {
+        shortCount += 1;
+      }
+    });
+    if (shortCount > 0) {
+      issues.push(
+        makeIssue("description_quality", `${shortCount} item(s) in ${fieldName} are very short - provide actionable guidance`, {
+          field: fieldName,
+          severity: "suggestion",
+        }),
+      );
+      score -= Math.min(shortCount, 3);
+    }
+  }
+  return Math.max(0, score);
+}
+
+function scoreKeywordCoverage(keywordCount: number): number {
+  for (const [minimumKeywords, score] of keywordCoverageBands) {
+    if (keywordCount >= minimumKeywords) {
+      return score;
+    }
+  }
+  return Math.max(0, keywordCount);
+}
+
+function checkSchemaDescriptions(schema: Record<string, unknown>, makeIssue: GraderIssueFactory): ToolManualIssue[] {
+  const issues: ToolManualIssue[] = [];
+  const properties = schema.properties;
+  if (!isRecord(properties)) {
+    return issues;
+  }
+
+  for (const [propertyName, propertyDefinition] of Object.entries(properties)) {
+    if (!isRecord(propertyDefinition)) {
+      issues.push(
+        makeIssue("schema_completeness", `Field '${propertyName}' must be described by a schema object`, {
+          field: `input_schema.properties.${propertyName}`,
+          severity: "warning",
+        }),
+      );
+      continue;
+    }
+
+    const field = `input_schema.properties.${propertyName}`;
+    const description = propertyDefinition.description;
+    if (description === undefined || (typeof description === "string" && description.trim().length === 0)) {
+      issues.push(
+        makeIssue("schema_completeness", `Field '${propertyName}' has no description - agents will not know what to pass`, {
+          field,
+          severity: "warning",
+          suggestion: `Add a description explaining what '${propertyName}' represents and any constraints`,
+        }),
+      );
+    } else if (typeof description !== "string") {
+      issues.push(
+        makeIssue("schema_completeness", `Field '${propertyName}' description must be a string`, {
+          field,
+          severity: "warning",
+          suggestion: "Replace non-string descriptions with short explanatory text",
+        }),
+      );
+    } else if (description.trim().length < 10) {
+      issues.push(
+        makeIssue("schema_completeness", `Field '${propertyName}' has a very short description (${description.trim().length} chars)`, {
+          field,
+          severity: "suggestion",
+          suggestion: "Expand the description to at least 10 characters for clarity",
+        }),
+      );
+    }
+
+    if (Array.isArray(propertyDefinition.enum)) {
+      const trivial = propertyDefinition.enum.filter((item) => typeof item === "string" && item.length <= 1);
+      if (trivial.length > 0 && trivial.length === propertyDefinition.enum.length) {
+        issues.push(
+          makeIssue("schema_completeness", `Field '${propertyName}' has only single-character enum values - use meaningful names`, {
+            field,
+            severity: "warning",
+            suggestion: "Replace enum values like 'a','b','c' with descriptive names like 'celsius','fahrenheit'",
+          }),
+        );
+      }
+    }
+
+    if (propertyDefinition.type === "object") {
+      issues.push(...checkSchemaDescriptions(propertyDefinition, makeIssue));
+    }
+    if (isRecord(propertyDefinition.items) && propertyDefinition.items.type === "object") {
+      issues.push(...checkSchemaDescriptions(propertyDefinition.items, makeIssue));
+    }
+  }
+
+  return issues;
+}
+
+function estimateKeywordCoverage(manual: Record<string, unknown>): number {
+  const textParts: string[] = [];
+  if (Array.isArray(manual.trigger_conditions)) {
+    textParts.push(...manual.trigger_conditions.filter((item): item is string => typeof item === "string"));
+  }
+  if (typeof manual.job_to_be_done === "string") {
+    textParts.push(manual.job_to_be_done);
+  }
+  if (typeof manual.summary_for_model === "string") {
+    textParts.push(manual.summary_for_model);
+  }
+  if (Array.isArray(manual.usage_hints)) {
+    textParts.push(...manual.usage_hints.filter((item): item is string => typeof item === "string"));
+  }
+  const words = extractWords(textParts.join(" ").toLowerCase());
+  const meaningful = new Set(words.filter((word) => !stopWords.has(word) && word.length >= 2));
+  return meaningful.size;
+}
+
+function extractWords(text: string): string[] {
+  return [...text.matchAll(WORD_RE)].map((match) => match[0]);
+}
+
+function overallToGrade(score: number): ToolManualQualityReport["grade"] {
+  for (const [grade, minimumScore] of gradeThresholds) {
+    if (score >= minimumScore) {
+      return grade;
+    }
+  }
+  return "F";
+}
+
+function buildImprovementSuggestions(scores: ManualScoreParts): string[] {
+  const suggestions: string[] = [];
+  if (scores.trigger_score < 20) {
+    suggestions.push("Improve trigger_conditions: write 3-5 specific situations describing WHEN an agent should select this tool.");
+  }
+  if (scores.input_schema_score < 15) {
+    suggestions.push("Add descriptions to all input_schema properties. Each description should be at least 10 characters and explain what the field represents.");
+  }
+  if (scores.summary_score < 7) {
+    suggestions.push("Rewrite summary_for_model with factual, plain language. Avoid marketing adjectives and describe what the tool does.");
+  }
+  if (scores.do_not_use_score < 7) {
+    suggestions.push("Add concrete do_not_use_when conditions that are genuinely different from your trigger_conditions.");
+  }
+  if (scores.output_schema_score < 7) {
+    suggestions.push("Add descriptions to output_schema properties so agents know what data they will receive.");
+  }
+  if (scores.hints_score < 7) {
+    suggestions.push("Expand usage_hints and result_hints with actionable guidance for agents.");
+  }
+  if (scores.keyword_count < 10) {
+    suggestions.push(
+      `Keyword coverage is low (${scores.keyword_count} unique terms). Use varied vocabulary across trigger_conditions and hints to cover more request phrasings.`,
+    );
+  }
+  return suggestions;
+}

--- a/siglume-api-sdk-ts/src/tool-manual-validator.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-validator.ts
@@ -1,0 +1,302 @@
+import type { ToolManual, ToolManualIssue, ToolManualPermissionClass } from "./types";
+import { PermissionClass, SettlementMode, ToolManualPermissionClass as ToolManualPermissionClassValues } from "./types";
+import { isRecord } from "./utils";
+
+const JURISDICTION_PATTERN = /^[A-Z]{2}(-[A-Z0-9]{1,3})?$/;
+const TOOL_NAME_RE = /^[A-Za-z0-9_]{3,64}$/;
+const PLATFORM_INJECTED_FIELDS = new Set([
+  "execution_id",
+  "trace_id",
+  "connected_account_id",
+  "dry_run",
+  "idempotency_key",
+  "budget_snapshot",
+]);
+const COMPOSITION_KEYWORDS = new Set(["oneOf", "anyOf", "allOf"]);
+const INPUT_SCHEMA_FORBIDDEN_KEYS = new Set(["patternProperties"]);
+
+type ManualInput = ToolManual | Record<string, unknown> | { to_dict(): unknown } | unknown;
+
+function issue(
+  code: string,
+  message: string,
+  field?: string,
+  severity: ToolManualIssue["severity"] = "error",
+  suggestion?: string,
+): ToolManualIssue {
+  return { code, message, field, severity, suggestion };
+}
+
+function coerceToolManual(manual: ManualInput): unknown {
+  if (isRecord(manual) && typeof manual.to_dict === "function") {
+    return manual.to_dict();
+  }
+  return manual;
+}
+
+function checkSchemaForbiddenRecursive(
+  schema: Record<string, unknown>,
+  rootField: string,
+  pushIssue: (nextIssue: ToolManualIssue) => void,
+  path = "",
+): void {
+  for (const keyword of COMPOSITION_KEYWORDS) {
+    if (keyword in schema) {
+      const location = path ? `${rootField}.${path}.${keyword}` : `${rootField}.${keyword}`;
+      pushIssue(
+        issue(
+          "INPUT_SCHEMA",
+          `Composition keyword '${keyword}' is not allowed in beta${path ? ` at ${path}` : ""}`,
+          location,
+        ),
+      );
+    }
+  }
+
+  for (const forbidden of INPUT_SCHEMA_FORBIDDEN_KEYS) {
+    if (forbidden in schema) {
+      const location = path ? `${rootField}.${path}.${forbidden}` : `${rootField}.${forbidden}`;
+      pushIssue(
+        issue(
+          "INPUT_SCHEMA",
+          `'${forbidden}' is not allowed${path ? ` at ${path}` : ""}`,
+          location,
+        ),
+      );
+    }
+  }
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "properties" && isRecord(value)) {
+      for (const [propertyName, propertyDefinition] of Object.entries(value)) {
+        if (!isRecord(propertyDefinition)) {
+          continue;
+        }
+        const subPath = path ? `${path}.${propertyName}` : propertyName;
+        checkSchemaForbiddenRecursive(propertyDefinition, rootField, pushIssue, subPath);
+      }
+    } else if (key === "items" && isRecord(value)) {
+      const subPath = path ? `${path}.items` : "items";
+      checkSchemaForbiddenRecursive(value, rootField, pushIssue, subPath);
+    }
+  }
+}
+
+export function tool_manual_to_dict(manual: ToolManual | Record<string, unknown>): Record<string, unknown> {
+  return isRecord(manual) ? { ...manual } : {};
+}
+
+export function validate_tool_manual(manualInput: ManualInput): [boolean, ToolManualIssue[]] {
+  const manual = coerceToolManual(manualInput);
+  const issues: ToolManualIssue[] = [];
+  const pushError = (code: string, message: string, field?: string) => {
+    issues.push(issue(code, message, field, "error"));
+  };
+  const pushWarning = (code: string, message: string, field?: string) => {
+    issues.push(issue(code, message, field, "warning"));
+  };
+
+  if (!isRecord(manual)) {
+    pushError("INVALID_ROOT", "tool manual must be a dict");
+    return [false, issues];
+  }
+
+  const requiredFields = [
+    "tool_name",
+    "job_to_be_done",
+    "summary_for_model",
+    "trigger_conditions",
+    "do_not_use_when",
+    "permission_class",
+    "dry_run_supported",
+    "requires_connected_accounts",
+    "input_schema",
+    "output_schema",
+    "usage_hints",
+    "result_hints",
+    "error_hints",
+  ];
+  for (const fieldName of requiredFields) {
+    if (!(fieldName in manual)) {
+      pushError("MISSING_FIELD", `required field '${fieldName}' is missing`, fieldName);
+    }
+  }
+
+  const toolName = manual.tool_name;
+  if (typeof toolName === "string" && toolName.length > 0 && !TOOL_NAME_RE.test(toolName)) {
+    pushError("INVALID_TOOL_NAME", "tool_name must be alphanumeric + underscore, 3-64 chars", "tool_name");
+  }
+
+  for (const [fieldName, minLength, maxLength] of [
+    ["job_to_be_done", 10, 500],
+    ["summary_for_model", 10, 300],
+  ] as const) {
+    const value = manual[fieldName];
+    if (typeof value === "string" && (value.length < minLength || value.length > maxLength)) {
+      pushError("INVALID_TYPE", `${fieldName} must be ${minLength}-${maxLength} characters`, fieldName);
+    }
+  }
+
+  const triggerConditions = manual.trigger_conditions;
+  if (Array.isArray(triggerConditions)) {
+    if (triggerConditions.length < 3) {
+      pushError("TOO_FEW_ITEMS", "trigger_conditions needs at least 3 items", "trigger_conditions");
+    } else if (triggerConditions.length > 8) {
+      pushError("TOO_MANY_ITEMS", "trigger_conditions allows at most 8 items", "trigger_conditions");
+    }
+    triggerConditions.forEach((item, index) => {
+      if (typeof item === "string" && (item.length < 10 || item.length > 200)) {
+        pushError(
+          item.length < 10 ? "ITEM_TOO_SHORT" : "ITEM_TOO_LONG",
+          `trigger_conditions[${index}] must be 10-200 chars`,
+          `trigger_conditions[${index}]`,
+        );
+      }
+    });
+  }
+
+  const doNotUseWhen = manual.do_not_use_when;
+  if (Array.isArray(doNotUseWhen)) {
+    if (doNotUseWhen.length < 1) {
+      pushError("TOO_FEW_ITEMS", "do_not_use_when needs at least 1 item", "do_not_use_when");
+    } else if (doNotUseWhen.length > 5) {
+      pushError("TOO_MANY_ITEMS", "do_not_use_when allows at most 5 items", "do_not_use_when");
+    }
+  }
+
+  const permissionClass = manual.permission_class;
+  const validPermissionClasses: ToolManualPermissionClass[] = [
+    ToolManualPermissionClassValues.READ_ONLY,
+    ToolManualPermissionClassValues.ACTION,
+    ToolManualPermissionClassValues.PAYMENT,
+  ];
+  if (typeof permissionClass === "string" && !validPermissionClasses.includes(permissionClass as ToolManualPermissionClass)) {
+    if (permissionClass === PermissionClass.READ_ONLY || permissionClass === PermissionClass.RECOMMENDATION) {
+      pushError(
+        "INVALID_PERMISSION_CLASS",
+        `ToolManual uses underscored values (${JSON.stringify(validPermissionClasses)}), not the hyphenated AppManifest form '${permissionClass}'`,
+        "permission_class",
+      );
+    } else {
+      pushError(
+        "INVALID_PERMISSION_CLASS",
+        `permission_class must be one of ${JSON.stringify(validPermissionClasses)}`,
+        "permission_class",
+      );
+    }
+  }
+
+  const requireString = (fieldName: string, context: string) => {
+    const value = manual[fieldName];
+    if (value === undefined || value === null) {
+      pushError("MISSING_FIELD", `'${fieldName}' is required for permission_class='${context}'`, fieldName);
+    } else if (typeof value !== "string") {
+      pushError("INVALID_TYPE", `'${fieldName}' must be a string`, fieldName);
+    } else if (value.length === 0) {
+      pushError("TOO_SHORT", `'${fieldName}' must be at least 1 char`, fieldName);
+    }
+  };
+
+  const requireSchema = (fieldName: string, context: string) => {
+    const value = manual[fieldName];
+    if (value === undefined || value === null) {
+      pushError("MISSING_FIELD", `'${fieldName}' is required for permission_class='${context}'`, fieldName);
+    } else if (!isRecord(value)) {
+      pushError("INVALID_TYPE", `'${fieldName}' must be a JSON Schema object`, fieldName);
+    }
+  };
+
+  if (permissionClass === ToolManualPermissionClassValues.ACTION || permissionClass === ToolManualPermissionClassValues.PAYMENT) {
+    requireString("approval_summary_template", permissionClass);
+    requireSchema("preview_schema", permissionClass);
+    requireString("side_effect_summary", permissionClass);
+    requireString("jurisdiction", permissionClass);
+    if (typeof manual.jurisdiction === "string" && manual.jurisdiction.length > 0 && !JURISDICTION_PATTERN.test(manual.jurisdiction)) {
+      pushError(
+        "INVALID_JURISDICTION",
+        `jurisdiction must be ISO 3166-1 alpha-2 (optionally -subregion), got: ${JSON.stringify(manual.jurisdiction)}`,
+        "jurisdiction",
+      );
+    }
+    if (!("idempotency_support" in manual)) {
+      pushError("MISSING_FIELD", `'idempotency_support' is required for permission_class='${permissionClass}'`, "idempotency_support");
+    } else if (manual.idempotency_support !== true) {
+      pushError("IDEMPOTENCY_REQUIRED", "idempotency_support must be true for action/payment", "idempotency_support");
+    }
+  }
+
+  if (permissionClass === ToolManualPermissionClassValues.PAYMENT) {
+    requireSchema("quote_schema", "payment");
+    requireString("currency", "payment");
+    requireString("settlement_mode", "payment");
+    requireString("refund_or_cancellation_note", "payment");
+    if (typeof manual.currency === "string" && manual.currency !== "USD") {
+      pushError("INVALID_CURRENCY", "currency must be 'USD'", "currency");
+    }
+    if (
+      typeof manual.settlement_mode === "string" &&
+      !Object.values(SettlementMode).includes(manual.settlement_mode as SettlementMode)
+    ) {
+      pushError(
+        "INVALID_SETTLEMENT_MODE",
+        `settlement_mode must be one of ${JSON.stringify(Object.values(SettlementMode))}`,
+        "settlement_mode",
+      );
+    }
+  }
+
+  const inputSchema = manual.input_schema;
+  if (isRecord(inputSchema)) {
+    if (inputSchema.type !== "object") {
+      pushError("INPUT_SCHEMA", "Root type must be 'object'", "input_schema");
+    }
+    if (inputSchema.additionalProperties !== false) {
+      pushError("INPUT_SCHEMA", "additionalProperties must be false", "input_schema");
+    }
+    checkSchemaForbiddenRecursive(inputSchema, "input_schema", (nextIssue) => issues.push(nextIssue));
+    const properties = inputSchema.properties;
+    if (isRecord(properties)) {
+      for (const fieldName of Object.keys(properties)) {
+        if (PLATFORM_INJECTED_FIELDS.has(fieldName)) {
+          pushWarning(
+            "INPUT_SCHEMA",
+            `'${fieldName}' is platform-injected; remove from input_schema`,
+            `input_schema.properties.${fieldName}`,
+          );
+        }
+      }
+    }
+  }
+
+  const outputSchema = manual.output_schema;
+  if (isRecord(outputSchema)) {
+    const required = outputSchema.required;
+    if (!Array.isArray(required) || required.length === 0) {
+      pushError("OUTPUT_SCHEMA", "output_schema must have at least one stable required key", "output_schema.required");
+    }
+    const properties = outputSchema.properties;
+    if (isRecord(properties) && !("summary" in properties)) {
+      pushError("OUTPUT_SCHEMA", "output_schema must include a 'summary' property", "output_schema.properties");
+    }
+    if (permissionClass === ToolManualPermissionClassValues.PAYMENT) {
+      if (Array.isArray(required)) {
+        if (!required.includes("amount_usd")) {
+          pushError("OUTPUT_SCHEMA", "Payment output_schema must require 'amount_usd'", "output_schema.required");
+        }
+        if (!required.includes("currency")) {
+          pushError("OUTPUT_SCHEMA", "Payment output_schema must require 'currency'", "output_schema.required");
+        }
+      }
+      if (isRecord(properties)) {
+        if (!("amount_usd" in properties)) {
+          pushError("OUTPUT_SCHEMA", "Payment output_schema must include 'amount_usd' in properties", "output_schema.properties");
+        }
+        if (!("currency" in properties)) {
+          pushError("OUTPUT_SCHEMA", "Payment output_schema must include 'currency' in properties", "output_schema.properties");
+        }
+      }
+    }
+  }
+
+  return [!issues.some((nextIssue) => nextIssue.severity === "error"), issues];
+}

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -1,0 +1,411 @@
+export type Awaitable<T> = T | Promise<T>;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+export const PermissionClass = {
+  READ_ONLY: "read-only",
+  RECOMMENDATION: "recommendation",
+  ACTION: "action",
+  PAYMENT: "payment",
+} as const;
+export type PermissionClass = (typeof PermissionClass)[keyof typeof PermissionClass];
+
+export const ApprovalMode = {
+  AUTO: "auto",
+  BUDGET_BOUNDED: "budget-bounded",
+  ALWAYS_ASK: "always-ask",
+  DENY: "deny",
+} as const;
+export type ApprovalMode = (typeof ApprovalMode)[keyof typeof ApprovalMode];
+
+export const ExecutionKind = {
+  DRY_RUN: "dry_run",
+  QUOTE: "quote",
+  ACTION: "action",
+  PAYMENT: "payment",
+} as const;
+export type ExecutionKind = (typeof ExecutionKind)[keyof typeof ExecutionKind];
+
+export const Environment = {
+  SANDBOX: "sandbox",
+  LIVE: "live",
+} as const;
+export type Environment = (typeof Environment)[keyof typeof Environment];
+
+export const PriceModel = {
+  FREE: "free",
+  SUBSCRIPTION: "subscription",
+  ONE_TIME: "one_time",
+  BUNDLE: "bundle",
+  USAGE_BASED: "usage_based",
+  PER_ACTION: "per_action",
+} as const;
+export type PriceModel = (typeof PriceModel)[keyof typeof PriceModel];
+
+export const AppCategory = {
+  COMMERCE: "commerce",
+  BOOKING: "booking",
+  CRM: "crm",
+  FINANCE: "finance",
+  DOCUMENT: "document",
+  COMMUNICATION: "communication",
+  MONITORING: "monitoring",
+  OTHER: "other",
+} as const;
+export type AppCategory = (typeof AppCategory)[keyof typeof AppCategory];
+
+export interface ConnectedAccountRef {
+  provider_key: string;
+  session_token: string;
+  scopes?: string[];
+  environment?: Environment;
+}
+
+export interface AppManifest {
+  capability_key: string;
+  version?: string;
+  name: string;
+  job_to_be_done: string;
+  category?: AppCategory;
+  permission_class: PermissionClass;
+  approval_mode?: ApprovalMode;
+  dry_run_supported?: boolean;
+  required_connected_accounts?: string[];
+  permission_scopes?: string[];
+  price_model?: PriceModel;
+  price_value_minor?: number;
+  currency?: "USD";
+  jurisdiction: string;
+  applicable_regulations?: string[];
+  data_residency?: string;
+  short_description?: string;
+  docs_url?: string;
+  support_contact?: string;
+  compatibility_tags?: string[];
+  example_prompts?: string[];
+  latency_tier?: string;
+}
+
+export interface ExecutionContext {
+  agent_id: string;
+  owner_user_id: string;
+  task_type: string;
+  input_params?: Record<string, unknown>;
+  source_type?: string;
+  environment?: Environment;
+  execution_kind?: ExecutionKind;
+  connected_accounts?: Record<string, ConnectedAccountRef>;
+  budget_remaining_minor?: number | null;
+  trace_id?: string;
+  idempotency_key?: string;
+  request_hash?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExecutionArtifact {
+  artifact_type: string;
+  external_id?: string;
+  external_url?: string;
+  title?: string;
+  summary?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SideEffectRecord {
+  action: string;
+  provider: string;
+  external_id?: string;
+  reversible?: boolean;
+  reversal_hint?: string;
+  timestamp_iso?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ReceiptRef {
+  receipt_id: string;
+  trace_id?: string;
+  intent_id?: string;
+}
+
+export interface ApprovalRequestHint {
+  action_summary: string;
+  permission_class: "action" | "payment";
+  estimated_amount_minor?: number;
+  currency?: string;
+  side_effects?: string[];
+  preview?: Record<string, unknown>;
+  reversible?: boolean;
+}
+
+export interface ExecutionResult {
+  success: boolean;
+  output?: Record<string, unknown>;
+  execution_kind?: ExecutionKind;
+  units_consumed?: number;
+  amount_minor?: number;
+  currency?: string;
+  provider_status?: string;
+  error_message?: string;
+  fallback_applied?: boolean;
+  needs_approval?: boolean;
+  approval_prompt?: string;
+  receipt_summary?: Record<string, unknown>;
+  artifacts?: ExecutionArtifact[];
+  side_effects?: SideEffectRecord[];
+  receipt_ref?: ReceiptRef;
+  approval_hint?: ApprovalRequestHint;
+}
+
+export const ToolManualPermissionClass = {
+  READ_ONLY: "read_only",
+  ACTION: "action",
+  PAYMENT: "payment",
+} as const;
+export type ToolManualPermissionClass =
+  (typeof ToolManualPermissionClass)[keyof typeof ToolManualPermissionClass];
+
+export const SettlementMode = {
+  STRIPE_CHECKOUT: "stripe_checkout",
+  STRIPE_PAYMENT_INTENT: "stripe_payment_intent",
+  POLYGON_MANDATE: "polygon_mandate",
+  EMBEDDED_WALLET_CHARGE: "embedded_wallet_charge",
+} as const;
+export type SettlementMode = (typeof SettlementMode)[keyof typeof SettlementMode];
+
+export interface ToolManual {
+  tool_name: string;
+  job_to_be_done: string;
+  summary_for_model: string;
+  trigger_conditions: string[];
+  do_not_use_when: string[];
+  permission_class: ToolManualPermissionClass;
+  dry_run_supported: boolean;
+  requires_connected_accounts: string[];
+  input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  usage_hints: string[];
+  result_hints: string[];
+  error_hints: string[];
+  approval_summary_template?: string;
+  preview_schema?: Record<string, unknown>;
+  idempotency_support?: boolean;
+  side_effect_summary?: string;
+  quote_schema?: Record<string, unknown>;
+  currency?: string;
+  settlement_mode?: SettlementMode;
+  refund_or_cancellation_note?: string;
+  jurisdiction?: string;
+  legal_notes?: string;
+}
+
+export type ToolManualIssueSeverity = "error" | "warning" | "critical" | "suggestion";
+export type ToolManualGrade = "A" | "B" | "C" | "D" | "F";
+
+export interface ToolManualIssue {
+  code: string;
+  message: string;
+  field?: string;
+  severity: ToolManualIssueSeverity;
+  suggestion?: string;
+}
+
+export interface ToolManualQualityReport {
+  overall_score: number;
+  grade: ToolManualGrade;
+  issues: ToolManualIssue[];
+  keyword_coverage_estimate: number;
+  improvement_suggestions: string[];
+  publishable?: boolean | null;
+  validation_ok?: boolean;
+  validation_errors?: ToolManualIssue[];
+  validation_warnings?: ToolManualIssue[];
+}
+
+export interface HealthCheckResult {
+  healthy: boolean;
+  message?: string;
+  provider_status?: Record<string, string>;
+}
+
+export interface EnvelopeMeta {
+  request_id?: string | null;
+  trace_id?: string | null;
+}
+
+export interface CursorPage<T> {
+  items: T[];
+  next_cursor?: string | null;
+  limit?: number | null;
+  offset?: number | null;
+  meta: EnvelopeMeta;
+  all_items?: () => Promise<T[]>;
+  allItems?: () => Promise<T[]>;
+}
+
+export interface AppListingRecord {
+  listing_id: string;
+  capability_key: string;
+  name: string;
+  status: string;
+  category?: string | null;
+  job_to_be_done?: string | null;
+  permission_class?: string | null;
+  approval_mode?: string | null;
+  dry_run_supported: boolean;
+  price_model?: string | null;
+  price_value_minor: number;
+  currency: string;
+  short_description?: string | null;
+  docs_url?: string | null;
+  support_contact?: string | null;
+  review_status?: string | null;
+  review_note?: string | null;
+  submission_blockers: string[];
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface AutoRegistrationReceipt {
+  listing_id: string;
+  status: string;
+  auto_manifest: Record<string, unknown>;
+  confidence: Record<string, unknown>;
+  review_url?: string | null;
+  trace_id?: string | null;
+  request_id?: string | null;
+}
+
+export interface RegistrationQuality {
+  overall_score: number;
+  grade: string;
+  issues: Array<Record<string, unknown>>;
+  improvement_suggestions: string[];
+  raw: Record<string, unknown>;
+}
+
+export interface RegistrationConfirmation {
+  listing_id: string;
+  status: string;
+  release: Record<string, unknown>;
+  quality: RegistrationQuality;
+  trace_id?: string | null;
+  request_id?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface DeveloperPortalSummary {
+  seller_onboarding?: Record<string, unknown> | null;
+  platform: Record<string, unknown>;
+  monetization: Record<string, unknown>;
+  payout_readiness: Record<string, unknown>;
+  listings: Record<string, unknown>;
+  usage: Record<string, unknown>;
+  support: Record<string, unknown>;
+  apps: AppListingRecord[];
+  trace_id?: string | null;
+  request_id?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface SandboxSession {
+  session_id: string;
+  agent_id: string;
+  capability_key: string;
+  environment: string;
+  sandbox_support?: string | null;
+  dry_run_supported: boolean;
+  approval_mode?: string | null;
+  required_connected_accounts: unknown[];
+  connected_accounts: Array<Record<string, unknown>>;
+  stub_providers_enabled: boolean;
+  simulated_receipts: boolean;
+  approval_simulator: boolean;
+  trace_id?: string | null;
+  request_id?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface AccessGrantRecord {
+  access_grant_id: string;
+  capability_listing_id: string;
+  grant_status: string;
+  billing_model?: string | null;
+  agent_id?: string | null;
+  starts_at?: string | null;
+  ends_at?: string | null;
+  bindings: Array<Record<string, unknown>>;
+  metadata: Record<string, unknown>;
+  raw: Record<string, unknown>;
+}
+
+export interface CapabilityBindingRecord {
+  binding_id: string;
+  access_grant_id: string;
+  agent_id: string;
+  binding_status: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface GrantBindingResult {
+  binding: CapabilityBindingRecord;
+  access_grant: AccessGrantRecord;
+  trace_id?: string | null;
+  request_id?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface ConnectedAccountRecord {
+  connected_account_id: string;
+  provider_key: string;
+  account_role: string;
+  display_name?: string | null;
+  environment?: string | null;
+  connection_status?: string | null;
+  scopes: string[];
+  metadata: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface UsageEventRecord {
+  usage_event_id: string;
+  capability_key?: string | null;
+  agent_id?: string | null;
+  environment?: string | null;
+  task_type?: string | null;
+  units_consumed: number;
+  outcome?: string | null;
+  execution_kind?: string | null;
+  permission_class?: string | null;
+  approval_mode?: string | null;
+  latency_ms?: number | null;
+  trace_id?: string | null;
+  period_key?: string | null;
+  created_at?: string | null;
+  metadata: Record<string, unknown>;
+  raw: Record<string, unknown>;
+}
+
+export interface SupportCaseRecord {
+  support_case_id: string;
+  case_type: string;
+  summary: string;
+  status: string;
+  capability_key?: string | null;
+  agent_id?: string | null;
+  trace_id?: string | null;
+  environment?: string | null;
+  resolution_note?: string | null;
+  metadata: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}

--- a/siglume-api-sdk-ts/src/utils.ts
+++ b/siglume-api-sdk-ts/src/utils.ts
@@ -1,0 +1,134 @@
+import type { JsonValue } from "./types";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function stringOrNull(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const text = String(value).trim();
+  return text.length > 0 ? text : null;
+}
+
+export function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function toRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? { ...value } : {};
+}
+
+export function toJsonable(value: unknown): JsonValue | Record<string, unknown> | unknown[] {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonable(item));
+  }
+  if (isRecord(value)) {
+    const toDict = value.to_dict;
+    if (typeof toDict === "function") {
+      return toJsonable(toDict.call(value));
+    }
+    const toJson = value.toJSON;
+    if (typeof toJson === "function") {
+      return toJsonable(toJson.call(value));
+    }
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => !key.startsWith("_"))
+        .map(([key, item]) => [key, toJsonable(item)]),
+    );
+  }
+  return String(value);
+}
+
+export function coerceMapping(value: unknown, label: string): Record<string, unknown> {
+  const payload = toJsonable(value);
+  if (!isRecord(payload)) {
+    throw new TypeError(`${label} must be a mapping-like object`);
+  }
+  return payload;
+}
+
+export function renderJson(value: unknown): string {
+  return JSON.stringify(toJsonable(value), null, 2);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function parseRetryAfter(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed * 1000 : null;
+}
+
+export function camelCaseFromCapabilityKey(capabilityKey: string): string {
+  const words = capabilityKey
+    .replaceAll("_", "-")
+    .split("-")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (words.length === 0) {
+    return "GeneratedRegistrationApp";
+  }
+  return `${words.map((word) => word[0]!.toUpperCase() + word.slice(1)).join("")}App`;
+}
+
+export function buildDefaultI18n(manifestPayload: Record<string, unknown>): Record<string, string> {
+  const job = String(manifestPayload.job_to_be_done ?? "").trim();
+  const shortDescription = String(
+    manifestPayload.short_description ?? manifestPayload.job_to_be_done ?? manifestPayload.name ?? "",
+  ).trim();
+  return {
+    job_to_be_done_en: job,
+    job_to_be_done_ja: job,
+    short_description_en: shortDescription,
+    short_description_ja: shortDescription,
+  };
+}
+
+export function buildRegistrationStubSource(
+  manifestPayload: Record<string, unknown>,
+  toolManualPayload: Record<string, unknown>,
+): string {
+  const capabilityKey = String(manifestPayload.capability_key ?? "generated-registration");
+  const jobToBeDone = String(
+    manifestPayload.job_to_be_done ??
+      toolManualPayload.job_to_be_done ??
+      "Register this API listing on Siglume.",
+  );
+  const name = String(manifestPayload.name ?? capabilityKey.replaceAll("-", " "));
+  const className = camelCaseFromCapabilityKey(capabilityKey);
+  return [
+    'import { AppAdapter } from "@siglume/api-sdk";',
+    "",
+    `export default class ${className} extends AppAdapter {`,
+    "  manifest() {",
+    `    return ${JSON.stringify(
+      {
+        capability_key: capabilityKey,
+        name,
+        job_to_be_done: jobToBeDone,
+      },
+      null,
+      2,
+    ).replaceAll("\n", "\n    ")};`,
+    "  }",
+    "",
+    "  async execute(ctx) {",
+    "    throw new Error(\"Registration bootstrap source is metadata-only.\");",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}

--- a/siglume-api-sdk-ts/test/bin.test.ts
+++ b/siglume-api-sdk-ts/test/bin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("siglume bin", () => {
+  it("forwards argv to runCli and sets process.exitCode", async () => {
+    vi.resetModules();
+    const runCli = vi.fn(async () => 7);
+    vi.doMock("../src/cli/index", () => ({ runCli }));
+
+    const originalArgv = process.argv;
+    const originalExitCode = process.exitCode;
+    process.argv = ["node", "siglume", "score", ".", "--offline"];
+    process.exitCode = undefined;
+
+    try {
+      await import("../src/bin/siglume");
+      expect(runCli).toHaveBeenCalledWith(["score", ".", "--offline"]);
+      expect(process.exitCode).toBe(7);
+    } finally {
+      process.argv = originalArgv;
+      process.exitCode = originalExitCode;
+      vi.doUnmock("../src/cli/index");
+      vi.resetModules();
+    }
+  });
+});

--- a/siglume-api-sdk-ts/test/cli-advanced.test.ts
+++ b/siglume-api-sdk-ts/test/cli-advanced.test.ts
@@ -1,0 +1,199 @@
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { SiglumeClientShape } from "../src/index";
+import { runCli } from "../src/cli/index";
+
+function createMockClient(publishable = true): SiglumeClientShape {
+  return {
+    async preview_quality_score() {
+      return {
+        overall_score: publishable ? 92 : 72,
+        grade: publishable ? "A" : "C",
+        issues: [],
+        keyword_coverage_estimate: 30,
+        improvement_suggestions: [],
+        publishable,
+        validation_ok: true,
+        validation_errors: [],
+        validation_warnings: [],
+      };
+    },
+    async auto_register() {
+      return {
+        listing_id: "lst_123",
+        status: "draft",
+        auto_manifest: {},
+        confidence: {},
+      };
+    },
+    async confirm_registration() {
+      return {
+        listing_id: "lst_123",
+        status: "pending_review",
+        release: {},
+        quality: {
+          overall_score: 84,
+          grade: "B",
+          issues: [],
+          improvement_suggestions: [],
+          raw: {},
+        },
+        raw: {},
+      };
+    },
+    async get_usage() {
+      return {
+        items: [],
+        meta: {},
+      };
+    },
+    async create_support_case() {
+      return {
+        support_case_id: "case_123",
+        case_type: "app_execution",
+        summary: "help",
+        status: "open",
+        metadata: {},
+        raw: {},
+      };
+    },
+  } as unknown as SiglumeClientShape;
+}
+
+async function createEchoProject(validManual = true): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "siglume-ts-cli-advanced-"));
+  const importHref = pathToFileURL(join(process.cwd(), "src", "index.ts")).href;
+  const adapterSource = [
+    `import { AppAdapter, AppCategory, ApprovalMode, PermissionClass, PriceModel } from "${importHref}";`,
+    "",
+    "export default class EchoApp extends AppAdapter {",
+    "  manifest() {",
+    "    return {",
+    '      capability_key: "echo-helper",',
+    '      name: "Echo Helper",',
+    '      job_to_be_done: "Return the provided input in a structured echo response.",',
+    "      category: AppCategory.OTHER,",
+    "      permission_class: PermissionClass.READ_ONLY,",
+    "      approval_mode: ApprovalMode.AUTO,",
+    "      dry_run_supported: true,",
+    "      required_connected_accounts: [],",
+    "      price_model: PriceModel.FREE,",
+    '      jurisdiction: "US",',
+    '      short_description: "Simple echo helper.",',
+    '      example_prompts: ["Echo this back to me."],',
+    "    };",
+    "  }",
+    "  async execute(ctx) {",
+    "    return { success: true, execution_kind: ctx.execution_kind, output: { summary: 'ok', input: ctx.input_params } };",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+  const toolManual = {
+    tool_name: "echo_helper",
+    job_to_be_done: "Return the provided input in a structured echo response.",
+    summary_for_model: "Echoes the provided request back in a structured response.",
+    trigger_conditions: [
+      "owner asks the agent to echo or repeat back a request payload",
+      "agent needs a trivial read-only helper for test or wiring validation",
+      "request is to mirror a provided string in a structured result",
+    ],
+    do_not_use_when: ["the request needs external data rather than a local echo response"],
+    permission_class: "read_only",
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "String to echo back." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line echo result." },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+    usage_hints: validManual ? ["Use for basic read-only smoke tests."] : undefined,
+    result_hints: ["Show the echoed payload in plain language."],
+    error_hints: ["If input is missing, ask for the text to echo."],
+  };
+
+  await writeFile(join(dir, "adapter.ts"), adapterSource, "utf8");
+  await writeFile(join(dir, "tool_manual.json"), JSON.stringify(toolManual, null, 2), "utf8");
+  return dir;
+}
+
+describe("siglume CLI advanced branches", () => {
+  it("prints text-mode output for init, score, support, and usage", async () => {
+    const initDir = await mkdtemp(join(tmpdir(), "siglume-ts-init-text-"));
+    const scoreDir = await createEchoProject();
+    const stdout: string[] = [];
+
+    const initExit = await runCli(["init", initDir], { stdout: (line) => stdout.push(line) });
+    const packageLinkDir = join(initDir, "node_modules", "@siglume");
+    await mkdir(packageLinkDir, { recursive: true });
+    await symlink(process.cwd(), join(packageLinkDir, "api-sdk"), "junction");
+    const scoreExit = await runCli(["score", scoreDir, "--offline"], {
+      stdout: (line) => stdout.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(true),
+    });
+    const supportExit = await runCli(["support", "create", "--subject", "help", "--body", "details"], {
+      stdout: (line) => stdout.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(true),
+    });
+    const usageExit = await runCli(["usage"], {
+      stdout: (line) => stdout.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(true),
+    });
+
+    expect(initExit).toBe(0);
+    expect(scoreExit).toBe(0);
+    expect(supportExit).toBe(0);
+    expect(usageExit).toBe(0);
+    expect(stdout.some((line) => line.includes("Initialized Siglume starter template"))).toBe(true);
+    expect(stdout.some((line) => line.includes("Offline quality:"))).toBe(true);
+    expect(stdout.some((line) => line.includes("Support case created."))).toBe(true);
+    expect(stdout.some((line) => line.includes("Usage events: 0"))).toBe(true);
+    expect(await readFile(join(initDir, "README.md"), "utf8")).toContain("siglume init");
+  });
+
+  it("returns project errors for failed validate and score commands", async () => {
+    const invalidProject = await createEchoProject(false);
+    const stderr: string[] = [];
+    const validateExit = await runCli(["validate", invalidProject], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(true),
+    });
+    const scoreExit = await runCli(["score", invalidProject, "--remote"], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(false),
+    });
+
+    expect(validateExit).toBe(1);
+    expect(scoreExit).toBe(1);
+    expect(stderr).toEqual(expect.arrayContaining(["Validation failed.", "Score failed."]));
+  });
+
+  it("returns commander exit codes for help and unknown commands", async () => {
+    const helpExit = await runCli(["--help"]);
+    const badExit = await runCli(["definitely-not-a-command"]);
+
+    expect(helpExit).toBe(0);
+    expect(badExit).toBe(1);
+  });
+});

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -1,0 +1,303 @@
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { SiglumeClientShape } from "../src/index";
+import { runCli } from "../src/cli/index";
+
+function createMockClient() {
+  return {
+    async preview_quality_score() {
+      return {
+        overall_score: 92,
+        grade: "A",
+        issues: [],
+        keyword_coverage_estimate: 30,
+        improvement_suggestions: [],
+        publishable: true,
+        validation_ok: true,
+        validation_errors: [],
+        validation_warnings: [],
+      };
+    },
+    async auto_register() {
+      return {
+        listing_id: "lst_123",
+        status: "draft",
+        auto_manifest: {},
+        confidence: {},
+      };
+    },
+    async confirm_registration() {
+      return {
+        listing_id: "lst_123",
+        status: "pending_review",
+        release: {},
+        quality: {
+          overall_score: 84,
+          grade: "B",
+          issues: [],
+          improvement_suggestions: [],
+          raw: {},
+        },
+        raw: {},
+      };
+    },
+    async submit_review() {
+      return {
+        listing_id: "lst_123",
+        capability_key: "payment-quote",
+        name: "Payment Quote",
+        status: "pending_review",
+        dry_run_supported: true,
+        price_value_minor: 0,
+        currency: "USD",
+        submission_blockers: [],
+        raw: {},
+      };
+    },
+    async get_usage() {
+      return {
+        items: [],
+        meta: {},
+        async all_items() {
+          return [];
+        },
+      };
+    },
+    async create_support_case() {
+      return {
+        support_case_id: "case_123",
+        case_type: "app_execution",
+        summary: "help",
+        status: "open",
+        metadata: {},
+        raw: {},
+      };
+    },
+  };
+}
+
+async function createTestProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "siglume-ts-cli-"));
+  const importHref = pathToFileURL(join(process.cwd(), "src", "index.ts")).href;
+  const adapterSource = [
+    `import { AppAdapter, AppCategory, ApprovalMode, PermissionClass, PriceModel } from "${importHref}";`,
+    "",
+    "export default class PaymentQuoteApp extends AppAdapter {",
+    "  manifest() {",
+    "    return {",
+    "      capability_key: \"payment-quote\",",
+    "      name: \"Payment Quote\",",
+    "      job_to_be_done: \"Quote a USD charge and complete the payment only after owner approval.\",",
+    "      category: AppCategory.FINANCE,",
+    "      permission_class: PermissionClass.PAYMENT,",
+    "      approval_mode: ApprovalMode.ALWAYS_ASK,",
+    "      dry_run_supported: true,",
+    "      required_connected_accounts: [],",
+    "      price_model: PriceModel.FREE,",
+    "      jurisdiction: \"US\",",
+    "      short_description: \"Preview, quote, and complete a USD payment flow with explicit approval.\",",
+    "      example_prompts: [\"Quote the charge for this premium report purchase.\"],",
+    "    };",
+    "  }",
+    "",
+    "  async execute(ctx) {",
+    "    const amountUsd = Number(ctx.input_params?.amount_usd ?? 12.5);",
+    "    const summary = `Charge USD ${amountUsd.toFixed(2)} for the requested purchase.`;",
+    "    if (ctx.execution_kind === \"dry_run\") {",
+    "      return { success: true, execution_kind: ctx.execution_kind, output: { summary, amount_usd: amountUsd, currency: \"USD\" }, needs_approval: true, approval_prompt: summary };",
+    "    }",
+    "    if (ctx.execution_kind === \"quote\") {",
+    "      return { success: true, execution_kind: ctx.execution_kind, output: { summary: `Quoted USD ${amountUsd.toFixed(2)}.`, amount_usd: amountUsd, currency: \"USD\" }, receipt_summary: { action: \"payment_quote_generated\", amount_usd: amountUsd, currency: \"USD\" } };",
+    "    }",
+    "    return { success: true, execution_kind: ctx.execution_kind, output: { summary: `Charged USD ${amountUsd.toFixed(2)}.`, amount_usd: amountUsd, currency: \"USD\", payment_id: \"pay_123\" }, receipt_summary: { action: \"payment_captured\", payment_id: \"pay_123\", amount_usd: amountUsd, currency: \"USD\" } };",
+    "  }",
+    "",
+    "  supported_task_types() {",
+    "    return [\"quote_payment\", \"charge_payment\"];",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+  const toolManual = {
+    tool_name: "payment_quote",
+    job_to_be_done: "Quote a USD payment amount and then complete the charge only after the owner approves it.",
+    summary_for_model: "Previews and quotes a USD payment amount, then completes the charge after explicit owner approval.",
+    trigger_conditions: [
+      "owner asks for the price of a purchase before deciding whether to approve it",
+      "agent needs to quote a USD charge and then complete payment after approval",
+      "request is to preview or charge a payment rather than only returning read-only information",
+    ],
+    do_not_use_when: [
+      "the owner only wants accounting advice and does not want to quote or charge a payment",
+      "the request is to compare prices without initiating any payment flow",
+    ],
+    permission_class: "payment",
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        amount_usd: { type: "number", description: "USD amount to quote or charge." },
+      },
+      required: ["amount_usd"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line summary of the quote or payment result." },
+        amount_usd: { type: "number", description: "USD amount that was quoted or charged." },
+        currency: { type: "string", description: "Currency code for the quote or charge." },
+      },
+      required: ["summary", "amount_usd", "currency"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use dry_run or quote first so the owner can review the amount before any payment is attempted."],
+    result_hints: ["Show the quoted or charged USD amount before any secondary details such as payment_id."],
+    error_hints: ["If the amount is missing or invalid, ask the owner for a concrete USD amount before retrying."],
+    approval_summary_template: "Charge USD {amount_usd}.",
+    preview_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Preview of the payment that would be charged." },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+    idempotency_support: true,
+    side_effect_summary: "Captures a USD payment when the owner approves the charge.",
+    quote_schema: {
+      type: "object",
+      properties: {
+        amount_usd: { type: "number", description: "Quoted USD amount." },
+        currency: { type: "string", description: "Currency code for the quote." },
+      },
+      required: ["amount_usd", "currency"],
+      additionalProperties: false,
+    },
+    currency: "USD",
+    settlement_mode: "embedded_wallet_charge",
+    refund_or_cancellation_note: "Refunds are handled according to the merchant's cancellation policy.",
+    jurisdiction: "US",
+  };
+
+  await writeFile(join(dir, "adapter.ts"), adapterSource, "utf8");
+  await writeFile(join(dir, "tool_manual.json"), JSON.stringify(toolManual, null, 2), "utf8");
+  return dir;
+}
+
+describe("siglume CLI", () => {
+  it("runs offline score and harness flows", async () => {
+    const projectDir = await createTestProject();
+    const stdout: string[] = [];
+    const clientFactory = () => createMockClient();
+
+    const scoreExit = await runCli(["score", projectDir, "--offline", "--json"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+    const testExit = await runCli(["test", projectDir, "--json"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(scoreExit).toBe(0);
+    expect(testExit).toBe(0);
+    expect(stdout.some((line) => line.includes("\"overall_score\": 100"))).toBe(true);
+    expect(stdout.some((line) => line.includes("\"ok\": true"))).toBe(true);
+  });
+
+  it("supports init and validate with a mocked remote client", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "siglume-ts-init-"));
+    const stdout: string[] = [];
+    const clientFactory = () => createMockClient();
+
+    const initExit = await runCli(["init", projectDir, "--template", "echo", "--json"], {
+      stdout: (line) => stdout.push(line),
+    });
+    const packageLinkDir = join(projectDir, "node_modules", "@siglume");
+    await mkdir(packageLinkDir, { recursive: true });
+    await symlink(process.cwd(), join(packageLinkDir, "api-sdk"), "junction");
+    const validateExit = await runCli(["validate", projectDir, "--json"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(initExit).toBe(0);
+    expect(validateExit).toBe(0);
+    const manifest = JSON.parse(await readFile(join(projectDir, "manifest.json"), "utf8")) as Record<string, unknown>;
+    const validatePayload = JSON.parse(stdout.at(-1) as string) as Record<string, unknown>;
+    expect(manifest.capability_key).toBe("echo-starter");
+    expect(validatePayload.ok).toBe(true);
+  });
+
+  it("covers register, support, and usage commands with mocked client methods", async () => {
+    const projectDir = await createTestProject();
+    const stdout: string[] = [];
+    const seen: { trace_id?: string; submit_review_calls: number } = { submit_review_calls: 0 };
+    const clientFactory = () => ({
+      ...createMockClient(),
+      async submit_review() {
+        seen.submit_review_calls += 1;
+        return {
+          listing_id: "lst_123",
+          capability_key: "payment-quote",
+          name: "Payment Quote",
+          status: "pending_review",
+          dry_run_supported: true,
+          price_value_minor: 0,
+          currency: "USD",
+          submission_blockers: [],
+          raw: {},
+        };
+      },
+      async create_support_case(_subject: string, _body: string, options?: { trace_id?: string }) {
+        seen.trace_id = options?.trace_id;
+        return {
+          support_case_id: "case_123",
+          case_type: "app_execution",
+          summary: "help",
+          status: "open",
+          metadata: {},
+          raw: {},
+        };
+      },
+    });
+
+    const registerExit = await runCli(["register", projectDir, "--submit-review", "--json"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+    const supportExit = await runCli(
+      ["support", "create", "--subject", "help", "--body", "details", "--trace-id", "trc_123", "--json"],
+      {
+        stdout: (line) => stdout.push(line),
+        client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+      },
+    );
+    const usageExit = await runCli(["usage", "--window", "7d", "--json"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(registerExit).toBe(0);
+    expect(supportExit).toBe(0);
+    expect(usageExit).toBe(0);
+    expect(stdout.some((line) => line.includes("\"review\""))).toBe(true);
+    expect(stdout.some((line) => line.includes("\"case\""))).toBe(true);
+    expect(stdout.some((line) => line.includes("\"window\": \"7d\""))).toBe(true);
+    expect(seen.submit_review_calls).toBe(1);
+    expect(seen.trace_id).toBe("trc_123");
+  });
+});

--- a/siglume-api-sdk-ts/test/client-extra.test.ts
+++ b/siglume-api-sdk-ts/test/client-extra.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AppCategory,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  SiglumeClient,
+  SiglumeClientError,
+  SiglumeNotFoundError,
+  ToolManualPermissionClass,
+} from "../src/index";
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(String(input));
+}
+
+function buildManifest() {
+  return {
+    capability_key: "price-compare-helper",
+    name: "Price Compare Helper",
+    job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+    category: AppCategory.COMMERCE,
+    permission_class: PermissionClass.READ_ONLY,
+    approval_mode: ApprovalMode.AUTO,
+    dry_run_supported: true,
+    required_connected_accounts: [],
+    price_model: PriceModel.FREE,
+    jurisdiction: "US",
+  };
+}
+
+function buildToolManual() {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Search multiple retailers for a product and return a ranked price comparison.",
+    summary_for_model: "Looks up current retailer offers and returns the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: ["the request is to complete checkout or place an order instead of comparing offers"],
+    permission_class: ToolManualPermissionClass.READ_ONLY,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+    result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
+    error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+  };
+}
+
+describe("SiglumeClient extra branches", () => {
+  it("requires an api key at construction time", () => {
+    expect(() => new SiglumeClient({ api_key: "" })).toThrow("SIGLUME_API_KEY is required.");
+  });
+
+  it("prefers source_url or source_code and allows confirmation overrides", async () => {
+    const requests: Array<{ path: string; body: Record<string, unknown> }> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        requests.push({ path: url.pathname, body });
+        if (url.pathname.endsWith("/auto-register")) {
+          return new Response(JSON.stringify({ data: { listing_id: "lst_url", status: "draft" } }), {
+            status: 201,
+            headers: { "x-request-id": "req_1", "x-trace-id": "trc_1" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              listing_id: "lst_url",
+              status: "pending_review",
+              release: {},
+              quality: { score: 88, grade: "B", issues: [], improvement_suggestions: [] },
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    });
+
+    const receipt = await client.auto_register(buildManifest(), buildToolManual(), {
+      source_url: "https://github.com/example/repo",
+    });
+    const confirmation = await client.confirm_registration("lst_url", {
+      manifest: { name: "Override Name", job_to_be_done: "Override job" },
+      tool_manual: { tool_name: "override_tool" },
+    });
+    client.close();
+
+    expect(receipt.trace_id).toBe("trc_1");
+    expect(requests[0]?.body.source_url).toBe("https://github.com/example/repo");
+    expect(requests[0]?.body.source_code).toBeUndefined();
+    expect((requests[1]?.body.overrides as Record<string, unknown>).name).toBe("Override Name");
+    expect(((requests[1]?.body.overrides as Record<string, unknown>).tool_manual as Record<string, unknown>).tool_name).toBe(
+      "override_tool",
+    );
+    expect(confirmation.quality.grade).toBe("B");
+  });
+
+  it("supports list_my_listings, allItems alias, and invalid-json success responses", async () => {
+    let sawMine = false;
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/capabilities") {
+          sawMine = url.searchParams.get("mine") === "true";
+          return new Response(
+            JSON.stringify({
+              data: {
+                items: [{ id: "lst_1", capability_key: "price-compare-helper", name: "Price Compare Helper", status: "draft" }],
+                next_cursor: null,
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not-json", {
+          status: 200,
+          headers: { "x-request-id": "req_raw", "x-trace-id": "trc_raw" },
+        });
+      },
+    });
+
+    const page = await client.list_my_listings();
+    const listing = await client.get_listing("broken_json");
+
+    expect(sawMine).toBe(true);
+    expect((await page.allItems()).map((item) => item.listing_id)).toEqual(["lst_1"]);
+    expect(listing.listing_id).toBe("");
+  });
+
+  it("maps top-level preview errors and 404 responses", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/tool-manuals/preview-quality") {
+          return new Response(
+            JSON.stringify({
+              ok: false,
+              errors: [{ code: "BAD_ROOT", message: "tool manual must be a dict", field: "tool_manual" }],
+              warnings: [{ code: "LOW_HINTS", message: "add more hints", field: "usage_hints" }],
+              quality: {
+                score: 81,
+                grade: "B",
+                keyword_coverage: 11,
+                improvement_suggestions: ["Add more details."],
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ error: { code: "NOT_FOUND", message: "missing" } }), { status: 404 });
+      },
+    });
+
+    const quality = await client.preview_quality_score(buildToolManual());
+
+    expect(quality.validation_ok).toBe(false);
+    expect(quality.publishable).toBe(false);
+    expect(quality.validation_errors).toHaveLength(1);
+    expect(quality.validation_warnings).toHaveLength(1);
+    await expect(client.get_listing("missing")).rejects.toBeInstanceOf(SiglumeNotFoundError);
+  });
+
+  it("retries transport failures and surfaces client errors when retries are exhausted", async () => {
+    let attempts = 0;
+    const retryingClient = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      max_retries: 2,
+      timeout_ms: 20,
+      fetch: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("socket closed");
+        }
+        return new Response(JSON.stringify({ data: { id: "lst_2", capability_key: "price-compare-helper", name: "ok", status: "published" } }), {
+          status: 200,
+        });
+      },
+    });
+
+    const listing = await retryingClient.get_listing("lst_2");
+    expect(attempts).toBe(2);
+    expect(listing.listing_id).toBe("lst_2");
+
+    const failingClient = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      max_retries: 1,
+      fetch: async () => {
+        throw new Error("network down");
+      },
+    });
+    await expect(failingClient.get_listing("lst_3")).rejects.toBeInstanceOf(SiglumeClientError);
+  });
+});

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AppCategory,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  SiglumeAPIError,
+  SiglumeClient,
+  ToolManualPermissionClass,
+} from "../src/index";
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(String(input));
+}
+
+function envelope(data: Record<string, unknown>, meta: Record<string, unknown> = { request_id: "req_test", trace_id: "trc_test" }) {
+  return { data, meta, error: null };
+}
+
+function buildManifest() {
+  return {
+    capability_key: "price-compare-helper",
+    name: "Price Compare Helper",
+    job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+    category: AppCategory.COMMERCE,
+    permission_class: PermissionClass.READ_ONLY,
+    approval_mode: ApprovalMode.AUTO,
+    dry_run_supported: true,
+    required_connected_accounts: [],
+    price_model: PriceModel.FREE,
+    jurisdiction: "US",
+    short_description: "Search multiple retailers and summarize the best current price.",
+    example_prompts: ["Compare prices for Sony WH-1000XM5."],
+  };
+}
+
+function buildToolManual() {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+    summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: [
+      "the request is to complete checkout or place an order instead of comparing offers",
+    ],
+    permission_class: ToolManualPermissionClass.READ_ONLY,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+        offers: { type: "array", items: { type: "object" }, description: "Ranked retailer offers." },
+      },
+      required: ["summary", "offers"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+    result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
+    error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+  };
+}
+
+describe("SiglumeClient", () => {
+  it("returns typed objects for auto-register and confirm-registration", async () => {
+    const requests: Array<{ method: string; path: string; body: Record<string, unknown> }> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        requests.push({ method: String(init?.method ?? "GET"), path: url.pathname, body });
+        if (url.pathname === "/v1/market/capabilities/auto-register") {
+          return new Response(
+            JSON.stringify(
+              envelope({
+                listing_id: "lst_123",
+                status: "draft",
+                auto_manifest: { capability_key: "price-compare-helper" },
+                confidence: { overall: 0.94 },
+                review_url: "/owner/publish?listing=lst_123",
+              }),
+            ),
+            { status: 201 },
+          );
+        }
+        if (url.pathname === "/v1/market/capabilities/lst_123/confirm-auto-register") {
+          return new Response(
+            JSON.stringify(
+              envelope({
+                listing_id: "lst_123",
+                status: "pending_review",
+                release: { release_id: "rel_123", release_status: "pending_review" },
+                quality: {
+                  overall_score: 84,
+                  grade: "B",
+                  issues: [],
+                  improvement_suggestions: ["Add one more retailer-specific trigger example."],
+                },
+              }, { request_id: "req_confirm", trace_id: "trc_confirm" }),
+            ),
+            { status: 200 },
+          );
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const receipt = await client.auto_register(buildManifest(), buildToolManual());
+    const confirmation = await client.confirm_registration(receipt.listing_id);
+
+    expect(receipt.listing_id).toBe("lst_123");
+    expect(receipt.trace_id).toBe("trc_test");
+    expect(confirmation.listing_id).toBe("lst_123");
+    expect(confirmation.quality.overall_score).toBe(84);
+    expect(confirmation.trace_id).toBe("trc_confirm");
+    expect(requests[0]?.path).toBe("/v1/market/capabilities/auto-register");
+    expect(requests[1]?.path).toBe("/v1/market/capabilities/lst_123/confirm-auto-register");
+  });
+
+  it("follows cursor pagination for capabilities and usage", async () => {
+    const counts = { listings: 0, usage: 0 };
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/capabilities") {
+          counts.listings += 1;
+          if (url.searchParams.get("cursor") === "next_listing") {
+            return new Response(JSON.stringify(envelope({
+              items: [{ id: "lst_2", capability_key: "calendar-sync", name: "Calendar Sync", status: "published", dry_run_supported: true, price_model: "free", price_value_minor: 0, currency: "USD" }],
+              next_cursor: null,
+              limit: 1,
+              offset: 1,
+            })), { status: 200 });
+          }
+          return new Response(JSON.stringify(envelope({
+            items: [{ id: "lst_1", capability_key: "price-compare-helper", name: "Price Compare Helper", status: "draft", dry_run_supported: true, price_model: "free", price_value_minor: 0, currency: "USD" }],
+            next_cursor: "next_listing",
+            limit: 1,
+            offset: 0,
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/usage") {
+          counts.usage += 1;
+          if (url.searchParams.get("cursor") === "next_usage") {
+            return new Response(JSON.stringify(envelope({
+              items: [{ id: "use_2", capability_key: "price-compare-helper", units_consumed: 3, outcome: "success", execution_kind: "dry_run", created_at: "2026-04-19T00:00:00Z" }],
+              next_cursor: null,
+              limit: 1,
+              offset: 1,
+            })), { status: 200 });
+          }
+          return new Response(JSON.stringify(envelope({
+            items: [{ id: "use_1", capability_key: "price-compare-helper", units_consumed: 1, outcome: "success", execution_kind: "dry_run", created_at: "2026-04-18T00:00:00Z" }],
+            next_cursor: "next_usage",
+            limit: 1,
+            offset: 0,
+          })), { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const listings = await client.list_capabilities({ limit: 1 });
+    const usage = await client.get_usage({ limit: 1 });
+
+    expect((await listings.all_items()).map((item) => item.listing_id)).toEqual(["lst_1", "lst_2"]);
+    expect((await usage.all_items()).map((item) => item.usage_event_id)).toEqual(["use_1", "use_2"]);
+    expect(counts.listings).toBe(2);
+    expect(counts.usage).toBe(2);
+  });
+
+  it("parses quality previews and surfaces API errors", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/tool-manuals/preview-quality") {
+          return new Response(JSON.stringify(envelope({
+            ok: true,
+            quality: {
+              overall_score: 96,
+              grade: "A",
+              publishable: true,
+              keyword_coverage_estimate: 33,
+              issues: [{ category: "description_quality", severity: "suggestion", message: "Looks good", field: "summary_for_model" }],
+              improvement_suggestions: ["none"],
+            },
+          })), { status: 200 });
+        }
+        return new Response(JSON.stringify({ error: { code: "NOPE", message: "bad request" } }), { status: 400 });
+      },
+    });
+
+    const quality = await client.preview_quality_score(buildToolManual());
+    expect(quality.overall_score).toBe(96);
+    expect(quality.grade).toBe("A");
+    expect(quality.publishable).toBe(true);
+
+    await expect(client.get_listing("missing")).rejects.toBeInstanceOf(SiglumeAPIError);
+  });
+
+  it("covers developer portal, sandbox, grants, accounts, support, and retries", async () => {
+    let retryCount = 0;
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/capabilities/retry_listing") {
+          retryCount += 1;
+          if (retryCount === 1) {
+            return new Response(JSON.stringify({ error: { code: "TEMP", message: "retry later" } }), { status: 500 });
+          }
+          return new Response(JSON.stringify(envelope({
+            id: "retry_listing",
+            capability_key: "price-compare-helper",
+            name: "Price Compare Helper",
+            status: "published",
+            dry_run_supported: true,
+            price_model: "free",
+            price_value_minor: 0,
+            currency: "USD",
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/developer/portal") {
+          return new Response(JSON.stringify(envelope({
+            seller_onboarding: { status: "ready" },
+            platform: { region: "us" },
+            monetization: { active: true },
+            payout_readiness: { ready: true },
+            listings: { total: 2 },
+            usage: { total_events: 10 },
+            support: { open_cases: 1 },
+            apps: [{ id: "lst_1", capability_key: "price-compare-helper", name: "Price Compare Helper", status: "published", dry_run_supported: true, price_model: "free", price_value_minor: 0, currency: "USD" }],
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/sandbox/sessions") {
+          return new Response(JSON.stringify(envelope({
+            session_id: "sns_123",
+            agent_id: "agt_123",
+            capability_key: "price-compare-helper",
+            environment: "sandbox",
+            dry_run_supported: true,
+            required_connected_accounts: [],
+            connected_accounts: [],
+            stub_providers_enabled: true,
+            simulated_receipts: true,
+            approval_simulator: true,
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/access-grants") {
+          return new Response(JSON.stringify(envelope({
+            items: [{
+              id: "grant_1",
+              capability_listing_id: "lst_1",
+              grant_status: "active",
+              bindings: [],
+              metadata: { tier: "pro" },
+            }],
+            next_cursor: null,
+            limit: 20,
+            offset: 0,
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/access-grants/grant_1/bind-agent") {
+          return new Response(JSON.stringify(envelope({
+            binding: { id: "bind_1", access_grant_id: "grant_1", agent_id: "agt_123", binding_status: "active" },
+            access_grant: { id: "grant_1", capability_listing_id: "lst_1", grant_status: "active", bindings: [], metadata: {} },
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/connected-accounts") {
+          return new Response(JSON.stringify(envelope({
+            items: [{
+              id: "conn_1",
+              provider_key: "stripe",
+              account_role: "seller",
+              scopes: ["charges:read"],
+              metadata: {},
+            }],
+            next_cursor: null,
+            limit: 50,
+            offset: 0,
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/support-cases" && init?.method === "POST") {
+          return new Response(JSON.stringify(envelope({
+            id: "case_1",
+            case_type: "app_execution",
+            summary: "subject\n\nbody",
+            status: "open",
+            metadata: {},
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/market/support-cases" && (!init?.method || init.method === "GET")) {
+          return new Response(JSON.stringify(envelope({
+            items: [{
+              id: "case_1",
+              case_type: "app_execution",
+              summary: "subject\n\nbody",
+              status: "open",
+              metadata: {},
+            }],
+            next_cursor: null,
+            limit: 50,
+            offset: 0,
+          })), { status: 200 });
+        }
+        return new Response("{}", { status: 404 });
+      },
+    });
+
+    const listing = await client.get_listing("retry_listing");
+    const portal = await client.get_developer_portal();
+    const sandbox = await client.create_sandbox_session({ agent_id: "agt_123", capability_key: "price-compare-helper" });
+    const grants = await client.list_access_grants();
+    const binding = await client.bind_agent_to_grant("grant_1", { agent_id: "agt_123" });
+    const accounts = await client.list_connected_accounts();
+    const supportCase = await client.create_support_case("subject", "body", { trace_id: "trc_123" });
+    const supportCases = await client.list_support_cases();
+
+    expect(retryCount).toBe(2);
+    expect(listing.listing_id).toBe("retry_listing");
+    expect(portal.apps).toHaveLength(1);
+    expect(sandbox.session_id).toBe("sns_123");
+    expect((await grants.all_items()).map((item) => item.access_grant_id)).toEqual(["grant_1"]);
+    expect(binding.binding.binding_id).toBe("bind_1");
+    expect((await accounts.all_items()).map((item) => item.connected_account_id)).toEqual(["conn_1"]);
+    expect(supportCase.support_case_id).toBe("case_1");
+    expect((await supportCases.all_items()).map((item) => item.support_case_id)).toEqual(["case_1"]);
+  });
+
+  it("validates support case payloads locally", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () => new Response("{}", { status: 500 }),
+    });
+
+    await expect(client.create_support_case("", "")).rejects.toThrow("Support case subject or body is required.");
+    await expect(client.create_support_case("x".repeat(1001), "y".repeat(1001))).rejects.toThrow(
+      "Support case summary/body must fit within the 2000 character API limit.",
+    );
+  });
+});

--- a/siglume-api-sdk-ts/test/harness.test.ts
+++ b/siglume-api-sdk-ts/test/harness.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+} from "../src/index";
+import type { ExecutionContext, ExecutionResult } from "../src/index";
+
+class PaymentQuoteApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "payment-quote",
+      name: "Payment Quote",
+      job_to_be_done: "Quote a USD charge and complete the payment only after owner approval.",
+      category: AppCategory.FINANCE,
+      permission_class: PermissionClass.PAYMENT,
+      approval_mode: ApprovalMode.ALWAYS_ASK,
+      dry_run_supported: true,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Preview, quote, and complete a USD payment flow with explicit approval.",
+      example_prompts: ["Quote the charge for this premium report purchase."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const amount_usd = Number(ctx.input_params?.amount_usd ?? 12.5);
+    const summary = `Charge USD ${amount_usd.toFixed(2)} for the requested purchase.`;
+    if (ctx.execution_kind === "dry_run") {
+      return {
+        success: true,
+        execution_kind: ctx.execution_kind,
+        output: { summary, amount_usd, currency: "USD" },
+        needs_approval: true,
+        approval_prompt: summary,
+      };
+    }
+    if (ctx.execution_kind === "quote") {
+      return {
+        success: true,
+        execution_kind: ctx.execution_kind,
+        output: { summary: `Quoted USD ${amount_usd.toFixed(2)}.`, amount_usd, currency: "USD" },
+        receipt_summary: { action: "payment_quote_generated", amount_usd, currency: "USD" },
+      };
+    }
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: { summary: `Charged USD ${amount_usd.toFixed(2)}.`, amount_usd, currency: "USD", payment_id: "pay_123" },
+      receipt_summary: { action: "payment_captured", payment_id: "pay_123", amount_usd, currency: "USD" },
+    };
+  }
+
+  supported_task_types() {
+    return ["quote_payment", "charge_payment"];
+  }
+}
+
+describe("AppTestHarness", () => {
+  it("runs dry-run, quote, and payment flows", async () => {
+    const harness = new AppTestHarness(new PaymentQuoteApp());
+
+    expect(await harness.validate_manifest()).toEqual([]);
+    expect((await harness.dry_run("quote_payment", { input_params: { amount_usd: 12.5 } })).success).toBe(true);
+    expect((await harness.execute_quote("quote_payment", { input_params: { amount_usd: 12.5 } })).success).toBe(true);
+    expect((await harness.execute_payment("charge_payment", { input_params: { amount_usd: 12.5 } })).success).toBe(true);
+  });
+
+  it("reports receipt issues when an action omits receipt details", () => {
+    const harness = new AppTestHarness(new PaymentQuoteApp());
+    const issues = harness.validate_receipt({
+      success: true,
+      execution_kind: "action",
+      output: { summary: "done" },
+      side_effects: [],
+    });
+    expect(issues).toContain("Action/payment execution should report side effects");
+  });
+
+  it("supports health checks and missing-account simulation", async () => {
+    const harness = new AppTestHarness(new PaymentQuoteApp());
+
+    const health = await harness.health();
+    const missing = await harness.simulate_connected_account_missing("quote_payment", { input_params: { amount_usd: 5 } });
+
+    expect(health.healthy).toBe(true);
+    expect(missing.success).toBe(true);
+  });
+});

--- a/siglume-api-sdk-ts/test/manual-fixtures.ts
+++ b/siglume-api-sdk-ts/test/manual-fixtures.ts
@@ -1,0 +1,224 @@
+export const EXPECTED_PARITY: Record<string, { overall_score: number; keyword_coverage_estimate: number }> = {
+  baseline_read_only: { overall_score: 100, keyword_coverage_estimate: 40 },
+  action_good: { overall_score: 100, keyword_coverage_estimate: 40 },
+  payment_good: { overall_score: 100, keyword_coverage_estimate: 40 },
+  short_triggers: { overall_score: 85, keyword_coverage_estimate: 30 },
+  vague_triggers: { overall_score: 83, keyword_coverage_estimate: 34 },
+  marketing_triggers: { overall_score: 91, keyword_coverage_estimate: 41 },
+  imperative_triggers: { overall_score: 89, keyword_coverage_estimate: 37 },
+  too_few_triggers: { overall_score: 95, keyword_coverage_estimate: 34 },
+  overlapping_do_not_use: { overall_score: 97, keyword_coverage_estimate: 40 },
+  short_do_not_use: { overall_score: 98, keyword_coverage_estimate: 40 },
+  short_summary: { overall_score: 97, keyword_coverage_estimate: 35 },
+  marketing_summary: { overall_score: 97, keyword_coverage_estimate: 40 },
+  missing_input_descriptions: { overall_score: 90, keyword_coverage_estimate: 40 },
+  short_input_descriptions: { overall_score: 96, keyword_coverage_estimate: 40 },
+  trivial_enum_values: { overall_score: 95, keyword_coverage_estimate: 40 },
+  missing_output_descriptions: { overall_score: 96, keyword_coverage_estimate: 40 },
+  empty_hints: { overall_score: 94, keyword_coverage_estimate: 33 },
+  short_hints: { overall_score: 98, keyword_coverage_estimate: 34 },
+  low_keyword_coverage: { overall_score: 60, keyword_coverage_estimate: 6 },
+  invalid_root: { overall_score: 0, keyword_coverage_estimate: 0 },
+};
+
+export function baseManual(): Record<string, unknown> {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Compare retailer prices for a product and return the best current offer with supporting details.",
+    summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: [
+      "the request is to complete checkout or place an order instead of comparing offers",
+    ],
+    permission_class: "read_only",
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+        max_price_usd: { type: "number", description: "Optional maximum budget in USD for filtering offers." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+        offers: { type: "array", items: { type: "object" }, description: "Ranked retailer offers." },
+      },
+      required: ["summary", "offers"],
+      additionalProperties: false,
+    },
+    usage_hints: [
+      "Use this tool after the owner has named a product and wants evidence-backed price comparison.",
+    ],
+    result_hints: [
+      "Lead with the best offer and then summarize notable trade-offs.",
+    ],
+    error_hints: [
+      "If no offers are found, ask for a clearer product name or model number.",
+    ],
+  };
+}
+
+export function cloneBase(): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(baseManual())) as Record<string, unknown>;
+}
+
+export function buildParityCases(): Array<[string, unknown]> {
+  const cases: Array<[string, unknown]> = [];
+
+  let manual = cloneBase();
+  cases.push(["baseline_read_only", manual]);
+
+  manual = cloneBase();
+  manual.permission_class = "action";
+  manual.tool_name = "draft_creator";
+  manual.approval_summary_template = "Create draft for {query}";
+  manual.preview_schema = {
+    type: "object",
+    properties: { summary: { type: "string", description: "Preview of the action to perform." } },
+    required: ["summary"],
+    additionalProperties: false,
+  };
+  manual.idempotency_support = true;
+  manual.side_effect_summary = "Creates or updates an external draft resource.";
+  manual.jurisdiction = "US";
+  cases.push(["action_good", manual]);
+
+  manual = cloneBase();
+  manual.permission_class = "payment";
+  manual.tool_name = "payment_quote";
+  manual.approval_summary_template = "Charge USD {amount_usd} for {query}";
+  manual.preview_schema = {
+    type: "object",
+    properties: { summary: { type: "string", description: "Preview of the payment attempt." } },
+    required: ["summary"],
+    additionalProperties: false,
+  };
+  manual.idempotency_support = true;
+  manual.side_effect_summary = "Captures a USD payment if the owner approves.";
+  manual.jurisdiction = "US";
+  manual.quote_schema = {
+    type: "object",
+    properties: {
+      amount_usd: { type: "number", description: "Quoted USD amount." },
+      currency: { type: "string", description: "Currency code for the quote." },
+    },
+    required: ["amount_usd", "currency"],
+    additionalProperties: false,
+  };
+  manual.currency = "USD";
+  manual.settlement_mode = "embedded_wallet_charge";
+  manual.refund_or_cancellation_note = "Refunds follow the merchant cancellation policy.";
+  ((manual.output_schema as Record<string, unknown>).properties as Record<string, unknown>).amount_usd = {
+    type: "number",
+    description: "USD amount that was quoted or charged.",
+  };
+  ((manual.output_schema as Record<string, unknown>).properties as Record<string, unknown>).currency = {
+    type: "string",
+    description: "Currency code for the quote or charge.",
+  };
+  (manual.output_schema as Record<string, unknown>).required = ["summary", "offers", "amount_usd", "currency"];
+  cases.push(["payment_good", manual]);
+
+  manual = cloneBase();
+  manual.trigger_conditions = ["short one", "tiny trigger", "brief"];
+  cases.push(["short_triggers", manual]);
+
+  manual = cloneBase();
+  manual.trigger_conditions = [
+    "Use when helpful for shopping tasks",
+    "Use this tool as needed for many tasks",
+    "If appropriate, use for productivity shopping support",
+  ];
+  cases.push(["vague_triggers", manual]);
+
+  manual = cloneBase();
+  manual.trigger_conditions = [
+    "Ultimate price comparison for amazing shopping decisions",
+    "Game-changing offer search for world-class bargain hunting",
+    "Next-generation retailer scan for unbeatable deals",
+  ];
+  cases.push(["marketing_triggers", manual]);
+
+  manual = cloneBase();
+  manual.trigger_conditions = [
+    "Use this tool to compare the latest retailer offers for the requested product",
+    "Call this tool to gather seller price information for a named item",
+    "Execute this tool to identify the best-value option for a purchase",
+  ];
+  cases.push(["imperative_triggers", manual]);
+
+  manual = cloneBase();
+  manual.trigger_conditions = (manual.trigger_conditions as unknown[]).slice(0, 2);
+  cases.push(["too_few_triggers", manual]);
+
+  manual = cloneBase();
+  manual.do_not_use_when = ["compare prices for a product before deciding where to buy"];
+  cases.push(["overlapping_do_not_use", manual]);
+
+  manual = cloneBase();
+  manual.do_not_use_when = ["skip"];
+  cases.push(["short_do_not_use", manual]);
+
+  manual = cloneBase();
+  manual.summary_for_model = "Compares prices.";
+  cases.push(["short_summary", manual]);
+
+  manual = cloneBase();
+  manual.summary_for_model = "Amazing revolutionary world-class price comparison assistant for unbeatable shopping.";
+  cases.push(["marketing_summary", manual]);
+
+  manual = cloneBase();
+  const missingInputDescriptions = (manual.input_schema as Record<string, unknown>).properties as Record<string, Record<string, unknown>>;
+  delete missingInputDescriptions.query!.description;
+  delete missingInputDescriptions.max_price_usd!.description;
+  cases.push(["missing_input_descriptions", manual]);
+
+  manual = cloneBase();
+  const shortInputDescriptions = (manual.input_schema as Record<string, unknown>).properties as Record<string, Record<string, unknown>>;
+  shortInputDescriptions.query!.description = "Name";
+  shortInputDescriptions.max_price_usd!.description = "Cap";
+  cases.push(["short_input_descriptions", manual]);
+
+  manual = cloneBase();
+  ((manual.input_schema as Record<string, unknown>).properties as Record<string, unknown>).unit = {
+    type: "string",
+    description: "Preferred unit system for the returned offer metrics.",
+    enum: ["a", "b", "c"],
+  };
+  cases.push(["trivial_enum_values", manual]);
+
+  manual = cloneBase();
+  const missingOutputDescriptions = (manual.output_schema as Record<string, unknown>).properties as Record<string, Record<string, unknown>>;
+  delete missingOutputDescriptions.summary!.description;
+  delete missingOutputDescriptions.offers!.description;
+  cases.push(["missing_output_descriptions", manual]);
+
+  manual = cloneBase();
+  manual.usage_hints = [];
+  manual.result_hints = [];
+  cases.push(["empty_hints", manual]);
+
+  manual = cloneBase();
+  manual.usage_hints = ["brief"];
+  manual.result_hints = ["tiny"];
+  cases.push(["short_hints", manual]);
+
+  manual = cloneBase();
+  manual.job_to_be_done = "Do task";
+  manual.summary_for_model = "Do thing";
+  manual.trigger_conditions = ["when needed", "as needed", "if appropriate"];
+  manual.usage_hints = ["use"];
+  cases.push(["low_keyword_coverage", manual]);
+
+  cases.push(["invalid_root", "not a dict"]);
+  return cases;
+}

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -1,0 +1,407 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AppCategory,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  type SiglumeClientShape,
+} from "../src/index";
+import {
+  buildToolManualTemplate,
+  createSupportCaseReport,
+  getUsageReport,
+  loadProject,
+  runRegistration,
+  scoreProject,
+  validateProject,
+  writeInitTemplate,
+} from "../src/cli/project";
+
+function manifestBase(permission_class: PermissionClass = PermissionClass.READ_ONLY) {
+  return {
+    capability_key: permission_class === PermissionClass.PAYMENT ? "payment-quote" : "price-compare-helper",
+    name: permission_class === PermissionClass.PAYMENT ? "Payment Quote" : "Price Compare Helper",
+    job_to_be_done:
+      permission_class === PermissionClass.PAYMENT
+        ? "Quote and complete a USD payment after explicit owner approval."
+        : "Compare retailer prices for a product and return the best current offer.",
+    category: permission_class === PermissionClass.PAYMENT ? AppCategory.FINANCE : AppCategory.COMMERCE,
+    permission_class,
+    approval_mode: permission_class === PermissionClass.READ_ONLY ? ApprovalMode.AUTO : ApprovalMode.ALWAYS_ASK,
+    dry_run_supported: true,
+    required_connected_accounts: [],
+    price_model: PriceModel.FREE,
+    jurisdiction: "US",
+    short_description:
+      permission_class === PermissionClass.PAYMENT
+        ? "Preview, quote, and capture a USD payment with approval."
+        : "Returns a structured offer comparison.",
+    example_prompts: ["Example prompt."],
+  };
+}
+
+function manualBase() {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Compare retailer prices for a product and return the best current offer with supporting details.",
+    summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: ["the request is to complete checkout or place an order instead of comparing offers"],
+    permission_class: "read_only",
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+    result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
+    error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+  };
+}
+
+async function createObjectProject(options: {
+  manualFileName?: "tool_manual.json" | "tool-manual.json";
+  toolManual?: Record<string, unknown>;
+  manifest?: Record<string, unknown>;
+} = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "siglume-ts-project-"));
+  const adapterSource = [
+    "const app = {",
+    "  async manifest() {",
+    `    return ${JSON.stringify(options.manifest ?? manifestBase(), null, 2).replaceAll("\n", "\n    ")};`,
+    "  },",
+    "  async execute(ctx) {",
+    "    return { success: true, execution_kind: ctx.execution_kind, output: { summary: 'ok' } };",
+    "  },",
+    "};",
+    "export default app;",
+    "",
+  ].join("\n");
+  await writeFile(join(dir, "adapter.mjs"), adapterSource, "utf8");
+  await writeFile(
+    join(dir, options.manualFileName ?? "tool_manual.json"),
+    JSON.stringify(options.toolManual ?? manualBase(), null, 2),
+    "utf8",
+  );
+  return dir;
+}
+
+function usageClientFactory(
+  capture: { api_key?: string; usage_calls: number },
+  allItems = false,
+): (api_key: string, base_url?: string) => SiglumeClientShape {
+  return (api_key: string) => {
+    capture.api_key = api_key;
+    return {
+      async get_usage() {
+        capture.usage_calls += 1;
+        const page = {
+          items: [
+            {
+              usage_event_id: "use_1",
+              capability_key: "price-compare-helper",
+              units_consumed: 2,
+              raw: {},
+            },
+          ],
+          meta: {},
+        };
+        if (allItems) {
+          return {
+            ...page,
+            async all_items() {
+              return page.items;
+            },
+          };
+        }
+        return page;
+      },
+    } as unknown as SiglumeClientShape;
+  };
+}
+
+describe("cli project helpers", () => {
+  it("builds action and payment tool-manual templates with required fields", () => {
+    const actionTemplate = buildToolManualTemplate(manifestBase(PermissionClass.ACTION));
+    const paymentTemplate = buildToolManualTemplate(manifestBase(PermissionClass.PAYMENT));
+
+    expect(actionTemplate.permission_class).toBe("action");
+    expect(actionTemplate.preview_schema).toBeTruthy();
+    expect(paymentTemplate.currency).toBe("USD");
+    expect(paymentTemplate.quote_schema).toBeTruthy();
+    expect(paymentTemplate.refund_or_cancellation_note).toBeTruthy();
+  });
+
+  it("loads projects from duck-typed default exports and hyphenated tool-manual paths", async () => {
+    const projectDir = await createObjectProject({ manualFileName: "tool-manual.json" });
+
+    const project = await loadProject(projectDir);
+
+    expect(project.adapter_path).toMatch(/adapter\.mjs$/);
+    expect(project.tool_manual_path).toMatch(/tool-manual\.json$/);
+    expect(project.manifest.capability_key).toBe("price-compare-helper");
+  });
+
+  it("rejects empty and ambiguous project roots", async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), "siglume-empty-project-"));
+    await expect(loadProject(emptyDir)).rejects.toThrow("No adapter TypeScript/JavaScript file found");
+
+    const ambiguousDir = await mkdtemp(join(tmpdir(), "siglume-ambiguous-project-"));
+    await writeFile(join(ambiguousDir, "a.mjs"), "export default {};\n", "utf8");
+    await writeFile(join(ambiguousDir, "b.mjs"), "export default {};\n", "utf8");
+    await expect(loadProject(ambiguousDir)).rejects.toThrow("Multiple adapter files found");
+  });
+
+  it("guards init template collisions", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "siglume-init-project-"));
+    await writeInitTemplate("echo", dir);
+    await expect(writeInitTemplate("echo", dir)).rejects.toThrow("adapter.ts already exists");
+  });
+
+  it("scores remote projects and marks non-publishable remote reports as failed", async () => {
+    const projectDir = await createObjectProject();
+    const report = await scoreProject(projectDir, "remote", {
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () =>
+        ({
+          async preview_quality_score() {
+            return {
+              overall_score: 82,
+              grade: "B",
+              issues: [],
+              keyword_coverage_estimate: 18,
+              improvement_suggestions: [],
+              publishable: false,
+              validation_ok: true,
+              validation_errors: [],
+              validation_warnings: [],
+            };
+          },
+        }) as unknown as SiglumeClientShape,
+    });
+
+    expect(report.mode).toBe("remote");
+    expect(report.ok).toBe(false);
+  });
+
+  it("allows injected clients without resolving real credentials", async () => {
+    const projectDir = await createObjectProject();
+    let receivedApiKey: string | null = null;
+
+    const report = await validateProject(projectDir, {
+      env: {},
+      client_factory: (api_key: string) => {
+        receivedApiKey = api_key;
+        return {
+          async preview_quality_score() {
+            return {
+              overall_score: 95,
+              grade: "A",
+              issues: [],
+              keyword_coverage_estimate: 20,
+              improvement_suggestions: [],
+              publishable: true,
+              validation_ok: true,
+              validation_errors: [],
+              validation_warnings: [],
+            };
+          },
+        } as unknown as SiglumeClientShape;
+      },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(receivedApiKey).toBe("siglume_test_key");
+  });
+
+  it("covers registration, support, and usage helper branches", async () => {
+    const projectDir = await createObjectProject();
+    const usageCapture = { api_key: undefined as string | undefined, usage_calls: 0 };
+
+    const submitReview = await runRegistration(
+      projectDir,
+      { submit_review: true },
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async auto_register() {
+              return { listing_id: "lst_123", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+            async submit_review() {
+              return {
+                listing_id: "lst_123",
+                capability_key: "price-compare-helper",
+                name: "Price Compare Helper",
+                status: "pending_review",
+                dry_run_supported: true,
+                price_value_minor: 0,
+                currency: "USD",
+                submission_blockers: [],
+                raw: {},
+              };
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    const confirmSkip = await runRegistration(
+      projectDir,
+      { confirm: true, submit_review: true },
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async auto_register() {
+              return { listing_id: "lst_123", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+            async confirm_registration() {
+              return {
+                listing_id: "lst_123",
+                status: "pending_review",
+                release: {},
+                quality: { overall_score: 80, grade: "B", issues: [], improvement_suggestions: [], raw: {} },
+                raw: {},
+              };
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    const supportReport = await createSupportCaseReport(
+      { subject: "Need help", body: "details", trace_id: "trc_123" },
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async create_support_case(subject: string, body: string, options?: { trace_id?: string }) {
+              return {
+                support_case_id: "case_1",
+                case_type: "app_execution",
+                summary: `${subject}:${body}:${options?.trace_id}`,
+                status: "open",
+                metadata: {},
+                raw: {},
+              };
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    const usageTopLevelHome = await mkdtemp(join(tmpdir(), "siglume-home-top-"));
+    await mkdir(join(usageTopLevelHome, ".siglume"), { recursive: true });
+    await writeFile(join(usageTopLevelHome, ".siglume", "credentials.toml"), 'api_key = "sig_top"\n', "utf8");
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = usageTopLevelHome;
+    process.env.USERPROFILE = usageTopLevelHome;
+    try {
+      const usageReport = await getUsageReport(
+        { window: "7d" },
+        {
+          env: {},
+          client_factory: usageClientFactory(usageCapture, false),
+        },
+      );
+
+      expect(usageReport.count).toBe(1);
+      expect(usageCapture.api_key).toBe("siglume_test_key");
+    } finally {
+      process.env.HOME = previousHome;
+      process.env.USERPROFILE = previousUserProfile;
+    }
+
+    const usageNestedHome = await mkdtemp(join(tmpdir(), "siglume-home-nested-"));
+    await mkdir(join(usageNestedHome, ".siglume"), { recursive: true });
+    await writeFile(
+      join(usageNestedHome, ".siglume", "credentials.toml"),
+      ['[default]', 'api_key = "sig_nested"', ""].join("\n"),
+      "utf8",
+    );
+
+    process.env.HOME = usageNestedHome;
+    process.env.USERPROFILE = usageNestedHome;
+    try {
+      const usageCaptureNested = { api_key: undefined as string | undefined, usage_calls: 0 };
+      const usageReport = await getUsageReport(
+        { window: "30d" },
+        {
+          env: {},
+          client_factory: usageClientFactory(usageCaptureNested, true),
+        },
+      );
+
+      expect(usageReport.window).toBe("30d");
+      expect(usageCaptureNested.api_key).toBe("siglume_test_key");
+    } finally {
+      process.env.HOME = previousHome;
+      process.env.USERPROFILE = previousUserProfile;
+    }
+
+    expect((submitReview.review as { listing_id: string }).listing_id).toBe("lst_123");
+    expect(confirmSkip.submit_review_skipped).toBe(true);
+    expect((supportReport.case as { summary: string }).summary).toBe("Need help:details:trc_123");
+    expect(usageCapture.usage_calls).toBe(1);
+  });
+
+  it("resolves credentials files when using the default client path", async () => {
+    const credentialsHome = await mkdtemp(join(tmpdir(), "siglume-home-default-client-"));
+    await mkdir(join(credentialsHome, ".siglume"), { recursive: true });
+    await writeFile(join(credentialsHome, ".siglume", "credentials.toml"), 'api_key = "sig_top"\n', "utf8");
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    const originalFetch = globalThis.fetch;
+    let authorizationHeader: string | null = null;
+    process.env.HOME = credentialsHome;
+    process.env.USERPROFILE = credentialsHome;
+    globalThis.fetch = (async (_input, init) => {
+      const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+      authorizationHeader = headers.get("authorization");
+      return new Response(
+        JSON.stringify({
+          data: {
+            items: [],
+            next_cursor: null,
+            limit: 50,
+            offset: 0,
+          },
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    try {
+      const usageReport = await getUsageReport({ window: "7d" }, { env: {} });
+      expect(usageReport.count).toBe(0);
+      expect(authorizationHeader).toBe("Bearer sig_top");
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.env.HOME = previousHome;
+      process.env.USERPROFILE = previousUserProfile;
+    }
+  });
+});

--- a/siglume-api-sdk-ts/test/runtime-extra.test.ts
+++ b/siglume-api-sdk-ts/test/runtime-extra.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  StubProvider,
+} from "../src/index";
+import type { ExecutionContext, ExecutionResult } from "../src/index";
+
+class RecordingApp extends AppAdapter {
+  lastContext: ExecutionContext | null = null;
+
+  manifest() {
+    return {
+      capability_key: "price-compare-helper",
+      name: "Price Compare Helper",
+      job_to_be_done: "Compare retailer prices for a product and return the best offer.",
+      category: AppCategory.COMMERCE,
+      permission_class: PermissionClass.READ_ONLY,
+      approval_mode: ApprovalMode.AUTO,
+      dry_run_supported: true,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Returns a structured offer comparison.",
+      example_prompts: ["Compare prices for Sony headphones."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    this.lastContext = ctx;
+    return {
+      success: true,
+      output: { summary: "ok", task_type: ctx.task_type },
+    };
+  }
+}
+
+class BrokenManifestApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "Bad Key",
+      name: "",
+      job_to_be_done: "",
+      category: AppCategory.FINANCE,
+      permission_class: PermissionClass.PAYMENT,
+      approval_mode: ApprovalMode.AUTO,
+      dry_run_supported: false,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      example_prompts: [],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: { summary: "broken" },
+    };
+  }
+}
+
+describe("runtime helpers", () => {
+  it("normalizes execution results and injects stub connected accounts", async () => {
+    const app = new RecordingApp();
+    const harness = new AppTestHarness(app, { stripe: new StubProvider("stripe") });
+
+    const result = await harness.dry_run("lookup_price", {
+      input_params: { query: "Sony WH-1000XM5" },
+      trace_id: "trc_123",
+      idempotency_key: "idem_123",
+      metadata: { source: "test" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.execution_kind).toBe("dry_run");
+    expect(result.units_consumed).toBe(1);
+    expect(result.amount_minor).toBe(0);
+    expect(result.currency).toBe("USD");
+    expect(result.provider_status).toBe("ok");
+    expect(app.lastContext?.connected_accounts?.stripe?.provider_key).toBe("stripe");
+    expect(app.lastContext?.metadata).toEqual({ source: "test" });
+    expect(app.lastContext?.trace_id).toBe("trc_123");
+    expect(app.supported_task_types()).toEqual(["default"]);
+    await expect(app.on_install("agent", "owner")).resolves.toBeUndefined();
+    await expect(app.on_uninstall("agent", "owner")).resolves.toBeUndefined();
+    await expect(app.health_check()).resolves.toEqual({ healthy: true, message: "" });
+  });
+
+  it("reports manifest and receipt issues for risky app definitions", async () => {
+    const harness = new AppTestHarness(new BrokenManifestApp());
+
+    expect(await harness.validate_manifest()).toEqual(
+      expect.arrayContaining([
+        "capability_key must be lowercase alphanumeric with hyphens (e.g., 'price-compare-helper')",
+        "name is required",
+        "job_to_be_done is required",
+        "at least one example_prompt is recommended",
+        "action/payment apps should support dry_run",
+        "action/payment apps should not use auto approval",
+      ]),
+    );
+
+    const issues = harness.validate_receipt({
+      success: true,
+      execution_kind: "payment",
+      output: { summary: "charged" },
+      needs_approval: true,
+      artifacts: [{} as never],
+      side_effects: [{ action: "", provider: "" }],
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        "needs_approval=True but no approval_prompt or approval_hint provided",
+        "artifacts[0].artifact_type is empty",
+        "side_effects[0].action is empty",
+        "side_effects[0].provider is empty",
+      ]),
+    );
+  });
+
+  it("supports stub providers and optional tool-manual validation", async () => {
+    const stub = new StubProvider("stripe");
+    await expect(stub.handle("quotes.create", { amount_minor: 1500 })).resolves.toEqual({
+      status: "stub_ok",
+      provider: "stripe",
+      method: "quotes.create",
+      params: { amount_minor: 1500 },
+    });
+
+    const harness = new AppTestHarness(new RecordingApp());
+    expect(harness.validate_tool_manual()).toEqual([true, []]);
+    const missing = await harness.simulate_connected_account_missing("lookup_price", {
+      input_params: { query: "headphones" },
+    });
+    expect(missing.execution_kind).toBe("dry_run");
+  });
+});

--- a/siglume-api-sdk-ts/test/tool-manual-grader-extra.test.ts
+++ b/siglume-api-sdk-ts/test/tool-manual-grader-extra.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { score_tool_manual_offline, score_tool_manual_remote } from "../src/index";
+import { cloneBase } from "./manual-fixtures";
+
+describe("tool manual grader extra branches", () => {
+  it("covers the remote scorer wrapper", async () => {
+    const report = await score_tool_manual_remote(cloneBase(), {
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            quality: {
+              overall_score: 95,
+              grade: "A",
+              publishable: true,
+              keyword_coverage_estimate: 24,
+              issues: [],
+              improvement_suggestions: [],
+            },
+          }),
+          { status: 200 },
+        ),
+    });
+
+    expect(report.grade).toBe("A");
+    expect(report.publishable).toBe(true);
+  });
+
+  it("reports missing and malformed major sections", () => {
+    const manual = cloneBase();
+    manual.trigger_conditions = [123, "Use when helpful", "Ultimate shopping tool"];
+    manual.do_not_use_when = [456, "same words as helpful shopping tool"];
+    manual.summary_for_model = 123;
+    manual.input_schema = "bad";
+    manual.output_schema = { type: "object", properties: {}, required: ["summary"], additionalProperties: false };
+    manual.usage_hints = "bad";
+    manual.result_hints = [];
+    manual.error_hints = ["short"];
+
+    const report = score_tool_manual_offline(manual);
+
+    expect(report.issues.some((issue) => issue.field === "trigger_conditions[0]")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "do_not_use_when[0]")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "summary_for_model")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "input_schema")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "output_schema" && issue.severity === "warning")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "usage_hints")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "result_hints")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "error_hints" && issue.severity === "suggestion")).toBe(true);
+  });
+
+  it("checks nested schema descriptions and enum quality", () => {
+    const manual = cloneBase();
+    manual.input_schema = {
+      type: "object",
+      properties: {
+        query: { type: "string", description: 99 },
+        filters: {
+          type: "object",
+          properties: {
+            nested: "bad",
+          },
+        },
+        rows: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              code: { type: "string", description: "tiny", enum: ["a", "b"] },
+            },
+          },
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    };
+
+    const report = score_tool_manual_offline(manual);
+
+    expect(report.issues.some((issue) => issue.field === "input_schema.properties.query")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "input_schema.properties.nested")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "input_schema.properties.code")).toBe(true);
+  });
+
+  it("emits every improvement suggestion when quality is broadly weak", () => {
+    const manual = cloneBase();
+    manual.trigger_conditions = ["Use this", "Call tool", "If helpful"];
+    manual.do_not_use_when = [123, "short"];
+    manual.summary_for_model = "Amazing";
+    manual.input_schema = {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "" },
+        store: { type: "string", description: 99 },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    };
+    manual.output_schema = {
+      type: "object",
+      properties: {
+        summary: { type: "string" },
+        details: { type: "string" },
+        url: { type: "string" },
+      },
+      required: ["summary", "details", "url"],
+      additionalProperties: false,
+    };
+    manual.usage_hints = [];
+    manual.result_hints = [];
+    manual.error_hints = [];
+
+    const report = score_tool_manual_offline(manual);
+
+    expect(["C", "D"]).toContain(report.grade);
+    expect(report.improvement_suggestions).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Improve trigger_conditions"),
+        expect.stringContaining("Add descriptions to all input_schema properties"),
+        expect.stringContaining("Rewrite summary_for_model"),
+        expect.stringContaining("Add concrete do_not_use_when conditions"),
+        expect.stringContaining("Add descriptions to output_schema properties"),
+        expect.stringContaining("Expand usage_hints and result_hints"),
+      ]),
+    );
+  });
+
+  it("handles to_dict wrappers and critical hint issues", () => {
+    const wrapped = {
+      to_dict() {
+        const manual = cloneBase();
+        manual.usage_hints = [{ bad: true }];
+        manual.result_hints = [123];
+        manual.error_hints = [false];
+        return manual;
+      },
+    };
+
+    const report = score_tool_manual_offline(wrapped);
+
+    expect(report.publishable).toBe(false);
+    expect(report.issues.filter((issue) => issue.severity === "critical")).toHaveLength(3);
+  });
+});

--- a/siglume-api-sdk-ts/test/tool-manual-grader.test.ts
+++ b/siglume-api-sdk-ts/test/tool-manual-grader.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { score_tool_manual_offline, validate_tool_manual } from "../src/index";
+import { buildParityCases, cloneBase, EXPECTED_PARITY } from "./manual-fixtures";
+
+describe("tool manual offline grader", () => {
+  for (const [caseName, manual] of buildParityCases()) {
+    it(`stays within parity window for ${caseName}`, () => {
+      const report = score_tool_manual_offline(manual);
+      const expected = EXPECTED_PARITY[caseName]!;
+      expect(Math.abs(report.overall_score - expected.overall_score)).toBeLessThanOrEqual(5);
+      expect(report.keyword_coverage_estimate).toBe(expected.keyword_coverage_estimate);
+    });
+  }
+
+  it("exposes validation and publishable state", () => {
+    const manual = cloneBase();
+    delete manual.usage_hints;
+
+    const report = score_tool_manual_offline(manual);
+
+    expect(report.validation_ok).toBe(false);
+    expect(report.publishable).toBe(false);
+    expect(report.validation_errors?.some((issue) => issue.code === "MISSING_FIELD")).toBe(true);
+    expect(report.issues.some((issue) => issue.field === "usage_hints")).toBe(true);
+  });
+
+  it("blocks publishable status for non-string hint items", () => {
+    const manual = cloneBase();
+    manual.usage_hints = [123];
+
+    const report = score_tool_manual_offline(manual);
+
+    expect(report.overall_score).toBe(90);
+    expect(report.publishable).toBe(false);
+    expect(report.issues.some((issue) => issue.field === "usage_hints[0]" && issue.severity === "critical")).toBe(true);
+  });
+
+  it("validates a well-formed baseline manual", () => {
+    const [ok, issues] = validate_tool_manual(cloneBase());
+    expect(ok).toBe(true);
+    expect(issues).toHaveLength(0);
+  });
+});

--- a/siglume-api-sdk-ts/test/utils.test.ts
+++ b/siglume-api-sdk-ts/test/utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDefaultI18n,
+  buildRegistrationStubSource,
+  camelCaseFromCapabilityKey,
+  coerceMapping,
+  parseRetryAfter,
+  renderJson,
+  stringOrNull,
+  toJsonable,
+  toRecord,
+} from "../src/utils";
+
+describe("utils", () => {
+  it("converts rich values to jsonable payloads", () => {
+    const value = {
+      visible: 1,
+      _hidden: "skip",
+      nested: [
+        {
+          to_dict() {
+            return { ok: true };
+          },
+        },
+      ],
+      jsonLike: {
+        toJSON() {
+          return { rendered: "yes" };
+        },
+      },
+      weird: new Date("2026-04-19T00:00:00Z"),
+    };
+
+    expect(toJsonable(value)).toEqual({
+      visible: 1,
+      nested: [{ ok: true }],
+      jsonLike: { rendered: "yes" },
+      weird: "2026-04-19T00:00:00.000Z",
+    });
+  });
+
+  it("coerces mapping-like objects and renders json consistently", () => {
+    expect(coerceMapping({ ok: true }, "payload")).toEqual({ ok: true });
+    expect(() => coerceMapping("nope", "payload")).toThrow("payload must be a mapping-like object");
+    expect(renderJson({ alpha: 1, beta: null })).toContain("\"alpha\": 1");
+  });
+
+  it("handles retry-after parsing and string coercion helpers", () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter("wat")).toBeNull();
+    expect(parseRetryAfter("-1")).toBeNull();
+    expect(parseRetryAfter("2")).toBe(2000);
+    expect(stringOrNull(undefined)).toBeNull();
+    expect(stringOrNull("   ")).toBeNull();
+    expect(stringOrNull("  ok ")).toBe("ok");
+    expect(toRecord("bad")).toEqual({});
+    expect(toRecord({ ok: true })).toEqual({ ok: true });
+  });
+
+  it("builds registration helpers from capability metadata", () => {
+    expect(camelCaseFromCapabilityKey("price_compare-helper")).toBe("PriceCompareHelperApp");
+    expect(camelCaseFromCapabilityKey("")).toBe("GeneratedRegistrationApp");
+
+    const i18n = buildDefaultI18n({
+      name: "Quote App",
+      job_to_be_done: "Quote a USD charge",
+      short_description: "Preview a payment before approval",
+    });
+    expect(i18n).toEqual({
+      job_to_be_done_en: "Quote a USD charge",
+      job_to_be_done_ja: "Quote a USD charge",
+      short_description_en: "Preview a payment before approval",
+      short_description_ja: "Preview a payment before approval",
+    });
+
+    const source = buildRegistrationStubSource(
+      {
+        capability_key: "payment-quote",
+        name: "Payment Quote",
+      },
+      {
+        job_to_be_done: "Quote and capture a USD payment",
+      },
+    );
+    expect(source).toContain("class PaymentQuoteApp extends AppAdapter");
+    expect(source).toContain("\"capability_key\": \"payment-quote\"");
+    expect(source).toContain("\"job_to_be_done\": \"Quote and capture a USD payment\"");
+  });
+});

--- a/siglume-api-sdk-ts/test/validator-extra.test.ts
+++ b/siglume-api-sdk-ts/test/validator-extra.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { tool_manual_to_dict, validate_tool_manual } from "../src/tool-manual-validator";
+import { cloneBase } from "./manual-fixtures";
+
+describe("validate_tool_manual extra branches", () => {
+  it("rejects invalid roots and bad scalar constraints", () => {
+    const [invalidRootOk, invalidRootIssues] = validate_tool_manual("not a dict");
+    expect(invalidRootOk).toBe(false);
+    expect(invalidRootIssues[0]?.code).toBe("INVALID_ROOT");
+
+    const manual = cloneBase();
+    manual.tool_name = "bad name!";
+    manual.job_to_be_done = "short";
+    manual.summary_for_model = "short";
+    manual.trigger_conditions = new Array(9).fill(
+      "owner asks to compare prices for a product before deciding where to buy",
+    );
+    manual.do_not_use_when = new Array(6).fill(
+      "the request is to complete checkout or place an order instead of comparing offers",
+    );
+
+    const [ok, issues] = validate_tool_manual(manual);
+    expect(ok).toBe(false);
+    expect(issues.some((issue) => issue.code === "INVALID_TOOL_NAME")).toBe(true);
+    expect(issues.some((issue) => issue.field === "trigger_conditions" && issue.code === "TOO_MANY_ITEMS")).toBe(true);
+    expect(issues.some((issue) => issue.field === "do_not_use_when" && issue.code === "TOO_MANY_ITEMS")).toBe(true);
+  });
+
+  it("supports to_dict coercion and action/payment field validation", () => {
+    const wrapped = {
+      to_dict() {
+        const manual = cloneBase();
+        manual.permission_class = "payment";
+        manual.approval_summary_template = "";
+        manual.preview_schema = "bad";
+        manual.side_effect_summary = "";
+        manual.jurisdiction = "usa";
+        manual.idempotency_support = false;
+        manual.quote_schema = "bad";
+        manual.currency = "JPY";
+        manual.settlement_mode = "invalid";
+        manual.refund_or_cancellation_note = "";
+        manual.output_schema = {
+          type: "object",
+          properties: {
+            total: { type: "number" },
+          },
+          required: [],
+          additionalProperties: false,
+        };
+        return manual;
+      },
+    };
+
+    const [ok, issues] = validate_tool_manual(wrapped);
+
+    expect(ok).toBe(false);
+    expect(issues.some((issue) => issue.field === "approval_summary_template")).toBe(true);
+    expect(issues.some((issue) => issue.field === "preview_schema")).toBe(true);
+    expect(issues.some((issue) => issue.field === "jurisdiction" && issue.code === "INVALID_JURISDICTION")).toBe(true);
+    expect(issues.some((issue) => issue.field === "idempotency_support" && issue.code === "IDEMPOTENCY_REQUIRED")).toBe(true);
+    expect(issues.some((issue) => issue.field === "currency" && issue.code === "INVALID_CURRENCY")).toBe(true);
+    expect(issues.some((issue) => issue.field === "settlement_mode" && issue.code === "INVALID_SETTLEMENT_MODE")).toBe(true);
+    expect(issues.some((issue) => issue.field === "output_schema.properties" && issue.code === "OUTPUT_SCHEMA")).toBe(true);
+    expect(issues.some((issue) => issue.field === "output_schema.required" && issue.code === "OUTPUT_SCHEMA")).toBe(true);
+  });
+
+  it("exports mapping-like manuals as plain dicts", () => {
+    expect(tool_manual_to_dict({ tool_name: "echo_tool" })).toEqual({ tool_name: "echo_tool" });
+    expect(tool_manual_to_dict("bad" as unknown as Record<string, unknown>)).toEqual({});
+  });
+});

--- a/siglume-api-sdk-ts/test/validator.test.ts
+++ b/siglume-api-sdk-ts/test/validator.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { validate_tool_manual } from "../src/index";
+import { cloneBase } from "./manual-fixtures";
+
+describe("validate_tool_manual", () => {
+  it("flags hyphenated permission classes and missing payment fields", () => {
+    const manual = cloneBase();
+    manual.permission_class = "read-only";
+
+    const [ok, issues] = validate_tool_manual(manual);
+
+    expect(ok).toBe(false);
+    expect(issues.some((issue) => issue.code === "INVALID_PERMISSION_CLASS")).toBe(true);
+  });
+
+  it("rejects nested composition keywords and patternProperties", () => {
+    const manual = cloneBase();
+    manual.input_schema = {
+      type: "object",
+      properties: {
+        query: {
+          type: "object",
+          oneOf: [{ type: "string" }, { type: "number" }],
+          patternProperties: { "^x-": { type: "string" } },
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    };
+
+    const [ok, issues] = validate_tool_manual(manual);
+
+    expect(ok).toBe(false);
+    expect(issues.some((issue) => issue.field === "input_schema.query.oneOf")).toBe(true);
+    expect(issues.some((issue) => issue.field === "input_schema.query.patternProperties")).toBe(true);
+  });
+
+  it("warns about platform-injected input fields", () => {
+    const manual = cloneBase();
+    (manual.input_schema as Record<string, unknown>).properties = {
+      query: { type: "string", description: "Product query." },
+      trace_id: { type: "string", description: "should be omitted" },
+    };
+
+    const [, issues] = validate_tool_manual(manual);
+
+    expect(issues.some((issue) => issue.field === "input_schema.properties.trace_id" && issue.severity === "warning")).toBe(true);
+  });
+
+  it("requires payment-specific output fields", () => {
+    const manual = cloneBase();
+    manual.permission_class = "payment";
+    manual.approval_summary_template = "Charge USD {amount_usd}.";
+    manual.preview_schema = { type: "object", properties: { summary: { type: "string", description: "Preview" } }, required: ["summary"], additionalProperties: false };
+    manual.idempotency_support = true;
+    manual.side_effect_summary = "Captures a USD payment.";
+    manual.quote_schema = { type: "object", properties: { amount_usd: { type: "number", description: "Amount" } }, required: ["amount_usd"], additionalProperties: false };
+    manual.currency = "USD";
+    manual.settlement_mode = "embedded_wallet_charge";
+    manual.refund_or_cancellation_note = "Refunds follow merchant policy.";
+    manual.jurisdiction = "US";
+
+    const [ok, issues] = validate_tool_manual(manual);
+
+    expect(ok).toBe(false);
+    expect(issues.some((issue) => issue.field === "output_schema.required")).toBe(true);
+  });
+});

--- a/siglume-api-sdk-ts/tsconfig.json
+++ b/siglume-api-sdk-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "tsup.config.ts"]
+}

--- a/siglume-api-sdk-ts/tsup.config.ts
+++ b/siglume-api-sdk-ts/tsup.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: {
+      index: "src/index.ts",
+    },
+    format: ["esm", "cjs"],
+    dts: {
+      entry: {
+        index: "src/index.ts",
+      },
+    },
+    target: "es2022",
+    platform: "neutral",
+    sourcemap: true,
+    splitting: false,
+    clean: true,
+    outDir: "dist",
+  },
+  {
+    entry: {
+      "cli/index": "src/cli/index.ts",
+      "bin/siglume": "src/bin/siglume.ts",
+    },
+    format: ["esm", "cjs"],
+    dts: {
+      entry: {
+        "cli/index": "src/cli/index.ts",
+      },
+    },
+    target: "node18",
+    platform: "node",
+    sourcemap: true,
+    splitting: false,
+    clean: false,
+    banner: {
+      js: "#!/usr/bin/env node",
+    },
+    outDir: "dist",
+  },
+]);

--- a/siglume-api-sdk-ts/vitest.config.ts
+++ b/siglume-api-sdk-ts/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.ts"],
+      // v0.4 acceptance requires package coverage >= 85% while also preventing
+      // regressions in branch/function-heavy runtime paths.
+      thresholds: {
+        branches: 74,
+        functions: 71,
+        lines: 85,
+        statements: 85,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a new siglume-api-sdk-ts/ package for @siglume/api-sdk with ESM + CJS builds
- implement TS runtime parity for AppAdapter, AppTestHarness, SiglumeClient, offline ToolManual scoring, and the siglume CLI
- add vitest coverage, package/build checks, and runtime smoke verification for Node/Bun plus Deno library import

## Validation
- [x] py -3.11 -m pytest in public repo -> 45 passed
- [x] py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\\contract_sync.py -> passed
- [x] py -3.11 scripts\\contract_sync.py -> passed
- [x] 
pm test -> 70 passed, line/statement coverage 85.60%
- [x] 
pm run typecheck -> passed
- [x] 
pm run build -> passed
- [x] 
pm pack --json -> 332872 bytes package size
- [x] 
ode dist/bin/siglume.cjs --help -> passed
- [x] 
ode --input-type=module library smoke -> passed
- [x] un@1.3.12 library smoke -> passed
- [x] deno@2.7.12 library smoke -> passed

## Review
- [x] Reviewer agent (Dalton): no critical / warning remaining

## Notes
- Base branch is elease/v0.3.0 because the public main branch is still behind the active v0.3.x line; this keeps the PR scoped to PR-E only rather than reintroducing already-shipped v0.3 commits.
- Deno smoke was executed against the latest npm-published Deno CLI available in this environment (2.7.12).