### PR TITLE
fix(lint): resolve 23 ruff errors blocking CI on main

### DIFF
--- a/scripts/contract_sync.py
+++ b/scripts/contract_sync.py
@@ -12,7 +12,7 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from siglume_api_sdk import validate_tool_manual
+from siglume_api_sdk import validate_tool_manual  # noqa: E402
 
 
 DOC_FILES = (

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -31,7 +31,7 @@ for _name, _value in vars(_legacy).items():
         continue
     globals()[_name] = _value
 
-from .client import (  # noqa: E402
+from .client import (  # noqa: E402, F401
     AccessGrantRecord,
     AppListingRecord,
     AutoRegistrationReceipt,
@@ -52,6 +52,6 @@ from .client import (  # noqa: E402
     SupportCaseRecord,
     UsageEventRecord,
 )
-from .tool_manual_grader import score_tool_manual_offline, score_tool_manual_remote  # noqa: E402
+from .tool_manual_grader import score_tool_manual_offline, score_tool_manual_remote  # noqa: E402, F401
 
 __all__ = [name for name in globals() if not name.startswith("_")]

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -9,7 +9,7 @@ SCRIPTS_DIR = ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-import contract_sync
+import contract_sync  # noqa: E402
 
 
 def test_docs_and_contracts_are_in_sync() -> None:


### PR DESCRIPTION
## Summary
CI on \`main\` went red after PR #96 (release/v0.3.0 consolidation) due to 23 ruff lint errors that slipped through the PR-E / PR-C2 / v0.3.1 work.

- 21 F401 on \`siglume_api_sdk/__init__.py\` re-exports (dynamic \`__all__\` confuses ruff)
- 2 E402 on \`contract_sync.py\` / \`test_contract_sync.py\` imports after \`sys.path.insert()\`

## Fix
Minimal noqa additions. No logic changes.

## Verification
- \`py -3.11 -m ruff check .\` → All checks passed!
- \`py -3.11 -m pytest\` → 45 passed (no regression)