### PR TITLE
fix(cli-ts): return non-zero exit code on filesystem errors (Codex P1 on #95)

### DIFF
--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 
 import { SiglumeProjectError } from "../errors";
 import { renderJson } from "../utils";
@@ -165,9 +165,14 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
       emit(stderr, error.message);
       return 1;
     }
-    if (error instanceof Error && "code" in error) {
-      return Number((error as { exitCode?: number }).exitCode ?? 0);
+    if (error instanceof CommanderError) {
+      // Help / version displays carry exitCode 0; parse errors carry a non-zero code.
+      // Commander exits are the only class whose exitCode we trust; everything else falls through.
+      return typeof error.exitCode === "number" ? error.exitCode : 1;
     }
-    throw error;
+    // Node system errors (ENOENT, EACCES, ...) and any other uncaught throw
+    // are real failures — never report success just because the object has a `code` field.
+    emit(stderr, error instanceof Error ? error.message : String(error));
+    return 1;
   }
 }

--- a/siglume-api-sdk-ts/test/cli-advanced.test.ts
+++ b/siglume-api-sdk-ts/test/cli-advanced.test.ts
@@ -196,4 +196,17 @@ describe("siglume CLI advanced branches", () => {
     expect(helpExit).toBe(0);
     expect(badExit).toBe(1);
   });
+
+  it("returns non-zero exit code on filesystem errors (Node system errors)", async () => {
+    const stderr: string[] = [];
+    const nonexistent = join(tmpdir(), `siglume-nonexistent-${Date.now()}-${Math.random()}`);
+    const exitCode = await runCli(["validate", nonexistent], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      client_factory: () => createMockClient(true),
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
Codex bot P1 finding on PR #95 (public) and PR #56 (mirror): the CLI catch-all
branch \`if (error instanceof Error && \"code\" in error)\` routed Node system
errors (ENOENT, EACCES, ...) through the Commander path and returned
\`exitCode ?? 0\` — so \`siglume validate /nonexistent/path\` silently reported
success while the command had actually failed. CI and scripts would pass
regressions undetected.

## Fix
- Narrow the Commander branch to \`instanceof CommanderError\`, return
  \`exitCode ?? 1\` (so help/version keep their 0, parse errors get their
  non-zero code, and any edge case defaults to 1)
- Add an all-other-errors fallthrough that emits a stderr line and returns
  1 — Node system errors and uncaught throws are now real failures

## Test
New test in \`cli-advanced.test.ts\` asserts that \`runCli(['validate', '<nonexistent path>'])\`
returns non-zero. Would have failed on the old code.

## Verification
- \`npm test\` → 71 passed (was 70)
- Coverage: line 85.68% (floor: 85%)