### PR TITLE
feat(assist): add LLM ToolManual drafting helpers (PR-D)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -401,7 +401,7 @@ If your API needs OAuth tokens or API keys from the agent owner (e.g., X/Twitter
 
 ### What languages can I write APIs in?
 
-**Python** is currently the only supported language. TypeScript and Go support are under consideration.
+**Python** and **TypeScript** are supported today. Go support is still under consideration.
 
 ### How do I update my API?
 
@@ -992,6 +992,29 @@ else:
 ```
 
 This catches structural errors instantly without a network round-trip.
+
+If you want a starting draft instead of writing the ToolManual from scratch,
+the SDK also includes LLM helpers that run local validation and offline
+scoring before they return a result:
+
+```python
+from siglume_api_sdk.assist import OpenAIProvider, draft_tool_manual, fill_tool_manual_gaps
+
+draft = draft_tool_manual(
+    capability_key="currency-converter-jp",
+    job_to_be_done="Convert USD amounts to JPY with live rates",
+    permission_class="read_only",
+    llm=OpenAIProvider(),
+)
+
+filled = fill_tool_manual_gaps(
+    partial_manual={"tool_name": "currency_converter_jp", "permission_class": "read_only"},
+    source_code_hint="def convert(amount_usd: float) -> dict[str, object]: ...",
+    llm=OpenAIProvider(),
+)
+```
+
+Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` explicitly before using these helpers.
 
 ### Sandbox testing with public endpoints
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ pip install -e .
 python examples/hello_price_compare.py
 ```
 
+Draft a ToolManual with the bundled LLM helpers:
+
+```python
+from siglume_api_sdk.assist import AnthropicProvider, draft_tool_manual
+
+result = draft_tool_manual(
+    capability_key="currency-converter-jp",
+    job_to_be_done="Convert USD amounts to JPY with live rates",
+    permission_class="read_only",
+    llm=AnthropicProvider(),
+)
+
+print(result.quality_report.grade)
+print(result.tool_manual["summary_for_model"])
+```
+
+Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` before using the helper or the bundled [generate_tool_manual.py](./examples/generate_tool_manual.py) example.
+
 ## Example templates
 
 `hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, and `payment_quote.py` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
@@ -189,6 +207,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | `ToolManualIssue` | Single validation or quality issue |
 | `ToolManualQualityReport` | Quality score (0-100, grade A-F) |
 | `validate_tool_manual()` | Client-side validation (mirrors server rules) |
+| `draft_tool_manual()` / `fill_tool_manual_gaps()` | Generate or repair ToolManual content with offline scoring + retry |
 | `AppTestHarness` | Local sandbox test runner (incl. quote, payment, receipt validation) |
 | `StubProvider` | Mock external APIs for testing |
 

--- a/examples/generate_tool_manual.py
+++ b/examples/generate_tool_manual.py
@@ -1,0 +1,92 @@
+"""Generate or repair a ToolManual with the bundled LLM providers."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AnthropicProvider,
+    OpenAIProvider,
+    draft_tool_manual,
+    fill_tool_manual_gaps,
+)
+
+
+def build_partial_manual() -> dict[str, Any]:
+    return {
+        "tool_name": "currency_converter_jp",
+        "job_to_be_done": "Convert USD amounts to JPY with live rates for quoting and reporting tasks.",
+        "permission_class": "read_only",
+        "dry_run_supported": True,
+        "requires_connected_accounts": [],
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "amount_usd": {"type": "number", "description": "USD amount to convert."},
+            },
+            "required": ["amount_usd"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line summary of the converted amount."},
+                "amount_jpy": {"type": "number", "description": "Converted amount in JPY."},
+            },
+            "required": ["summary", "amount_jpy"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _serialize(value: Any) -> Any:
+    if is_dataclass(value):
+        return {key: _serialize(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {key: _serialize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_serialize(item) for item in value]
+    return value
+
+
+def build_provider():
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return AnthropicProvider()
+    if os.environ.get("OPENAI_API_KEY"):
+        return OpenAIProvider()
+    raise SystemExit("Set ANTHROPIC_API_KEY or OPENAI_API_KEY before running this example.")
+
+
+def main() -> None:
+    provider = build_provider()
+
+    draft = draft_tool_manual(
+        capability_key="currency-converter-jp",
+        job_to_be_done="Convert USD amounts to JPY with live rates",
+        permission_class="read_only",
+        llm=provider,
+    )
+    print("=== full draft ===")
+    print(json.dumps(_serialize(draft), indent=2, ensure_ascii=False))
+
+    filled = fill_tool_manual_gaps(
+        partial_manual=build_partial_manual(),
+        source_code_hint="""
+def convert(amount_usd: float) -> dict[str, object]:
+    # returns live USD/JPY conversion data for quoting tasks
+    return {"summary": "...", "amount_jpy": 1512.0}
+""".strip(),
+        llm=provider,
+    )
+    print("=== gap filler ===")
+    print(json.dumps(_serialize(filled), indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ py-modules = ["siglume_api_sdk", "siglume_api_sdk_aiworks"]
 
 [tool.setuptools.packages.find]
 include = ["siglume_api_sdk*"]
+
+[tool.setuptools.package-data]
+siglume_api_sdk = ["prompts/*.md"]

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -3,3 +3,20 @@
 TypeScript runtime for building, testing, and registering Siglume developer apps.
 
 This package is prepared in the public SDK repo and ships with the v0.4 release line.
+
+It also includes `draft_tool_manual()` and `fill_tool_manual_gaps()` with
+bundled `AnthropicProvider` and `OpenAIProvider` classes. Provide
+`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`, then:
+
+```ts
+import { AnthropicProvider, draft_tool_manual } from "@siglume/api-sdk";
+
+const result = await draft_tool_manual({
+  capability_key: "currency-converter-jp",
+  job_to_be_done: "Convert USD amounts to JPY with live rates",
+  permission_class: "read_only",
+  llm: new AnthropicProvider(),
+});
+
+console.log(result.quality_report.grade);
+```

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.16.5",
-        "@vitest/coverage-v8": "^2.1.8",
+        "@vitest/coverage-istanbul": "^2.1.9",
         "tsup": "^8.3.0",
         "typescript": "^5.6.3",
         "vitest": "^2.1.8"
@@ -26,17 +26,155 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -57,6 +195,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
@@ -72,6 +232,38 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -84,12 +276,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -543,6 +729,16 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -918,22 +1114,20 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
+    "node_modules/@vitest/coverage-istanbul": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
-      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.9.tgz",
+      "integrity": "sha512-vdYE4FkC/y2lxcN3Dcj54Bw+ericmDwiex0B8LV5F/YNYEYP1mgVwhPnHwWGAXu38qizkjOuyczKbFTALfzFKw==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
         "debug": "^4.3.7",
         "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.12",
         "magicast": "^0.3.5",
-        "std-env": "^3.8.0",
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -941,13 +1135,7 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "2.1.9",
         "vitest": "2.1.9"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -1128,6 +1316,18 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1138,6 +1338,39 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/bundle-require": {
@@ -1163,6 +1396,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -1245,6 +1498,12 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1289,6 +1548,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1342,6 +1607,15 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -1418,6 +1692,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/glob": {
@@ -1510,6 +1793,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -1581,6 +1880,36 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lilconfig": {
@@ -1727,6 +2056,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2358,6 +2693,36 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -3044,6 +3409,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     }
   }
 }

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.16.5",
-    "@vitest/coverage-v8": "^2.1.8",
+    "@vitest/coverage-istanbul": "^2.1.9",
     "tsup": "^8.3.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"

--- a/siglume-api-sdk-ts/src/errors.ts
+++ b/siglume-api-sdk-ts/src/errors.ts
@@ -11,6 +11,8 @@ export class SiglumeProjectError extends SiglumeError {}
 
 export class SiglumeValidationError extends SiglumeError {}
 
+export class SiglumeAssistError extends SiglumeClientError {}
+
 export class SiglumeNotFoundError extends SiglumeClientError {}
 
 export class SiglumeAPIError extends SiglumeClientError {

--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./client";
 export * from "./errors";
 export * from "./runtime";
+export * from "./tool-manual-assist";
 export * from "./tool-manual-grader";
 export * from "./tool-manual-validator";
 export * from "./types";

--- a/siglume-api-sdk-ts/src/tool-manual-assist.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-assist.ts
@@ -1,0 +1,823 @@
+import { SiglumeAssistError } from "./errors";
+import { score_tool_manual_offline } from "./tool-manual-grader";
+import { validate_tool_manual } from "./tool-manual-validator";
+import type { ToolManual, ToolManualQualityReport } from "./types";
+import { isRecord } from "./utils";
+
+const ALL_TOOL_MANUAL_FIELDS = [
+  "tool_name",
+  "job_to_be_done",
+  "summary_for_model",
+  "trigger_conditions",
+  "do_not_use_when",
+  "permission_class",
+  "dry_run_supported",
+  "requires_connected_accounts",
+  "input_schema",
+  "output_schema",
+  "usage_hints",
+  "result_hints",
+  "error_hints",
+  "approval_summary_template",
+  "preview_schema",
+  "idempotency_support",
+  "side_effect_summary",
+  "quote_schema",
+  "currency",
+  "settlement_mode",
+  "refund_or_cancellation_note",
+  "jurisdiction",
+  "legal_notes",
+] as const;
+const BASE_REQUIRED_FIELDS = [
+  "tool_name",
+  "job_to_be_done",
+  "summary_for_model",
+  "trigger_conditions",
+  "do_not_use_when",
+  "permission_class",
+  "dry_run_supported",
+  "requires_connected_accounts",
+  "input_schema",
+  "output_schema",
+  "usage_hints",
+  "result_hints",
+  "error_hints",
+] as const;
+const ACTION_REQUIRED_FIELDS = [
+  "approval_summary_template",
+  "preview_schema",
+  "idempotency_support",
+  "side_effect_summary",
+  "jurisdiction",
+] as const;
+const PAYMENT_REQUIRED_FIELDS = [
+  "quote_schema",
+  "currency",
+  "settlement_mode",
+  "refund_or_cancellation_note",
+] as const;
+const PAYMENT_SETTLEMENT_MODES = [
+  "stripe_checkout",
+  "stripe_payment_intent",
+  "polygon_mandate",
+  "embedded_wallet_charge",
+] as const;
+const VALID_PERMISSION_CLASSES = new Set(["read_only", "action", "payment"]);
+
+export const TOOL_MANUAL_DRAFT_PROMPT = `# Siglume ToolManual Draft System Prompt
+
+You generate ToolManual payloads for the Siglume Agent API Store.
+
+Follow these rules on every response:
+
+1. Return only the structured payload requested by the caller's JSON schema.
+2. ToolManual permission_class values are \`read_only\`, \`action\`, and \`payment\`.
+3. Use factual, specific language. Do not use marketing words, hype, or vague phrases.
+4. \`trigger_conditions\` must describe concrete situations where the tool is the right next step.
+5. \`do_not_use_when\` must describe concrete situations where another tool or response is safer.
+6. \`summary_for_model\` should explain the tool's capability in one short factual paragraph.
+7. \`usage_hints\`, \`result_hints\`, and \`error_hints\` should help an agent decide how to invoke and explain the tool.
+8. For \`action\` and \`payment\`, include owner-approval framing, idempotency, and a governing \`jurisdiction\`.
+9. For \`payment\`, \`currency\` must be \`USD\` and \`settlement_mode\` must be one of the documented Siglume values.
+10. When filling gaps, keep non-target fields unchanged and only improve the requested fields.
+`;
+
+type ToolManualField = (typeof ALL_TOOL_MANUAL_FIELDS)[number];
+type FetchLike = typeof fetch;
+
+interface ProviderConfig {
+  provider_name: string;
+  default_model: string;
+  api_key_env: string;
+  default_base_url: string;
+  price_table: Record<string, { input: number; output: number; cache_write?: number; cache_read?: number }>;
+}
+
+export interface StructuredGenerationUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+}
+
+export interface ToolManualAssistAttempt {
+  attempt_number: number;
+  provider: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  estimated_cost_usd: number | null;
+  overall_score: number;
+  grade: string;
+  validation_ok: boolean;
+}
+
+export interface ToolManualAssistMetadata {
+  mode: "draft" | "gap_fill";
+  provider: string;
+  model: string;
+  attempts: ToolManualAssistAttempt[];
+  attempt_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_input_tokens: number;
+  total_cache_read_input_tokens: number;
+  total_estimated_cost_usd: number | null;
+}
+
+export interface ToolManualAssistResult {
+  tool_manual: ToolManual;
+  quality_report: ToolManualQualityReport;
+  metadata: ToolManualAssistMetadata;
+}
+
+interface StructuredGenerationResult {
+  payload: Record<string, unknown>;
+  usage: StructuredGenerationUsage;
+}
+
+export abstract class LLMProvider {
+  provider_name: string;
+  model: string;
+  api_key: string;
+  base_url: string;
+  timeout_ms: number;
+  protected readonly fetchImpl: FetchLike;
+  private readonly price_table: ProviderConfig["price_table"];
+
+  protected constructor(
+    options: {
+      api_key?: string;
+      model?: string;
+      base_url?: string;
+      fetch?: FetchLike;
+      timeout_ms?: number;
+    } = {},
+    config: ProviderConfig,
+  ) {
+    this.provider_name = config.provider_name;
+    this.model = options.model ?? config.default_model;
+    this.base_url = options.base_url ?? config.default_base_url;
+    this.timeout_ms = options.timeout_ms ?? 30_000;
+    this.api_key = options.api_key ?? readEnv(config.api_key_env) ?? "";
+    if (!this.api_key) {
+      throw new SiglumeAssistError(
+        `${this.constructor.name} requires an API key via the constructor or ${config.api_key_env}.`,
+      );
+    }
+    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.price_table = config.price_table;
+  }
+
+  abstract generateStructured(options: {
+    system_prompt: string;
+    user_prompt: string;
+    output_schema: Record<string, unknown>;
+  }): Promise<StructuredGenerationResult>;
+
+  estimate_cost_usd(usage: StructuredGenerationUsage): number | null {
+    const pricing = this.price_table[this.model];
+    if (!pricing) {
+      return null;
+    }
+    const inputCost = (usage.input_tokens * pricing.input) / 1_000_000;
+    const outputCost = (usage.output_tokens * pricing.output) / 1_000_000;
+    const cacheWriteCost = (usage.cache_creation_input_tokens * (pricing.cache_write ?? pricing.input)) / 1_000_000;
+    const cacheReadCost = (usage.cache_read_input_tokens * (pricing.cache_read ?? 0)) / 1_000_000;
+    return Number((inputCost + outputCost + cacheWriteCost + cacheReadCost).toFixed(8));
+  }
+
+  protected async fetchJson(url: string, init: RequestInit): Promise<unknown> {
+    const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+    const timeout = controller ? setTimeout(() => controller.abort(), this.timeout_ms) : undefined;
+    try {
+      const response = await this.fetchImpl(url, { ...init, signal: controller?.signal });
+      if (!response.ok) {
+        throw new SiglumeAssistError(
+          `${this.provider_name} API request failed: ${response.status} ${await response.text()}`,
+        );
+      }
+      return response.json();
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  }
+}
+
+export class AnthropicProvider extends LLMProvider {
+  constructor(options: { api_key?: string; model?: string; base_url?: string; fetch?: FetchLike; timeout_ms?: number } = {}) {
+    super(options, {
+      provider_name: "anthropic",
+      default_model: "claude-sonnet-4-6",
+      api_key_env: "ANTHROPIC_API_KEY",
+      default_base_url: "https://api.anthropic.com/v1/messages",
+      price_table: {
+        "claude-sonnet-4-6": {
+          input: 3.0,
+          output: 15.0,
+          cache_write: 3.75,
+          cache_read: 0.3,
+        },
+      },
+    });
+  }
+
+  async generateStructured(options: {
+    system_prompt: string;
+    user_prompt: string;
+    output_schema: Record<string, unknown>;
+  }): Promise<StructuredGenerationResult> {
+    const payload = await this.fetchJson(this.base_url, {
+      method: "POST",
+      headers: {
+        "x-api-key": this.api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: 3200,
+        system: [
+          {
+            type: "text",
+            text: options.system_prompt,
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+        messages: [{ role: "user", content: options.user_prompt }],
+        tools: [
+          {
+            name: "emit_tool_manual",
+            description: "Return a ToolManual payload that matches the supplied JSON schema exactly.",
+            input_schema: options.output_schema,
+            strict: true,
+          },
+        ],
+        tool_choice: { type: "tool", name: "emit_tool_manual" },
+      }),
+    });
+    if (!isRecord(payload)) {
+      throw new SiglumeAssistError("AnthropicProvider returned a non-object payload.");
+    }
+    const content = Array.isArray(payload.content) ? payload.content : [];
+    const toolUse = content.find(
+      (item) => isRecord(item) && item.type === "tool_use" && item.name === "emit_tool_manual",
+    );
+    if (!isRecord(toolUse?.input)) {
+      throw new SiglumeAssistError("AnthropicProvider did not return an emit_tool_manual tool_use payload.");
+    }
+    const usageBlock = isRecord(payload.usage) ? payload.usage : {};
+    return {
+      payload: { ...toolUse.input },
+      usage: {
+        input_tokens: safeInt(usageBlock.input_tokens),
+        output_tokens: safeInt(usageBlock.output_tokens),
+        cache_creation_input_tokens: safeInt(usageBlock.cache_creation_input_tokens),
+        cache_read_input_tokens: safeInt(usageBlock.cache_read_input_tokens),
+      },
+    };
+  }
+}
+
+export class OpenAIProvider extends LLMProvider {
+  constructor(options: { api_key?: string; model?: string; base_url?: string; fetch?: FetchLike; timeout_ms?: number } = {}) {
+    super(options, {
+      provider_name: "openai",
+      default_model: "gpt-5.4",
+      api_key_env: "OPENAI_API_KEY",
+      default_base_url: "https://api.openai.com/v1/responses",
+      price_table: {
+        "gpt-5.4": { input: 2.5, output: 15.0 },
+        "gpt-5": { input: 1.25, output: 10.0 },
+      },
+    });
+  }
+
+  async generateStructured(options: {
+    system_prompt: string;
+    user_prompt: string;
+    output_schema: Record<string, unknown>;
+  }): Promise<StructuredGenerationResult> {
+    const payload = await this.fetchJson(this.base_url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.api_key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        instructions: options.system_prompt,
+        input: options.user_prompt,
+        store: false,
+        text: {
+          format: {
+            type: "json_schema",
+            name: "tool_manual",
+            strict: true,
+            schema: options.output_schema,
+          },
+        },
+      }),
+    });
+    if (!isRecord(payload)) {
+      throw new SiglumeAssistError("OpenAIProvider returned a non-object payload.");
+    }
+    return {
+      payload: parseOpenAIPayload(payload),
+      usage: {
+        input_tokens: safeInt(isRecord(payload.usage) ? payload.usage.input_tokens : undefined),
+        output_tokens: safeInt(isRecord(payload.usage) ? payload.usage.output_tokens : undefined),
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    };
+  }
+}
+
+export async function draft_tool_manual(options: {
+  capability_key: string;
+  job_to_be_done: string;
+  permission_class: ToolManual["permission_class"];
+  llm: LLMProvider;
+  source_code_hint?: string;
+  max_attempts?: number;
+}): Promise<ToolManualAssistResult> {
+  const seedManual = buildSeedManual(options);
+  return runAssistLoop({
+    llm: options.llm,
+    mode: "draft",
+    seed_manual: seedManual,
+    current_manual: null,
+    target_fields: [...ALL_TOOL_MANUAL_FIELDS],
+    output_schema: buildToolManualSchema(options.permission_class, [...ALL_TOOL_MANUAL_FIELDS]),
+    source_code_hint: options.source_code_hint,
+    max_attempts: options.max_attempts ?? 3,
+  });
+}
+
+export async function fill_tool_manual_gaps(options: {
+  partial_manual: Record<string, unknown>;
+  source_code_hint?: string;
+  llm: LLMProvider;
+  max_attempts?: number;
+}): Promise<ToolManualAssistResult> {
+  const currentManual = normalizeToolManual(options.partial_manual);
+  const initialReport = score_tool_manual_offline(currentManual);
+  const inferredPermissionClass = inferPermissionClass(currentManual);
+  let targetFields = collectTargetFields(currentManual, initialReport, inferredPermissionClass);
+  if (!VALID_PERMISSION_CLASSES.has(String(currentManual.permission_class ?? "")) && inferredPermissionClass === null) {
+    targetFields = [...ALL_TOOL_MANUAL_FIELDS];
+  }
+  if (targetFields.length === 0 && initialReport.validation_ok && (initialReport.grade === "A" || initialReport.grade === "B")) {
+    return {
+      tool_manual: currentManual,
+      quality_report: initialReport,
+      metadata: {
+        mode: "gap_fill",
+        provider: options.llm.provider_name,
+        model: options.llm.model,
+        attempts: [],
+        attempt_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cache_creation_input_tokens: 0,
+        total_cache_read_input_tokens: 0,
+        total_estimated_cost_usd: 0,
+      },
+    };
+  }
+  return runAssistLoop({
+    llm: options.llm,
+    mode: "gap_fill",
+    seed_manual: null,
+    current_manual: currentManual,
+    target_fields: targetFields,
+    output_schema: buildToolManualSchema(
+      inferredPermissionClass ?? "read_only",
+      targetFields,
+    ),
+    source_code_hint: options.source_code_hint,
+    max_attempts: options.max_attempts ?? 3,
+  });
+}
+
+function buildSeedManual(options: {
+  capability_key: string;
+  job_to_be_done: string;
+  permission_class: ToolManual["permission_class"];
+}): Record<string, unknown> {
+  const seed: Record<string, unknown> = {
+    tool_name: options.capability_key.replaceAll("-", "_"),
+    job_to_be_done: options.job_to_be_done,
+    permission_class: options.permission_class,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+  };
+  if (options.permission_class === "action" || options.permission_class === "payment") {
+    seed.jurisdiction = "US";
+    seed.idempotency_support = true;
+  }
+  if (options.permission_class === "payment") {
+    seed.currency = "USD";
+  }
+  return seed;
+}
+
+async function runAssistLoop(options: {
+  llm: LLMProvider;
+  mode: "draft" | "gap_fill";
+  seed_manual: Record<string, unknown> | null;
+  current_manual: ToolManual | null;
+  target_fields: readonly ToolManualField[];
+  output_schema: Record<string, unknown>;
+  source_code_hint?: string;
+  max_attempts: number;
+}): Promise<ToolManualAssistResult> {
+  let feedback: Record<string, unknown> | null = null;
+  const metadata: ToolManualAssistMetadata = {
+    mode: options.mode,
+    provider: options.llm.provider_name,
+    model: options.llm.model,
+    attempts: [],
+    attempt_count: 0,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cache_creation_input_tokens: 0,
+    total_cache_read_input_tokens: 0,
+    total_estimated_cost_usd: 0,
+  };
+  let lastReport: ToolManualQualityReport | null = null;
+  for (let attemptNumber = 1; attemptNumber <= options.max_attempts; attemptNumber += 1) {
+    const generation = await options.llm.generateStructured({
+      system_prompt: TOOL_MANUAL_DRAFT_PROMPT,
+      user_prompt: buildUserPrompt({
+        mode: options.mode,
+        seed_manual: options.seed_manual,
+        current_manual: options.current_manual,
+        target_fields: options.target_fields,
+        source_code_hint: options.source_code_hint,
+        feedback,
+      }),
+      output_schema: options.output_schema,
+    });
+    let candidate = normalizeToolManual(generation.payload);
+    if (options.mode === "gap_fill" && options.current_manual) {
+      candidate = mergeToolManualPatch(options.current_manual, candidate, options.target_fields);
+    }
+    const report = score_tool_manual_offline(candidate);
+    const [validation_ok, validation_issues] = validate_tool_manual(candidate);
+    report.validation_ok = Boolean(report.validation_ok) && validation_ok;
+    if ((report.validation_errors?.length ?? 0) === 0) {
+      report.validation_errors = validation_issues.filter((issue) => issue.severity === "error");
+    }
+    const attempt: ToolManualAssistAttempt = {
+      attempt_number: attemptNumber,
+      provider: options.llm.provider_name,
+      model: options.llm.model,
+      input_tokens: generation.usage.input_tokens,
+      output_tokens: generation.usage.output_tokens,
+      cache_creation_input_tokens: generation.usage.cache_creation_input_tokens,
+      cache_read_input_tokens: generation.usage.cache_read_input_tokens,
+      estimated_cost_usd: options.llm.estimate_cost_usd(generation.usage),
+      overall_score: report.overall_score,
+      grade: report.grade,
+      validation_ok: report.validation_ok ?? false,
+    };
+    metadata.attempts.push(attempt);
+    metadata.attempt_count = metadata.attempts.length;
+    metadata.total_input_tokens += attempt.input_tokens;
+    metadata.total_output_tokens += attempt.output_tokens;
+    metadata.total_cache_creation_input_tokens += attempt.cache_creation_input_tokens;
+    metadata.total_cache_read_input_tokens += attempt.cache_read_input_tokens;
+    metadata.total_estimated_cost_usd =
+      metadata.total_estimated_cost_usd === null || attempt.estimated_cost_usd === null
+        ? null
+        : Number((metadata.total_estimated_cost_usd + attempt.estimated_cost_usd).toFixed(8));
+    lastReport = report;
+    if (attempt.validation_ok && (attempt.grade === "A" || attempt.grade === "B")) {
+      return {
+        tool_manual: candidate,
+        quality_report: report,
+        metadata,
+      };
+    }
+    feedback = buildFeedback(report);
+  }
+  throw new SiglumeAssistError(
+    `ToolManual generation did not reach grade B or better after ${options.max_attempts} attempts. Last grade: ${lastReport?.grade ?? "F"}.`,
+  );
+}
+
+function buildUserPrompt(options: {
+  mode: "draft" | "gap_fill";
+  seed_manual: Record<string, unknown> | null;
+  current_manual: ToolManual | null;
+  target_fields: readonly ToolManualField[];
+  source_code_hint?: string;
+  feedback: Record<string, unknown> | null;
+}): string {
+  return [
+    "Generate a Siglume ToolManual payload that satisfies the requested JSON schema.",
+    "Use factual, concrete wording. Avoid marketing language and vague phrases.",
+    "ToolManual.permission_class must use read_only, action, or payment.",
+    "For payment tools, currency must be USD.",
+    "For gap_fill mode, preserve every non-target field exactly as provided in current_manual.",
+    "Return only the structured payload required by the schema.",
+    "",
+    JSON.stringify(
+      {
+        mode: options.mode,
+        seed_manual: options.seed_manual,
+        current_manual: options.current_manual,
+        target_fields: [...options.target_fields],
+        source_code_hint: options.source_code_hint ?? null,
+        feedback_from_previous_attempt: options.feedback,
+      },
+      null,
+      2,
+    ),
+  ].join("\n");
+}
+
+function collectTargetFields(
+  manual: ToolManual,
+  report: ToolManualQualityReport,
+  permissionClass: ToolManual["permission_class"] | null = null,
+): ToolManualField[] {
+  const targetFields = new Set<ToolManualField>();
+  for (const fieldName of BASE_REQUIRED_FIELDS) {
+    if (isFieldMissingOrEmpty(fieldName, manual[fieldName])) {
+      targetFields.add(fieldName);
+    }
+  }
+  const effectivePermissionClass = permissionClass ?? manual.permission_class;
+  if (effectivePermissionClass === "action" || effectivePermissionClass === "payment") {
+    for (const fieldName of ACTION_REQUIRED_FIELDS) {
+      if (isFieldMissingOrEmpty(fieldName, manual[fieldName])) {
+        targetFields.add(fieldName);
+      }
+    }
+  }
+  if (effectivePermissionClass === "payment") {
+    for (const fieldName of PAYMENT_REQUIRED_FIELDS) {
+      if (isFieldMissingOrEmpty(fieldName, manual[fieldName])) {
+        targetFields.add(fieldName);
+      }
+    }
+  }
+  const [validation_ok, validation_issues] = validate_tool_manual(manual);
+  if (!validation_ok) {
+    for (const issue of validation_issues) {
+      const root = rootField(issue.field);
+      if (root && ALL_TOOL_MANUAL_FIELDS.includes(root)) {
+        targetFields.add(root);
+      }
+    }
+  }
+  if (report.grade !== "A" && report.grade !== "B") {
+    for (const issue of report.issues) {
+      const root = rootField(issue.field);
+      if (root && ALL_TOOL_MANUAL_FIELDS.includes(root)) {
+        targetFields.add(root);
+      }
+    }
+  }
+  return [...targetFields];
+}
+
+function buildFeedback(report: ToolManualQualityReport): Record<string, unknown> {
+  return {
+    overall_score: report.overall_score,
+    grade: report.grade,
+    issues: report.issues.map((issue) => ({
+      field: issue.field ?? null,
+      message: issue.message,
+      severity: issue.severity,
+      suggestion: issue.suggestion ?? null,
+    })),
+    improvement_suggestions: [...report.improvement_suggestions],
+  };
+}
+
+function mergeToolManualPatch(
+  currentManual: ToolManual,
+  patch: ToolManual,
+  targetFields: readonly ToolManualField[],
+): ToolManual {
+  const merged: Record<string, unknown> = { ...currentManual };
+  for (const fieldName of targetFields) {
+    if (fieldName in patch) {
+      merged[fieldName] = patch[fieldName];
+    }
+  }
+  return normalizeToolManual(merged);
+}
+
+function normalizeToolManual(raw: Record<string, unknown>): ToolManual {
+  const normalized: Record<string, unknown> = {};
+  for (const fieldName of ALL_TOOL_MANUAL_FIELDS) {
+    if (!(fieldName in raw)) {
+      continue;
+    }
+    const value = raw[fieldName];
+    if (fieldName === "trigger_conditions" || fieldName === "do_not_use_when" || fieldName === "requires_connected_accounts" || fieldName === "usage_hints" || fieldName === "result_hints" || fieldName === "error_hints") {
+      normalized[fieldName] = Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+      continue;
+    }
+    if (fieldName === "input_schema" || fieldName === "output_schema" || fieldName === "preview_schema" || fieldName === "quote_schema") {
+      normalized[fieldName] = normalizeSchema(value);
+      continue;
+    }
+    if (fieldName === "dry_run_supported" || fieldName === "idempotency_support") {
+      normalized[fieldName] = Boolean(value);
+      continue;
+    }
+    if (fieldName === "currency" && typeof value === "string") {
+      normalized[fieldName] = value.toUpperCase();
+      continue;
+    }
+    normalized[fieldName] = value;
+  }
+  return normalized as unknown as ToolManual;
+}
+
+function normalizeSchema(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) {
+    return { ...value };
+  }
+  if (typeof value === "string") {
+    try {
+      const decoded = JSON.parse(value);
+      return isRecord(decoded) ? decoded : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function buildToolManualSchema(
+  permissionClass: ToolManual["permission_class"] | "read_only",
+  fields: readonly ToolManualField[],
+): Record<string, unknown> {
+  const properties: Record<ToolManualField, Record<string, unknown>> = {
+    tool_name: { type: "string", minLength: 3, maxLength: 64 },
+    job_to_be_done: { type: "string", minLength: 10, maxLength: 500 },
+    summary_for_model: { type: "string", minLength: 10, maxLength: 300 },
+    trigger_conditions: {
+      type: "array",
+      items: { type: "string", minLength: 10, maxLength: 200 },
+      minItems: 1,
+    },
+    do_not_use_when: {
+      type: "array",
+      items: { type: "string", minLength: 1, maxLength: 200 },
+      minItems: 1,
+    },
+    permission_class: { type: "string", enum: ["read_only", "action", "payment"] },
+    dry_run_supported: { type: "boolean" },
+    requires_connected_accounts: { type: "array", items: { type: "string" } },
+    input_schema: { type: "object" },
+    output_schema: { type: "object" },
+    usage_hints: { type: "array", items: { type: "string" } },
+    result_hints: { type: "array", items: { type: "string" } },
+    error_hints: { type: "array", items: { type: "string" } },
+    approval_summary_template: { type: "string" },
+    preview_schema: { type: "object" },
+    idempotency_support: { type: "boolean" },
+    side_effect_summary: { type: "string" },
+    quote_schema: { type: "object" },
+    currency: { type: "string", enum: ["USD"] },
+    settlement_mode: { type: "string", enum: [...PAYMENT_SETTLEMENT_MODES] },
+    refund_or_cancellation_note: { type: "string" },
+    jurisdiction: { type: "string" },
+    legal_notes: { type: "string" },
+  };
+  const selectedFields = [...new Set(fields)];
+  let required = [...selectedFields];
+  if (selectedFields.length === ALL_TOOL_MANUAL_FIELDS.length) {
+    required = [...BASE_REQUIRED_FIELDS];
+    if (permissionClass === "action" || permissionClass === "payment") {
+      required.push(...ACTION_REQUIRED_FIELDS);
+    }
+    if (permissionClass === "payment") {
+      required.push(...PAYMENT_REQUIRED_FIELDS);
+    }
+  }
+  return {
+    type: "object",
+    properties: Object.fromEntries(selectedFields.map((fieldName) => [fieldName, properties[fieldName]])),
+    required,
+    additionalProperties: false,
+  };
+}
+
+function parseOpenAIPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  if (typeof payload.output_text === "string" && payload.output_text.trim().length > 0) {
+    try {
+      const decoded = JSON.parse(payload.output_text);
+      if (isRecord(decoded)) {
+        return { ...decoded };
+      }
+    } catch {
+      throw new SiglumeAssistError("OpenAI Responses output_text did not contain valid JSON.");
+    }
+  }
+  if (Array.isArray(payload.output)) {
+    for (const item of payload.output) {
+      if (!isRecord(item) || !Array.isArray(item.content)) {
+        continue;
+      }
+      for (const block of item.content) {
+        if (!isRecord(block) || typeof block.text !== "string") {
+          continue;
+        }
+        try {
+          const decoded = JSON.parse(block.text);
+          if (isRecord(decoded)) {
+            return { ...decoded };
+          }
+        } catch {
+          continue;
+        }
+      }
+    }
+  }
+  throw new SiglumeAssistError("OpenAIProvider did not return a structured JSON object.");
+}
+
+function rootField(fieldName: string | undefined): ToolManualField | null {
+  if (!fieldName) {
+    return null;
+  }
+  const root = fieldName.split("[", 1)[0]?.split(".", 1)[0];
+  if (root && ALL_TOOL_MANUAL_FIELDS.includes(root as ToolManualField)) {
+    return root as ToolManualField;
+  }
+  return null;
+}
+
+function inferPermissionClass(manual: ToolManual): ToolManual["permission_class"] | null {
+  if (VALID_PERMISSION_CLASSES.has(String(manual.permission_class ?? ""))) {
+    return manual.permission_class;
+  }
+  if (PAYMENT_REQUIRED_FIELDS.some((fieldName) => !isFieldMissingOrEmpty(fieldName, manual[fieldName]))) {
+    return "payment";
+  }
+  if (ACTION_REQUIRED_FIELDS.some((fieldName) => !isFieldMissingOrEmpty(fieldName, manual[fieldName]))) {
+    return "action";
+  }
+  return null;
+}
+
+function isMissingOrEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (isRecord(value)) {
+    return Object.keys(value).length === 0;
+  }
+  return false;
+}
+
+function isFieldMissingOrEmpty(fieldName: ToolManualField, value: unknown): boolean {
+  if (fieldName === "requires_connected_accounts" && Array.isArray(value)) {
+    return false;
+  }
+  return isMissingOrEmpty(value);
+}
+
+function safeInt(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function readEnv(name: string): string | undefined {
+  const processEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
+  if (processEnv && typeof processEnv[name] === "string" && processEnv[name]) {
+    return processEnv[name];
+  }
+  const bunEnv = (globalThis as { Bun?: { env?: Record<string, string | undefined> } }).Bun?.env;
+  if (bunEnv && typeof bunEnv[name] === "string" && bunEnv[name]) {
+    return bunEnv[name];
+  }
+  const denoEnv = (globalThis as { Deno?: { env?: { get: (key: string) => string | undefined } } }).Deno?.env;
+  if (denoEnv && typeof denoEnv.get === "function") {
+    const value = denoEnv.get(name);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/siglume-api-sdk-ts/test/tool-manual-assist.test.ts
+++ b/siglume-api-sdk-ts/test/tool-manual-assist.test.ts
@@ -146,7 +146,7 @@ class StubProvider extends LLMProvider {
 describe("tool-manual assist", () => {
   it("keeps the TS prompt in sync with the Python markdown prompt", async () => {
     const pythonPrompt = await readFile(join(process.cwd(), "..", "siglume_api_sdk", "prompts", "tool_manual_draft.md"), "utf8");
-    expect(TOOL_MANUAL_DRAFT_PROMPT.trim()).toBe(pythonPrompt.trim());
+    expect(TOOL_MANUAL_DRAFT_PROMPT.replace(/\r\n/g, "\n").trim()).toBe(pythonPrompt.replace(/\r\n/g, "\n").trim());
   });
 
   it("creates a full draft and returns metadata", async () => {

--- a/siglume-api-sdk-ts/test/tool-manual-assist.test.ts
+++ b/siglume-api-sdk-ts/test/tool-manual-assist.test.ts
@@ -1,0 +1,432 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SiglumeAssistError } from "../src/errors";
+import {
+  AnthropicProvider,
+  LLMProvider,
+  OpenAIProvider,
+  TOOL_MANUAL_DRAFT_PROMPT,
+  draft_tool_manual,
+  fill_tool_manual_gaps,
+} from "../src/tool-manual-assist";
+
+function goodManual() {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+    summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: [
+      "the request is to complete checkout or place an order instead of comparing offers",
+    ],
+    permission_class: "read_only" as const,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+        offers: { type: "array", items: { type: "object" }, description: "Ranked retailer offers." },
+      },
+      required: ["summary", "offers"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+    result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
+    error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+  };
+}
+
+function goodPaymentManual() {
+  return {
+    ...goodManual(),
+    permission_class: "payment" as const,
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the quoted payment." },
+        amount_usd: { type: "number", description: "Quoted USD amount." },
+        currency: { type: "string", description: "Currency code for the quote." },
+      },
+      required: ["summary", "amount_usd", "currency"],
+      additionalProperties: false,
+    },
+    approval_summary_template: "Charge USD {amount_usd}.",
+    preview_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Preview of the payment attempt." },
+      },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+    idempotency_support: true,
+    side_effect_summary: "Captures a USD payment if the owner approves.",
+    quote_schema: {
+      type: "object",
+      properties: {
+        amount_usd: { type: "number", description: "Quoted USD amount." },
+        currency: { type: "string", description: "Currency code for the quote." },
+      },
+      required: ["amount_usd", "currency"],
+      additionalProperties: false,
+    },
+    currency: "USD",
+    settlement_mode: "embedded_wallet_charge" as const,
+    refund_or_cancellation_note: "Refunds follow the merchant cancellation policy.",
+    jurisdiction: "US",
+  };
+}
+
+function weakManual() {
+  return {
+    ...goodManual(),
+    summary_for_model: "Bad.",
+    trigger_conditions: ["use when helpful", "for many tasks", "any request"],
+    usage_hints: [],
+    result_hints: [],
+    error_hints: [],
+  };
+}
+
+class StubProvider extends LLMProvider {
+  private readonly payloads: Array<Record<string, unknown>>;
+  calls = 0;
+  lastOutputSchema: Record<string, unknown> | null = null;
+
+  constructor(payloads: Array<Record<string, unknown>>) {
+    super(
+      { api_key: "stub-key" },
+      {
+        provider_name: "stub",
+        default_model: "stub-model",
+        api_key_env: "STUB_API_KEY",
+        default_base_url: "https://stub.example.test",
+        price_table: {},
+      },
+    );
+    this.payloads = payloads;
+  }
+
+  async generateStructured(options: {
+    system_prompt: string;
+    user_prompt: string;
+    output_schema: Record<string, unknown>;
+  }): Promise<{ payload: Record<string, unknown>; usage: { input_tokens: number; output_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number } }> {
+    this.lastOutputSchema = options.output_schema;
+    const payload = this.payloads[Math.min(this.calls, this.payloads.length - 1)]!;
+    this.calls += 1;
+    return {
+      payload,
+      usage: {
+        input_tokens: 100 * this.calls,
+        output_tokens: 20 * this.calls,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    };
+  }
+}
+
+describe("tool-manual assist", () => {
+  it("keeps the TS prompt in sync with the Python markdown prompt", async () => {
+    const pythonPrompt = await readFile(join(process.cwd(), "..", "siglume_api_sdk", "prompts", "tool_manual_draft.md"), "utf8");
+    expect(TOOL_MANUAL_DRAFT_PROMPT.trim()).toBe(pythonPrompt.trim());
+  });
+
+  it("creates a full draft and returns metadata", async () => {
+    const result = await draft_tool_manual({
+      capability_key: "price-compare-helper",
+      job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+      permission_class: "read_only",
+      llm: new StubProvider([goodManual()]),
+    });
+
+    expect(result.tool_manual.tool_name).toBe("price_compare_helper");
+    expect(result.quality_report.grade).toMatch(/[AB]/);
+    expect(result.metadata.attempt_count).toBe(1);
+    expect(result.metadata.total_input_tokens).toBe(100);
+  });
+
+  it("fills only missing fields while preserving existing valid fields", async () => {
+    const partial = goodManual();
+    delete (partial as Partial<typeof partial>).summary_for_model;
+    partial.usage_hints = [];
+
+    const result = await fill_tool_manual_gaps({
+      partial_manual: partial,
+      llm: new StubProvider([
+        {
+          summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+          usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+        },
+      ]),
+    });
+
+    expect(result.tool_manual.tool_name).toBe("price_compare_helper");
+    expect(result.tool_manual.summary_for_model).toContain("structured comparison");
+    expect(result.tool_manual.usage_hints.length).toBeGreaterThan(0);
+  });
+
+  it("returns immediately for a valid gap-fill manual with no missing fields", async () => {
+    const provider = new StubProvider([goodManual()]);
+    const partial = {
+      ...goodManual(),
+      input_schema: JSON.stringify(goodManual().input_schema),
+      output_schema: JSON.stringify(goodManual().output_schema),
+    };
+
+    const result = await fill_tool_manual_gaps({
+      partial_manual: partial,
+      llm: provider,
+    });
+
+    expect(result.metadata.attempt_count).toBe(0);
+    expect(provider.calls).toBe(0);
+    expect(result.tool_manual.input_schema).toEqual(goodManual().input_schema);
+  });
+
+  it("recovers payment-only fields when permission_class is missing", async () => {
+    const partial = goodPaymentManual();
+    delete (partial as Partial<typeof partial>).permission_class;
+    delete (partial as Partial<typeof partial>).refund_or_cancellation_note;
+    const provider = new StubProvider([
+      {
+        permission_class: "payment",
+        refund_or_cancellation_note: "Refunds follow the merchant cancellation policy.",
+      },
+    ]);
+
+    const result = await fill_tool_manual_gaps({
+      partial_manual: partial,
+      llm: provider,
+    });
+
+    expect(provider.lastOutputSchema).not.toBeNull();
+    expect((provider.lastOutputSchema?.properties as Record<string, unknown>).refund_or_cancellation_note).toBeDefined();
+    expect(result.tool_manual.permission_class).toBe("payment");
+    expect(result.tool_manual.refund_or_cancellation_note).toBe("Refunds follow the merchant cancellation policy.");
+  });
+
+  it("retries until the draft reaches grade B or better", async () => {
+    const result = await draft_tool_manual({
+      capability_key: "price-compare-helper",
+      job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+      permission_class: "read_only",
+      llm: new StubProvider([weakManual(), goodManual()]),
+    });
+
+    expect(result.metadata.attempt_count).toBe(2);
+    expect(result.metadata.attempts[0]?.grade).not.toMatch(/[AB]/);
+    expect(result.metadata.attempts[1]?.grade).toMatch(/[AB]/);
+  });
+
+  it("raises after exhausting attempts", async () => {
+    await expect(
+      draft_tool_manual({
+        capability_key: "price-compare-helper",
+        job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+        permission_class: "read_only",
+        llm: new StubProvider([weakManual(), weakManual(), weakManual()]),
+        max_attempts: 3,
+      }),
+    ).rejects.toBeInstanceOf(SiglumeAssistError);
+  });
+
+  it("uses prompt caching for Anthropic requests", async () => {
+    const requests: Record<string, unknown>[] = [];
+    const provider = new AnthropicProvider({
+      api_key: "ant_test_key",
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({
+            content: [{ type: "tool_use", name: "emit_tool_manual", input: goodManual() }],
+            usage: {
+              input_tokens: 120,
+              output_tokens: 40,
+              cache_creation_input_tokens: 80,
+              cache_read_input_tokens: 0,
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    });
+
+    const result = await draft_tool_manual({
+      capability_key: "price-compare-helper",
+      job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+      permission_class: "read_only",
+      llm: provider,
+    });
+
+    expect(requests[0]?.tool_choice).toEqual({ type: "tool", name: "emit_tool_manual" });
+    expect((requests[0]?.system as Array<Record<string, unknown>>)[0]?.cache_control).toEqual({ type: "ephemeral" });
+    expect(result.metadata.attempts[0]?.estimated_cost_usd).not.toBeNull();
+  });
+
+  it("surfaces Anthropic transport and payload errors", async () => {
+    const brokenProvider = new AnthropicProvider({
+      api_key: "ant_test_key",
+      fetch: async () => new Response(JSON.stringify({ content: [] }), { status: 200 }),
+    });
+
+    await expect(
+      brokenProvider.generateStructured({
+        system_prompt: TOOL_MANUAL_DRAFT_PROMPT,
+        user_prompt: "return a tool manual",
+        output_schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      }),
+    ).rejects.toBeInstanceOf(SiglumeAssistError);
+
+    const httpErrorProvider = new AnthropicProvider({
+      api_key: "ant_test_key",
+      fetch: async () => new Response("boom", { status: 503 }),
+    });
+
+    await expect(
+      httpErrorProvider.generateStructured({
+        system_prompt: TOOL_MANUAL_DRAFT_PROMPT,
+        user_prompt: "return a tool manual",
+        output_schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      }),
+    ).rejects.toBeInstanceOf(SiglumeAssistError);
+  });
+
+  it("uses Responses text.format for OpenAI requests", async () => {
+    const requests: Record<string, unknown>[] = [];
+    const provider = new OpenAIProvider({
+      api_key: "openai_test_key",
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({
+            output_text: JSON.stringify(goodManual()),
+            usage: { input_tokens: 90, output_tokens: 30 },
+          }),
+          { status: 200 },
+        );
+      },
+    });
+
+    const result = await draft_tool_manual({
+      capability_key: "price-compare-helper",
+      job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+      permission_class: "read_only",
+      llm: provider,
+    });
+
+    expect(requests[0]?.store).toBe(false);
+    expect((requests[0]?.text as { format?: { type?: string } }).format?.type).toBe("json_schema");
+    expect(result.tool_manual.tool_name).toBe("price_compare_helper");
+  });
+
+  it("builds payment defaults into the draft prompt and can read env keys", async () => {
+    const requests: Record<string, unknown>[] = [];
+    const previous = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "openai_test_key";
+    try {
+      const provider = new OpenAIProvider({
+        fetch: async (_input, init) => {
+          requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+          return new Response(
+            JSON.stringify({
+              output_text: JSON.stringify(goodPaymentManual()),
+              usage: { input_tokens: 90, output_tokens: 30 },
+            }),
+            { status: 200 },
+          );
+        },
+      });
+
+      const result = await draft_tool_manual({
+        capability_key: "payment-quote",
+        job_to_be_done: "Quote a USD payment amount and complete the payment after approval.",
+        permission_class: "payment",
+        llm: provider,
+      });
+
+      expect(String(requests[0]?.input)).toContain("\"currency\": \"USD\"");
+      expect(String(requests[0]?.input)).toContain("\"jurisdiction\": \"US\"");
+      expect(result.tool_manual.permission_class).toBe("payment");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previous;
+      }
+    }
+  });
+
+  it("parses OpenAI fallback output blocks and rejects when no API key exists", async () => {
+    const previous = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    expect(() => new OpenAIProvider()).toThrow(SiglumeAssistError);
+    if (previous !== undefined) {
+      process.env.OPENAI_API_KEY = previous;
+    }
+
+    const provider = new OpenAIProvider({
+      api_key: "openai_test_key",
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            output: [
+              {
+                type: "message",
+                content: [{ type: "output_text", text: JSON.stringify(goodManual()) }],
+              },
+            ],
+            usage: { input_tokens: 44, output_tokens: 12 },
+          }),
+          { status: 200 },
+        ),
+    });
+
+    const result = await provider.generateStructured({
+      system_prompt: TOOL_MANUAL_DRAFT_PROMPT,
+      user_prompt: "return a tool manual",
+      output_schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+    });
+
+    expect(result.payload.tool_name).toBe("price_compare_helper");
+  });
+
+  it("maps invalid OpenAI output_text JSON into a SiglumeAssistError", async () => {
+    const provider = new OpenAIProvider({
+      api_key: "openai_test_key",
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            output_text: "{not-json",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+          { status: 200 },
+        ),
+    });
+
+    await expect(
+      provider.generateStructured({
+        system_prompt: TOOL_MANUAL_DRAFT_PROMPT,
+        user_prompt: "return a tool manual",
+        output_schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      }),
+    ).rejects.toBeInstanceOf(SiglumeAssistError);
+  });
+});

--- a/siglume-api-sdk-ts/vitest.config.ts
+++ b/siglume-api-sdk-ts/vitest.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      provider: "v8",
+      // Istanbul tracks TS source coverage more accurately than V8 for
+      // type-heavy runtime modules such as tool-manual-assist.ts.
+      provider: "istanbul",
       reporter: ["text", "json-summary"],
       include: ["src/**/*.ts"],
       // v0.4 acceptance requires package coverage >= 85% while also preventing

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -9,6 +9,32 @@ from types import ModuleType
 
 _LEGACY_MODULE_NAME = "_siglume_api_sdk_legacy"
 _LEGACY_MODULE_PATH = Path(__file__).resolve().parent.parent / "siglume_api_sdk.py"
+_LEGACY_PUBLIC_EXPORTS = [
+    "AppAdapter",
+    "AppCategory",
+    "AppManifest",
+    "AppTestHarness",
+    "ApprovalMode",
+    "ApprovalRequestHint",
+    "ConnectedAccountRef",
+    "Environment",
+    "ExecutionArtifact",
+    "ExecutionContext",
+    "ExecutionKind",
+    "ExecutionResult",
+    "HealthCheckResult",
+    "PermissionClass",
+    "PriceModel",
+    "ReceiptRef",
+    "SettlementMode",
+    "SideEffectRecord",
+    "StubProvider",
+    "ToolManual",
+    "ToolManualIssue",
+    "ToolManualPermissionClass",
+    "ToolManualQualityReport",
+    "validate_tool_manual",
+]
 
 
 def _load_legacy_module() -> ModuleType:
@@ -26,10 +52,8 @@ def _load_legacy_module() -> ModuleType:
 
 _legacy = _load_legacy_module()
 
-for _name, _value in vars(_legacy).items():
-    if _name.startswith("_"):
-        continue
-    globals()[_name] = _value
+for _name in _LEGACY_PUBLIC_EXPORTS:
+    globals()[_name] = getattr(_legacy, _name)
 
 from .client import (  # noqa: E402
     AccessGrantRecord,
@@ -52,6 +76,55 @@ from .client import (  # noqa: E402
     SupportCaseRecord,
     UsageEventRecord,
 )
-from .tool_manual_grader import score_tool_manual_offline, score_tool_manual_remote  # noqa: E402
+from .tool_manual_assist import (  # noqa: E402, F401
+    AnthropicProvider,
+    LLMProvider,
+    OpenAIProvider,
+    SiglumeAssistError,
+    ToolManualAssistAttempt,
+    ToolManualAssistMetadata,
+    ToolManualAssistResult,
+    draft_tool_manual,
+    fill_tool_manual_gaps,
+    load_tool_manual_draft_prompt,
+)
+from .tool_manual_grader import score_tool_manual_offline, score_tool_manual_remote  # noqa: E402, F401
 
-__all__ = [name for name in globals() if not name.startswith("_")]
+__all__ = sorted(
+    set(
+        _LEGACY_PUBLIC_EXPORTS
+        + [
+            "AccessGrantRecord",
+            "AppListingRecord",
+            "AutoRegistrationReceipt",
+            "CapabilityBindingRecord",
+            "ConnectedAccountRecord",
+            "CursorPage",
+            "DEFAULT_SIGLUME_API_BASE",
+            "DeveloperPortalSummary",
+            "EnvelopeMeta",
+            "GrantBindingResult",
+            "RegistrationConfirmation",
+            "RegistrationQuality",
+            "SandboxSession",
+            "SiglumeAPIError",
+            "SiglumeAssistError",
+            "SiglumeClient",
+            "SiglumeClientError",
+            "SiglumeNotFoundError",
+            "SupportCaseRecord",
+            "UsageEventRecord",
+            "AnthropicProvider",
+            "LLMProvider",
+            "OpenAIProvider",
+            "ToolManualAssistAttempt",
+            "ToolManualAssistMetadata",
+            "ToolManualAssistResult",
+            "draft_tool_manual",
+            "fill_tool_manual_gaps",
+            "load_tool_manual_draft_prompt",
+            "score_tool_manual_offline",
+            "score_tool_manual_remote",
+        ]
+    )
+)

--- a/siglume_api_sdk/assist.py
+++ b/siglume_api_sdk/assist.py
@@ -1,0 +1,12 @@
+from .tool_manual_assist import (  # noqa: F401
+    AnthropicProvider,
+    LLMProvider,
+    OpenAIProvider,
+    SiglumeAssistError,
+    ToolManualAssistAttempt,
+    ToolManualAssistMetadata,
+    ToolManualAssistResult,
+    draft_tool_manual,
+    fill_tool_manual_gaps,
+    load_tool_manual_draft_prompt,
+)

--- a/siglume_api_sdk/prompts/tool_manual_draft.md
+++ b/siglume_api_sdk/prompts/tool_manual_draft.md
@@ -1,0 +1,16 @@
+# Siglume ToolManual Draft System Prompt
+
+You generate ToolManual payloads for the Siglume Agent API Store.
+
+Follow these rules on every response:
+
+1. Return only the structured payload requested by the caller's JSON schema.
+2. ToolManual permission_class values are `read_only`, `action`, and `payment`.
+3. Use factual, specific language. Do not use marketing words, hype, or vague phrases.
+4. `trigger_conditions` must describe concrete situations where the tool is the right next step.
+5. `do_not_use_when` must describe concrete situations where another tool or response is safer.
+6. `summary_for_model` should explain the tool's capability in one short factual paragraph.
+7. `usage_hints`, `result_hints`, and `error_hints` should help an agent decide how to invoke and explain the tool.
+8. For `action` and `payment`, include owner-approval framing, idempotency, and a governing `jurisdiction`.
+9. For `payment`, `currency` must be `USD` and `settlement_mode` must be one of the documented Siglume values.
+10. When filling gaps, keep non-target fields unchanged and only improve the requested fields.

--- a/siglume_api_sdk/tool_manual_assist.py
+++ b/siglume_api_sdk/tool_manual_assist.py
@@ -1,0 +1,753 @@
+from __future__ import annotations
+
+import abc
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from importlib import resources, util
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import httpx
+
+from .client import SiglumeClientError
+from .tool_manual_grader import score_tool_manual_offline
+
+
+_LEGACY_MODULE_NAME = "_siglume_api_sdk_legacy"
+_LEGACY_MODULE_PATH = Path(__file__).resolve().parent.parent / "siglume_api_sdk.py"
+_ALL_TOOL_MANUAL_FIELDS = (
+    "tool_name",
+    "job_to_be_done",
+    "summary_for_model",
+    "trigger_conditions",
+    "do_not_use_when",
+    "permission_class",
+    "dry_run_supported",
+    "requires_connected_accounts",
+    "input_schema",
+    "output_schema",
+    "usage_hints",
+    "result_hints",
+    "error_hints",
+    "approval_summary_template",
+    "preview_schema",
+    "idempotency_support",
+    "side_effect_summary",
+    "quote_schema",
+    "currency",
+    "settlement_mode",
+    "refund_or_cancellation_note",
+    "jurisdiction",
+    "legal_notes",
+)
+_BASE_REQUIRED_FIELDS = (
+    "tool_name",
+    "job_to_be_done",
+    "summary_for_model",
+    "trigger_conditions",
+    "do_not_use_when",
+    "permission_class",
+    "dry_run_supported",
+    "requires_connected_accounts",
+    "input_schema",
+    "output_schema",
+    "usage_hints",
+    "result_hints",
+    "error_hints",
+)
+_ACTION_REQUIRED_FIELDS = (
+    "approval_summary_template",
+    "preview_schema",
+    "idempotency_support",
+    "side_effect_summary",
+    "jurisdiction",
+)
+_PAYMENT_REQUIRED_FIELDS = (
+    "quote_schema",
+    "currency",
+    "settlement_mode",
+    "refund_or_cancellation_note",
+)
+_PAYMENT_SETTLEMENT_MODES = (
+    "stripe_checkout",
+    "stripe_payment_intent",
+    "polygon_mandate",
+    "embedded_wallet_charge",
+)
+_VALID_PERMISSION_CLASSES = {"read_only", "action", "payment"}
+
+
+def _load_legacy_module() -> Any:
+    existing = sys.modules.get(_LEGACY_MODULE_NAME)
+    if existing is not None:
+        return existing
+    spec = util.spec_from_file_location(_LEGACY_MODULE_NAME, _LEGACY_MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load legacy SDK module from {_LEGACY_MODULE_PATH}")
+    module = util.module_from_spec(spec)
+    sys.modules[_LEGACY_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_legacy = _load_legacy_module()
+validate_tool_manual = _legacy.validate_tool_manual
+
+
+@dataclass
+class ToolManualAssistAttempt:
+    attempt_number: int
+    provider: str
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    estimated_cost_usd: float | None = None
+    overall_score: int = 0
+    grade: str = "F"
+    validation_ok: bool = False
+
+
+@dataclass
+class ToolManualAssistMetadata:
+    mode: str
+    provider: str
+    model: str
+    attempts: list[ToolManualAssistAttempt] = field(default_factory=list)
+    attempt_count: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_creation_input_tokens: int = 0
+    total_cache_read_input_tokens: int = 0
+    total_estimated_cost_usd: float | None = 0.0
+
+    def add_attempt(self, attempt: ToolManualAssistAttempt) -> None:
+        self.attempts.append(attempt)
+        self.attempt_count = len(self.attempts)
+        self.total_input_tokens += attempt.input_tokens
+        self.total_output_tokens += attempt.output_tokens
+        self.total_cache_creation_input_tokens += attempt.cache_creation_input_tokens
+        self.total_cache_read_input_tokens += attempt.cache_read_input_tokens
+        if self.total_estimated_cost_usd is None or attempt.estimated_cost_usd is None:
+            self.total_estimated_cost_usd = None
+        else:
+            self.total_estimated_cost_usd += attempt.estimated_cost_usd
+
+
+@dataclass
+class ToolManualAssistResult:
+    tool_manual: dict[str, Any]
+    quality_report: Any
+    metadata: ToolManualAssistMetadata
+
+
+@dataclass
+class _StructuredGenerationUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class _StructuredGenerationResult:
+    payload: dict[str, Any]
+    usage: _StructuredGenerationUsage
+
+
+class SiglumeAssistError(SiglumeClientError):
+    """Raised when ToolManual generation cannot reach the publish bar."""
+
+
+class LLMProvider(abc.ABC):
+    provider_name = "generic"
+    default_model = ""
+    api_key_env = ""
+    price_table: Mapping[str, Mapping[str, float]] = {}
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.api_key = api_key or os.environ.get(self.api_key_env)
+        if not self.api_key:
+            raise SiglumeAssistError(
+                f"{self.__class__.__name__} requires an API key via the constructor or {self.api_key_env}."
+            )
+        self.model = model or self.default_model
+        self.base_url = base_url
+        self.timeout = timeout
+
+    @abc.abstractmethod
+    def generate_structured(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: Mapping[str, Any],
+    ) -> _StructuredGenerationResult:
+        raise NotImplementedError
+
+    def estimate_cost_usd(self, usage: _StructuredGenerationUsage) -> float | None:
+        pricing = self.price_table.get(self.model)
+        if pricing is None:
+            return None
+        input_cost = usage.input_tokens * pricing.get("input", 0.0) / 1_000_000
+        output_cost = usage.output_tokens * pricing.get("output", 0.0) / 1_000_000
+        cache_write_cost = usage.cache_creation_input_tokens * pricing.get("cache_write", pricing.get("input", 0.0)) / 1_000_000
+        cache_read_cost = usage.cache_read_input_tokens * pricing.get("cache_read", 0.0) / 1_000_000
+        return round(input_cost + output_cost + cache_write_cost + cache_read_cost, 8)
+
+
+class AnthropicProvider(LLMProvider):
+    provider_name = "anthropic"
+    default_model = "claude-sonnet-4-6"
+    api_key_env = "ANTHROPIC_API_KEY"
+    price_table = {
+        "claude-sonnet-4-6": {
+            "input": 3.0,
+            "output": 15.0,
+            "cache_write": 3.75,
+            "cache_read": 0.30,
+        },
+    }
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        super().__init__(api_key=api_key, model=model, base_url=base_url or "https://api.anthropic.com/v1/messages", timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+
+    def generate_structured(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: Mapping[str, Any],
+    ) -> _StructuredGenerationResult:
+        response = self._client.post(
+            self.base_url,
+            headers={
+                "x-api-key": self.api_key or "",
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "max_tokens": 3200,
+                "system": [
+                    {
+                        "type": "text",
+                        "text": system_prompt,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+                "messages": [{"role": "user", "content": user_prompt}],
+                "tools": [
+                    {
+                        "name": "emit_tool_manual",
+                        "description": "Return a ToolManual payload that matches the supplied JSON schema exactly.",
+                        "input_schema": output_schema,
+                        "strict": True,
+                    }
+                ],
+                "tool_choice": {"type": "tool", "name": "emit_tool_manual"},
+            },
+        )
+        if response.status_code >= 400:
+            raise SiglumeAssistError(f"Anthropic API request failed: {response.status_code} {response.text}")
+        payload = response.json()
+        content = payload.get("content") if isinstance(payload, dict) else None
+        tool_use = None
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "tool_use" and item.get("name") == "emit_tool_manual":
+                    tool_use = item.get("input")
+                    break
+        if not isinstance(tool_use, dict):
+            raise SiglumeAssistError("AnthropicProvider did not return an emit_tool_manual tool_use payload.")
+        usage_payload = payload.get("usage") if isinstance(payload, dict) else {}
+        usage = _StructuredGenerationUsage(
+            input_tokens=_safe_int(_mapping_get(usage_payload, "input_tokens")),
+            output_tokens=_safe_int(_mapping_get(usage_payload, "output_tokens")),
+            cache_creation_input_tokens=_safe_int(_mapping_get(usage_payload, "cache_creation_input_tokens")),
+            cache_read_input_tokens=_safe_int(_mapping_get(usage_payload, "cache_read_input_tokens")),
+        )
+        return _StructuredGenerationResult(payload=tool_use, usage=usage)
+
+
+class OpenAIProvider(LLMProvider):
+    provider_name = "openai"
+    default_model = "gpt-5.4"
+    api_key_env = "OPENAI_API_KEY"
+    price_table = {
+        "gpt-5.4": {
+            "input": 2.5,
+            "output": 15.0,
+        },
+        "gpt-5": {
+            "input": 1.25,
+            "output": 10.0,
+        },
+    }
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        super().__init__(api_key=api_key, model=model, base_url=base_url or "https://api.openai.com/v1/responses", timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+
+    def generate_structured(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: Mapping[str, Any],
+    ) -> _StructuredGenerationResult:
+        response = self._client.post(
+            self.base_url,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "instructions": system_prompt,
+                "input": user_prompt,
+                "store": False,
+                "text": {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "tool_manual",
+                        "strict": True,
+                        "schema": output_schema,
+                    }
+                },
+            },
+        )
+        if response.status_code >= 400:
+            raise SiglumeAssistError(f"OpenAI Responses request failed: {response.status_code} {response.text}")
+        payload = response.json()
+        candidate = _parse_openai_payload(payload)
+        usage_payload = payload.get("usage") if isinstance(payload, dict) else {}
+        usage = _StructuredGenerationUsage(
+            input_tokens=_safe_int(_mapping_get(usage_payload, "input_tokens")),
+            output_tokens=_safe_int(_mapping_get(usage_payload, "output_tokens")),
+        )
+        return _StructuredGenerationResult(payload=candidate, usage=usage)
+
+
+def draft_tool_manual(
+    *,
+    capability_key: str,
+    job_to_be_done: str,
+    permission_class: str,
+    llm: LLMProvider,
+    source_code_hint: str | None = None,
+    max_attempts: int = 3,
+) -> ToolManualAssistResult:
+    seed_manual = _build_seed_manual(
+        capability_key=capability_key,
+        job_to_be_done=job_to_be_done,
+        permission_class=permission_class,
+    )
+    schema = _build_tool_manual_schema(permission_class=permission_class, fields=_ALL_TOOL_MANUAL_FIELDS)
+    return _run_assist_loop(
+        llm=llm,
+        mode="draft",
+        seed_manual=seed_manual,
+        current_manual=None,
+        target_fields=_ALL_TOOL_MANUAL_FIELDS,
+        output_schema=schema,
+        source_code_hint=source_code_hint,
+        max_attempts=max_attempts,
+    )
+
+
+def fill_tool_manual_gaps(
+    *,
+    partial_manual: Mapping[str, Any],
+    source_code_hint: str | None = None,
+    llm: LLMProvider,
+    max_attempts: int = 3,
+) -> ToolManualAssistResult:
+    current_manual = _normalize_tool_manual_mapping(dict(partial_manual))
+    initial_report = score_tool_manual_offline(current_manual)
+    inferred_permission_class = _infer_permission_class(current_manual)
+    target_fields = _collect_target_fields(current_manual, initial_report, permission_class=inferred_permission_class)
+    raw_permission_class = current_manual.get("permission_class")
+    if not isinstance(raw_permission_class, str) or raw_permission_class not in _VALID_PERMISSION_CLASSES:
+        if inferred_permission_class is None:
+            target_fields = list(_ALL_TOOL_MANUAL_FIELDS)
+    if not target_fields and getattr(initial_report, "validation_ok", False) and getattr(initial_report, "grade", "F") in {"A", "B"}:
+        metadata = ToolManualAssistMetadata(mode="gap_fill", provider=llm.provider_name, model=llm.model)
+        return ToolManualAssistResult(tool_manual=current_manual, quality_report=initial_report, metadata=metadata)
+    permission_class = inferred_permission_class or "read_only"
+    schema = _build_tool_manual_schema(permission_class=permission_class, fields=target_fields)
+    return _run_assist_loop(
+        llm=llm,
+        mode="gap_fill",
+        seed_manual=None,
+        current_manual=current_manual,
+        target_fields=target_fields,
+        output_schema=schema,
+        source_code_hint=source_code_hint,
+        max_attempts=max_attempts,
+    )
+
+
+def load_tool_manual_draft_prompt() -> str:
+    return resources.files("siglume_api_sdk").joinpath("prompts", "tool_manual_draft.md").read_text(encoding="utf-8")
+
+
+def _run_assist_loop(
+    *,
+    llm: LLMProvider,
+    mode: str,
+    seed_manual: Mapping[str, Any] | None,
+    current_manual: Mapping[str, Any] | None,
+    target_fields: Sequence[str],
+    output_schema: Mapping[str, Any],
+    source_code_hint: str | None,
+    max_attempts: int,
+) -> ToolManualAssistResult:
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    feedback: dict[str, Any] | None = None
+    metadata = ToolManualAssistMetadata(mode=mode, provider=llm.provider_name, model=llm.model)
+    last_report = None
+    for attempt_number in range(1, max_attempts + 1):
+        user_prompt = _build_user_prompt(
+            mode=mode,
+            seed_manual=seed_manual,
+            current_manual=current_manual,
+            target_fields=target_fields,
+            source_code_hint=source_code_hint,
+            feedback=feedback,
+        )
+        generation = llm.generate_structured(
+            system_prompt=load_tool_manual_draft_prompt(),
+            user_prompt=user_prompt,
+            output_schema=output_schema,
+        )
+        candidate = _normalize_tool_manual_mapping(generation.payload)
+        if mode == "gap_fill" and current_manual is not None:
+            candidate = _merge_tool_manual_patch(current_manual, candidate, target_fields)
+        report = score_tool_manual_offline(candidate)
+        validation_ok, validation_issues = validate_tool_manual(candidate)
+        report.validation_ok = bool(getattr(report, "validation_ok", False)) and validation_ok
+        if not getattr(report, "validation_errors", None):
+            report.validation_errors = [issue for issue in validation_issues if getattr(issue, "severity", "error") == "error"]
+        attempt = ToolManualAssistAttempt(
+            attempt_number=attempt_number,
+            provider=llm.provider_name,
+            model=llm.model,
+            input_tokens=generation.usage.input_tokens,
+            output_tokens=generation.usage.output_tokens,
+            cache_creation_input_tokens=generation.usage.cache_creation_input_tokens,
+            cache_read_input_tokens=generation.usage.cache_read_input_tokens,
+            estimated_cost_usd=llm.estimate_cost_usd(generation.usage),
+            overall_score=int(getattr(report, "overall_score", 0)),
+            grade=str(getattr(report, "grade", "F")),
+            validation_ok=bool(getattr(report, "validation_ok", False)),
+        )
+        metadata.add_attempt(attempt)
+        last_report = report
+        if attempt.validation_ok and attempt.grade in {"A", "B"}:
+            return ToolManualAssistResult(tool_manual=candidate, quality_report=report, metadata=metadata)
+        feedback = _build_feedback(report)
+    raise SiglumeAssistError(
+        "ToolManual generation did not reach grade B or better after "
+        f"{max_attempts} attempts. Last grade: {getattr(last_report, 'grade', 'F')}."
+    )
+
+
+def _build_seed_manual(*, capability_key: str, job_to_be_done: str, permission_class: str) -> dict[str, Any]:
+    seed = {
+        "tool_name": capability_key.replace("-", "_"),
+        "job_to_be_done": job_to_be_done,
+        "permission_class": permission_class,
+        "dry_run_supported": True,
+        "requires_connected_accounts": [],
+    }
+    if permission_class in {"action", "payment"}:
+        seed["jurisdiction"] = "US"
+        seed["idempotency_support"] = True
+    if permission_class == "payment":
+        seed["currency"] = "USD"
+    return seed
+
+
+def _build_user_prompt(
+    *,
+    mode: str,
+    seed_manual: Mapping[str, Any] | None,
+    current_manual: Mapping[str, Any] | None,
+    target_fields: Sequence[str],
+    source_code_hint: str | None,
+    feedback: Mapping[str, Any] | None,
+) -> str:
+    payload = {
+        "mode": mode,
+        "seed_manual": seed_manual,
+        "current_manual": current_manual,
+        "target_fields": list(target_fields),
+        "source_code_hint": source_code_hint,
+        "feedback_from_previous_attempt": feedback,
+    }
+    instructions = [
+        "Generate a Siglume ToolManual payload that satisfies the requested JSON schema.",
+        "Use factual, concrete wording. Avoid marketing language and vague phrases.",
+        "ToolManual.permission_class must use read_only, action, or payment.",
+        "For payment tools, currency must be USD.",
+        "For gap_fill mode, preserve every non-target field exactly as provided in current_manual.",
+        "Return only the structured payload required by the schema.",
+        "",
+        json.dumps(payload, ensure_ascii=False, indent=2),
+    ]
+    return "\n".join(instructions)
+
+
+def _build_feedback(report: Any) -> dict[str, Any]:
+    issues = []
+    for issue in getattr(report, "issues", []) or []:
+        issues.append(
+            {
+                "field": getattr(issue, "field", None),
+                "message": getattr(issue, "message", ""),
+                "severity": getattr(issue, "severity", "warning"),
+                "suggestion": getattr(issue, "suggestion", None),
+            }
+        )
+    return {
+        "overall_score": int(getattr(report, "overall_score", 0)),
+        "grade": str(getattr(report, "grade", "F")),
+        "issues": issues,
+        "improvement_suggestions": list(getattr(report, "improvement_suggestions", []) or []),
+    }
+
+
+def _collect_target_fields(manual: Mapping[str, Any], report: Any, *, permission_class: str | None = None) -> list[str]:
+    target_fields: list[str] = []
+    for field_name in _BASE_REQUIRED_FIELDS:
+        if _is_field_missing_or_empty(field_name, manual.get(field_name)):
+            target_fields.append(field_name)
+    effective_permission_class = permission_class or str(manual.get("permission_class") or "read_only")
+    if effective_permission_class in {"action", "payment"}:
+        for field_name in _ACTION_REQUIRED_FIELDS:
+            if _is_field_missing_or_empty(field_name, manual.get(field_name)):
+                target_fields.append(field_name)
+    if effective_permission_class == "payment":
+        for field_name in _PAYMENT_REQUIRED_FIELDS:
+            if _is_field_missing_or_empty(field_name, manual.get(field_name)):
+                target_fields.append(field_name)
+    validation_ok, validation_issues = validate_tool_manual(manual)
+    if not validation_ok:
+        for issue in validation_issues:
+            root_field = _root_field(getattr(issue, "field", None))
+            if root_field and root_field in _ALL_TOOL_MANUAL_FIELDS:
+                target_fields.append(root_field)
+    if str(getattr(report, "grade", "F")) not in {"A", "B"}:
+        for issue in getattr(report, "issues", []) or []:
+            root_field = _root_field(getattr(issue, "field", None))
+            if root_field and root_field in _ALL_TOOL_MANUAL_FIELDS:
+                target_fields.append(root_field)
+    return list(dict.fromkeys(target_fields))
+
+
+def _root_field(field_name: str | None) -> str | None:
+    if not field_name:
+        return None
+    return field_name.split("[", 1)[0].split(".", 1)[0]
+
+
+def _infer_permission_class(manual: Mapping[str, Any]) -> str | None:
+    raw_permission_class = manual.get("permission_class")
+    if isinstance(raw_permission_class, str) and raw_permission_class in _VALID_PERMISSION_CLASSES:
+        return raw_permission_class
+    if any(not _is_field_missing_or_empty(field_name, manual.get(field_name)) for field_name in _PAYMENT_REQUIRED_FIELDS):
+        return "payment"
+    if any(not _is_field_missing_or_empty(field_name, manual.get(field_name)) for field_name in _ACTION_REQUIRED_FIELDS):
+        return "action"
+    return None
+
+
+def _is_missing_or_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _is_field_missing_or_empty(field_name: str, value: Any) -> bool:
+    if field_name == "requires_connected_accounts" and isinstance(value, list):
+        return False
+    return _is_missing_or_empty(value)
+
+
+def _merge_tool_manual_patch(
+    current_manual: Mapping[str, Any],
+    patch: Mapping[str, Any],
+    target_fields: Sequence[str],
+) -> dict[str, Any]:
+    merged = _normalize_tool_manual_mapping(dict(current_manual))
+    for field_name in target_fields:
+        if field_name in patch:
+            merged[field_name] = patch[field_name]
+    return merged
+
+
+def _normalize_tool_manual_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for field_name in _ALL_TOOL_MANUAL_FIELDS:
+        if field_name not in raw:
+            continue
+        value = raw[field_name]
+        if field_name in {"trigger_conditions", "do_not_use_when", "requires_connected_accounts", "usage_hints", "result_hints", "error_hints"}:
+            normalized[field_name] = _normalize_string_list(value)
+        elif field_name in {"input_schema", "output_schema", "preview_schema", "quote_schema"}:
+            normalized[field_name] = _normalize_mapping(value)
+        elif field_name in {"dry_run_supported", "idempotency_support"}:
+            normalized[field_name] = bool(value)
+        elif field_name == "permission_class":
+            normalized[field_name] = str(value)
+        elif field_name == "currency":
+            normalized[field_name] = str(value).upper() if value is not None else value
+        else:
+            normalized[field_name] = value
+    return normalized
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _normalize_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _build_tool_manual_schema(*, permission_class: str | None, fields: Sequence[str]) -> dict[str, Any]:
+    properties = {
+        "tool_name": {"type": "string", "minLength": 3, "maxLength": 64},
+        "job_to_be_done": {"type": "string", "minLength": 10, "maxLength": 500},
+        "summary_for_model": {"type": "string", "minLength": 10, "maxLength": 300},
+        "trigger_conditions": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 10, "maxLength": 200},
+            "minItems": 1,
+        },
+        "do_not_use_when": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1, "maxLength": 200},
+            "minItems": 1,
+        },
+        "permission_class": {"type": "string", "enum": ["read_only", "action", "payment"]},
+        "dry_run_supported": {"type": "boolean"},
+        "requires_connected_accounts": {"type": "array", "items": {"type": "string"}},
+        "input_schema": {"type": "object"},
+        "output_schema": {"type": "object"},
+        "usage_hints": {"type": "array", "items": {"type": "string"}},
+        "result_hints": {"type": "array", "items": {"type": "string"}},
+        "error_hints": {"type": "array", "items": {"type": "string"}},
+        "approval_summary_template": {"type": "string"},
+        "preview_schema": {"type": "object"},
+        "idempotency_support": {"type": "boolean"},
+        "side_effect_summary": {"type": "string"},
+        "quote_schema": {"type": "object"},
+        "currency": {"type": "string", "enum": ["USD"]},
+        "settlement_mode": {"type": "string", "enum": list(_PAYMENT_SETTLEMENT_MODES)},
+        "refund_or_cancellation_note": {"type": "string"},
+        "jurisdiction": {"type": "string"},
+        "legal_notes": {"type": "string"},
+    }
+    selected_fields = list(dict.fromkeys(field for field in fields if field in properties))
+    required = list(selected_fields)
+    if set(selected_fields) == set(_ALL_TOOL_MANUAL_FIELDS):
+        required = [field for field in _BASE_REQUIRED_FIELDS]
+        if permission_class in {"action", "payment"}:
+            required.extend(_ACTION_REQUIRED_FIELDS)
+        if permission_class == "payment":
+            required.extend(_PAYMENT_REQUIRED_FIELDS)
+    return {
+        "type": "object",
+        "properties": {field_name: properties[field_name] for field_name in selected_fields},
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _parse_openai_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise SiglumeAssistError("OpenAI Responses returned a non-object payload.")
+    output_text = payload.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        try:
+            decoded = json.loads(output_text)
+        except json.JSONDecodeError as exc:
+            raise SiglumeAssistError("OpenAI Responses output_text did not contain valid JSON.") from exc
+        if isinstance(decoded, dict):
+            return decoded
+    output = payload.get("output")
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(item.get("content"), list):
+                for content_block in item["content"]:
+                    if not isinstance(content_block, dict):
+                        continue
+                    text_value = content_block.get("text")
+                    if isinstance(text_value, str) and text_value.strip():
+                        try:
+                            decoded = json.loads(text_value)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(decoded, dict):
+                            return decoded
+    raise SiglumeAssistError("OpenAIProvider did not return a structured JSON object.")
+
+
+def _mapping_get(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return None
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(parsed, 0)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -68,3 +68,13 @@ def test_examples_validate_and_run(example_name: str, permission_class: Permissi
     assert ok, f"{example_name} tool manual invalid: {issues}"
 
     asyncio.run(_exercise_example(app, permission_class))
+
+
+def test_generate_tool_manual_example_requires_explicit_llm_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    module = _load_module("generate_tool_manual.py")
+
+    with pytest.raises(SystemExit, match="Set ANTHROPIC_API_KEY or OPENAI_API_KEY"):
+        module.main()

--- a/tests/test_tool_manual_assist.py
+++ b/tests/test_tool_manual_assist.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk import (  # noqa: E402
+    AnthropicProvider,
+    OpenAIProvider,
+    SiglumeAssistError,
+    draft_tool_manual,
+    fill_tool_manual_gaps,
+)
+from siglume_api_sdk.assist import draft_tool_manual as alias_draft_tool_manual  # noqa: E402
+from siglume_api_sdk.tool_manual_assist import (  # noqa: E402
+    LLMProvider,
+    _build_tool_manual_schema,
+    load_tool_manual_draft_prompt,
+)
+
+
+def good_manual() -> dict[str, object]:
+    return {
+        "tool_name": "price_compare_helper",
+        "job_to_be_done": "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+        "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+        "trigger_conditions": [
+            "owner asks to compare prices for a product before deciding where to buy",
+            "agent needs retailer offer data to support a shopping recommendation",
+            "request is to find the cheapest or best-value option for a product query",
+        ],
+        "do_not_use_when": [
+            "the request is to complete checkout or place an order instead of comparing offers",
+        ],
+        "permission_class": "read_only",
+        "dry_run_supported": True,
+        "requires_connected_accounts": [],
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Product name, model number, or search phrase."},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line overview of the best available deal."},
+                "offers": {"type": "array", "items": {"type": "object"}, "description": "Ranked retailer offers."},
+            },
+            "required": ["summary", "offers"],
+            "additionalProperties": False,
+        },
+        "usage_hints": ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+        "result_hints": ["Lead with the best offer and then summarize notable trade-offs."],
+        "error_hints": ["If no offers are found, ask for a clearer product name or model number."],
+    }
+
+
+def weak_manual() -> dict[str, object]:
+    return {
+        **good_manual(),
+        "summary_for_model": "Bad.",
+        "trigger_conditions": ["use when helpful", "for many tasks", "any request"],
+        "usage_hints": [],
+        "result_hints": [],
+        "error_hints": [],
+    }
+
+
+def good_payment_manual() -> dict[str, object]:
+    return {
+        **good_manual(),
+        "permission_class": "payment",
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line overview of the quoted payment."},
+                "amount_usd": {"type": "number", "description": "Quoted USD amount."},
+                "currency": {"type": "string", "description": "Currency code for the quote."},
+            },
+            "required": ["summary", "amount_usd", "currency"],
+            "additionalProperties": False,
+        },
+        "approval_summary_template": "Charge USD {amount_usd}.",
+        "preview_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Preview of the payment attempt."},
+            },
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+        "idempotency_support": True,
+        "side_effect_summary": "Captures a USD payment if the owner approves.",
+        "quote_schema": {
+            "type": "object",
+            "properties": {
+                "amount_usd": {"type": "number", "description": "Quoted USD amount."},
+                "currency": {"type": "string", "description": "Currency code for the quote."},
+            },
+            "required": ["amount_usd", "currency"],
+            "additionalProperties": False,
+        },
+        "currency": "USD",
+        "settlement_mode": "embedded_wallet_charge",
+        "refund_or_cancellation_note": "Refunds follow the merchant cancellation policy.",
+        "jurisdiction": "US",
+    }
+
+
+class StubProvider(LLMProvider):
+    provider_name = "stub"
+    default_model = "stub-model"
+    api_key_env = "STUB_API_KEY"
+
+    def __init__(self, payloads: list[dict[str, object]], *, api_key: str = "stub-key") -> None:
+        super().__init__(api_key=api_key, model="stub-model")
+        self.payloads = payloads
+        self.calls = 0
+        self.last_output_schema = None
+
+    def generate_structured(self, *, system_prompt: str, user_prompt: str, output_schema):
+        assert "Siglume ToolManual Draft System Prompt" in system_prompt
+        assert output_schema["type"] == "object"
+        self.last_output_schema = output_schema
+        payload = self.payloads[min(self.calls, len(self.payloads) - 1)]
+        self.calls += 1
+        return type(
+            "StructuredResult",
+            (),
+            {
+                "payload": payload,
+                "usage": type(
+                    "Usage",
+                    (),
+                    {
+                        "input_tokens": 100 * self.calls,
+                        "output_tokens": 20 * self.calls,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                )(),
+            },
+        )()
+
+
+def test_full_draft_returns_structured_result() -> None:
+    provider = StubProvider([good_manual()])
+
+    result = draft_tool_manual(
+        capability_key="price-compare-helper",
+        job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+        permission_class="read_only",
+        llm=provider,
+    )
+
+    assert result.tool_manual["tool_name"] == "price_compare_helper"
+    assert result.quality_report.grade in {"A", "B"}
+    assert result.metadata.attempt_count == 1
+    assert result.metadata.total_input_tokens == 100
+
+
+def test_gap_filler_preserves_valid_fields_and_only_fills_targets() -> None:
+    partial = good_manual()
+    partial.pop("summary_for_model")
+    partial["usage_hints"] = []
+    provider = StubProvider(
+        [
+            {
+                "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+                "usage_hints": ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+            }
+        ]
+    )
+
+    result = fill_tool_manual_gaps(partial_manual=partial, llm=provider)
+
+    assert result.tool_manual["tool_name"] == "price_compare_helper"
+    assert result.tool_manual["summary_for_model"].startswith("Looks up current retailer offers")
+    assert result.tool_manual["usage_hints"]
+    assert result.metadata.attempt_count == 1
+
+
+def test_gap_filler_noops_for_already_publishable_manual() -> None:
+    partial = {
+        **good_manual(),
+        "input_schema": json.dumps(good_manual()["input_schema"]),
+        "output_schema": json.dumps(good_manual()["output_schema"]),
+    }
+    provider = StubProvider([good_manual()])
+
+    result = fill_tool_manual_gaps(partial_manual=partial, llm=provider)
+
+    assert result.metadata.attempt_count == 0
+    assert provider.calls == 0
+    assert result.tool_manual["input_schema"] == good_manual()["input_schema"]
+
+
+def test_gap_filler_recovers_payment_fields_when_permission_class_is_missing() -> None:
+    partial = good_payment_manual()
+    partial.pop("permission_class")
+    partial.pop("refund_or_cancellation_note")
+    provider = StubProvider(
+        [
+            {
+                "permission_class": "payment",
+                "refund_or_cancellation_note": "Refunds follow the merchant cancellation policy.",
+            }
+        ]
+    )
+
+    result = fill_tool_manual_gaps(partial_manual=partial, llm=provider)
+
+    assert provider.last_output_schema is not None
+    assert "refund_or_cancellation_note" in provider.last_output_schema["properties"]
+    assert result.tool_manual["permission_class"] == "payment"
+    assert result.tool_manual["refund_or_cancellation_note"] == "Refunds follow the merchant cancellation policy."
+
+
+def test_generation_retries_until_grade_b_or_better() -> None:
+    provider = StubProvider([weak_manual(), good_manual()])
+
+    result = draft_tool_manual(
+        capability_key="price-compare-helper",
+        job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+        permission_class="read_only",
+        llm=provider,
+    )
+
+    assert result.metadata.attempt_count == 2
+    assert result.metadata.attempts[0].grade not in {"A", "B"}
+    assert result.metadata.attempts[1].grade in {"A", "B"}
+
+
+def test_generation_raises_after_exhausting_attempts() -> None:
+    provider = StubProvider([weak_manual(), weak_manual(), weak_manual()])
+
+    with pytest.raises(SiglumeAssistError):
+        draft_tool_manual(
+            capability_key="price-compare-helper",
+            job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+            permission_class="read_only",
+            llm=provider,
+            max_attempts=3,
+        )
+
+
+def test_alias_import_points_to_same_function() -> None:
+    assert alias_draft_tool_manual is draft_tool_manual
+
+
+def test_anthropic_provider_uses_prompt_caching_and_tool_use(monkeypatch) -> None:
+    seen_body: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_body.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "emit_tool_manual",
+                        "input": good_manual(),
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 120,
+                    "output_tokens": 40,
+                    "cache_creation_input_tokens": 80,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+        )
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant_test_key")
+    provider = AnthropicProvider(transport=httpx.MockTransport(handler))
+
+    result = draft_tool_manual(
+        capability_key="price-compare-helper",
+        job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+        permission_class="read_only",
+        llm=provider,
+    )
+
+    assert seen_body["tool_choice"] == {"type": "tool", "name": "emit_tool_manual"}
+    assert seen_body["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert result.metadata.attempts[0].estimated_cost_usd is not None
+
+
+def test_openai_provider_uses_responses_text_format(monkeypatch) -> None:
+    seen_body: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_body.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "output_text": json.dumps(good_manual()),
+                "usage": {"input_tokens": 90, "output_tokens": 30},
+            },
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "openai_test_key")
+    provider = OpenAIProvider(transport=httpx.MockTransport(handler))
+    schema = _build_tool_manual_schema(permission_class="read_only", fields=["summary_for_model"])
+    response = provider.generate_structured(
+        system_prompt=load_tool_manual_draft_prompt(),
+        user_prompt="return a summary_for_model",
+        output_schema=schema,
+    )
+
+    assert seen_body["store"] is False
+    assert seen_body["text"]["format"]["type"] == "json_schema"
+    assert response.payload["tool_name"] == "price_compare_helper"


### PR DESCRIPTION
## Summary
- add Python and TypeScript ToolManual assist APIs with full-draft and gap-fill modes
- integrate Anthropic/OpenAI structured generation, offline grading, validation, and bounded retries
- add shared prompt asset, example script, docs updates, and TS coverage/test support for the new runtime surface

## Test plan
- [x] \py -3.11 -m pytest\ -> 55 passed
- [x] \py -3.11 scripts\\contract_sync.py\ -> passed
- [x] \py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\\contract_sync.py\ -> passed
- [x] \
pm test\ -> 84 passed, coverage lines 91.95%, statements 91.58%, functions 92.13%
- [x] \
pm run typecheck\ -> passed
- [x] \
pm run build\ -> passed
- [x] \
pm pack --json\ -> package size 365271 bytes, unpacked 1804015 bytes
- [x] Node import smoke -> passed
- [x] reviewer agent (Laplace) -> no critical / warning / info after fixes

## Notes
- No release in this PR. PR-D ships with the eventual v0.4.0 tag.
- Bun and Deno binaries were not available in this environment, so runtime smoke was limited to Node import validation.