### PR TITLE
feat(diff): Manifest / ToolManual diff tool (PR-J)

### DIFF
--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -33,6 +33,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "lint": "npm run typecheck",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --coverage",
     "pack:check": "npm pack --json",

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -4,6 +4,7 @@ import { SiglumeProjectError } from "../errors";
 import { renderJson } from "../utils";
 import {
   createSupportCaseReport,
+  diffJsonFiles,
   getUsageReport,
   runHarness,
   runRegistration,
@@ -25,6 +26,7 @@ function emit(output: ((line: string) => void) | undefined, line: string): void 
 export async function runCli(argv: string[], deps: CliRunDependencies = {}): Promise<number> {
   const stdout = deps.stdout;
   const stderr = deps.stderr ?? console.error;
+  let completionExitCode = 0;
   const program = new Command()
     .name("siglume")
     .description("Siglume developer CLI")
@@ -46,6 +48,34 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
       }
       emit(stdout, `Initialized Siglume starter template '${template}'.`);
       files.forEach((filePath) => emit(stdout, `- ${filePath}`));
+    });
+
+  program
+    .command("diff")
+    .option("--json", "emit machine-readable JSON", false)
+    .argument("<old_json>", "previous manifest/tool manual JSON")
+    .argument("<new_json>", "next manifest/tool manual JSON")
+    .action(async (oldPath: string, newPath: string, options: { json?: boolean }) => {
+      const report = await diffJsonFiles(oldPath, newPath);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+      } else {
+        const changes = (report.changes as Array<Record<string, unknown>>) ?? [];
+        if (changes.length === 0) {
+          emit(stdout, "No differences detected.");
+        } else {
+          for (const level of ["breaking", "warning", "info"]) {
+            const items = changes.filter((item) => item.level === level);
+            if (items.length === 0) {
+              continue;
+            }
+            emit(stdout, level.toUpperCase());
+            items.forEach((item) => emit(stdout, `- ${String(item.path)}: ${String(item.message)}`));
+            emit(stdout, "");
+          }
+        }
+      }
+      completionExitCode = Number(report.exit_code ?? 0);
     });
 
   program
@@ -159,7 +189,7 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
 
   try {
     await program.parseAsync(argv, { from: "user" });
-    return 0;
+    return completionExitCode;
   } catch (error) {
     if (error instanceof SiglumeProjectError) {
       emit(stderr, error.message);

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -8,7 +8,10 @@ import { createJiti } from "jiti";
 import {
   AppAdapter,
   AppTestHarness,
+  ChangeLevel,
   PermissionClass,
+  diff_manifest,
+  diff_tool_manual,
   score_tool_manual_offline,
   SettlementMode,
   SiglumeClient,
@@ -23,12 +26,39 @@ import type {
   ToolManualIssue,
 } from "../index";
 import { SiglumeProjectError } from "../errors";
-import { renderJson, toJsonable } from "../utils";
+import { isRecord, renderJson, toJsonable } from "../utils";
 
 const TEMPLATE_NAMES = ["echo", "price-compare", "publisher", "payment"] as const;
 type TemplateName = (typeof TEMPLATE_NAMES)[number];
 
 const SUPPORTED_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".mjs", ".cjs"]);
+const CAPABILITY_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+const MANIFEST_REQUIRED_KEYS = new Set([
+  "capability_key",
+  "name",
+  "job_to_be_done",
+  "permission_class",
+  "approval_mode",
+  "dry_run_supported",
+  "required_connected_accounts",
+  "price_model",
+  "jurisdiction",
+]);
+const TOOL_MANUAL_REQUIRED_KEYS = new Set([
+  "tool_name",
+  "job_to_be_done",
+  "summary_for_model",
+  "trigger_conditions",
+  "do_not_use_when",
+  "permission_class",
+  "dry_run_supported",
+  "requires_connected_accounts",
+  "input_schema",
+  "output_schema",
+  "usage_hints",
+  "result_hints",
+  "error_hints",
+]);
 
 export interface LoadedProject {
   root_dir: string;
@@ -298,6 +328,32 @@ export async function getUsageReport(
   };
 }
 
+export async function diffJsonFiles(
+  oldPath: string,
+  newPath: string,
+): Promise<Record<string, unknown>> {
+  const oldPayload = await loadJsonDocument(oldPath);
+  const newPayload = await loadJsonDocument(newPath);
+  const kind = detectDocumentKind(oldPayload, newPayload);
+  const changes =
+    kind === "manifest"
+      ? diff_manifest({ old: oldPayload, new: newPayload })
+      : diff_tool_manual({ old: oldPayload, new: newPayload });
+  const counts = {
+    breaking: changes.filter((change) => change.level === ChangeLevel.BREAKING).length,
+    warning: changes.filter((change) => change.level === ChangeLevel.WARNING).length,
+    info: changes.filter((change) => change.level === ChangeLevel.INFO).length,
+  };
+  return {
+    kind,
+    old_path: oldPath,
+    new_path: newPath,
+    exit_code: counts.breaking > 0 ? 1 : counts.warning > 0 ? 2 : 0,
+    counts,
+    changes: changes.map((change) => toJsonable(change)),
+  };
+}
+
 export async function runHarness(path = "."): Promise<Record<string, unknown>> {
   const project = await loadProject(path);
   return runHarnessForProject(project);
@@ -398,6 +454,119 @@ function toolManualPermissionClass(permission_class: AppManifest["permission_cla
     default:
       return ToolManualPermissionClass.READ_ONLY;
   }
+}
+
+async function loadJsonDocument(path: string): Promise<Record<string, unknown>> {
+  const payload = JSON.parse(await readFile(path, "utf8")) as unknown;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new SiglumeProjectError(`${path} must contain a top-level JSON object.`);
+  }
+  return payload as Record<string, unknown>;
+}
+
+function detectDocumentKind(
+  oldPayload: Record<string, unknown>,
+  newPayload: Record<string, unknown>,
+): "manifest" | "tool_manual" {
+  const oldKind = payloadKind(oldPayload);
+  const newKind = payloadKind(newPayload);
+  if (oldKind !== newKind) {
+    throw new SiglumeProjectError("Both files must be the same document type (manifest or tool_manual).");
+  }
+  if (!oldKind) {
+    throw new SiglumeProjectError("Could not detect document type. Expected AppManifest or ToolManual JSON.");
+  }
+  return oldKind;
+}
+
+function payloadKind(payload: Record<string, unknown>): "manifest" | "tool_manual" | null {
+  if (isManifestPayload(payload)) {
+    return "manifest";
+  }
+  if (isToolManualPayload(payload)) {
+    return "tool_manual";
+  }
+  return null;
+}
+
+function isManifestPayload(payload: Record<string, unknown>): boolean {
+  if (![...MANIFEST_REQUIRED_KEYS].every((key) => key in payload)) {
+    return false;
+  }
+  if (typeof payload.capability_key !== "string" || !CAPABILITY_KEY_RE.test(payload.capability_key)) {
+    return false;
+  }
+  if (typeof payload.name !== "string" || payload.name.trim().length === 0) {
+    return false;
+  }
+  if (typeof payload.job_to_be_done !== "string" || payload.job_to_be_done.trim().length === 0) {
+    return false;
+  }
+  if (typeof payload.permission_class !== "string") {
+    return false;
+  }
+  if (typeof payload.approval_mode !== "string") {
+    return false;
+  }
+  if (typeof payload.dry_run_supported !== "boolean") {
+    return false;
+  }
+  if (!Array.isArray(payload.required_connected_accounts)) {
+    return false;
+  }
+  if (typeof payload.price_model !== "string") {
+    return false;
+  }
+  if (typeof payload.jurisdiction !== "string" || payload.jurisdiction.trim().length === 0) {
+    return false;
+  }
+  return true;
+}
+
+function isToolManualPayload(payload: Record<string, unknown>): boolean {
+  if (![...TOOL_MANUAL_REQUIRED_KEYS].every((key) => key in payload)) {
+    return false;
+  }
+  if (typeof payload.tool_name !== "string" || payload.tool_name.trim().length === 0) {
+    return false;
+  }
+  if (typeof payload.job_to_be_done !== "string" || payload.job_to_be_done.trim().length === 0) {
+    return false;
+  }
+  if (typeof payload.summary_for_model !== "string" || payload.summary_for_model.trim().length === 0) {
+    return false;
+  }
+  if (typeof payload.permission_class !== "string") {
+    return false;
+  }
+  if (typeof payload.dry_run_supported !== "boolean") {
+    return false;
+  }
+  if (!Array.isArray(payload.trigger_conditions)) {
+    return false;
+  }
+  if (!Array.isArray(payload.do_not_use_when)) {
+    return false;
+  }
+  if (!Array.isArray(payload.requires_connected_accounts)) {
+    return false;
+  }
+  if (!Array.isArray(payload.usage_hints)) {
+    return false;
+  }
+  if (!Array.isArray(payload.result_hints)) {
+    return false;
+  }
+  if (!Array.isArray(payload.error_hints)) {
+    return false;
+  }
+  if (!isRecord(payload.input_schema)) {
+    return false;
+  }
+  if (!isRecord(payload.output_schema)) {
+    return false;
+  }
+  return true;
 }
 
 async function findAdapterPath(target: string): Promise<string> {

--- a/siglume-api-sdk-ts/src/diff.ts
+++ b/siglume-api-sdk-ts/src/diff.ts
@@ -1,0 +1,504 @@
+import type { AppManifest, JsonValue, ToolManual } from "./types";
+import { coerceMapping, isRecord, toJsonable } from "./utils";
+
+const MANIFEST_PERMISSION_ORDER: Record<string, number> = {
+  "read-only": 0,
+  recommendation: 0,
+  action: 1,
+  payment: 2,
+};
+const TOOL_MANUAL_PERMISSION_ORDER: Record<string, number> = {
+  read_only: 0,
+  action: 1,
+  payment: 2,
+};
+const SPECIAL_MANIFEST_KEYS = new Set([
+  "version",
+  "name",
+  "short_description",
+  "permission_class",
+  "price_model",
+  "currency",
+  "jurisdiction",
+]);
+const SPECIAL_TOOL_MANUAL_KEYS = new Set([
+  "input_schema",
+  "output_schema",
+  "permission_class",
+  "settlement_mode",
+  "currency",
+  "side_effect_summary",
+  "jurisdiction",
+  "trigger_conditions",
+  "do_not_use_when",
+  "approval_summary_template",
+]);
+
+export const ChangeLevel = {
+  BREAKING: "breaking",
+  WARNING: "warning",
+  INFO: "info",
+} as const;
+export type ChangeLevel = (typeof ChangeLevel)[keyof typeof ChangeLevel];
+
+export const BreakingChange = ChangeLevel.BREAKING;
+
+export interface Change {
+  level: ChangeLevel;
+  path: string;
+  old: JsonValue | Record<string, unknown> | unknown[] | null;
+  new: JsonValue | Record<string, unknown> | unknown[] | null;
+  message: string;
+  is_breaking: boolean;
+}
+
+export function diff_manifest(options: {
+  old: AppManifest | Record<string, unknown>;
+  new: AppManifest | Record<string, unknown>;
+}): Change[] {
+  const oldPayload = normalizeManifest(options.old);
+  const newPayload = normalizeManifest(options.new);
+  const changes: Change[] = [];
+  const emittedKeys = new Set<string>();
+
+  appendPermissionClassChange(
+    changes,
+    emittedKeys,
+    "permission_class",
+    oldPayload.permission_class,
+    newPayload.permission_class,
+    MANIFEST_PERMISSION_ORDER,
+    "Manifest permission_class escalated; existing callers may now require stronger approval.",
+    "Manifest permission_class downgraded.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "price_model",
+    oldPayload.price_model,
+    newPayload.price_model,
+    "Manifest price_model changed; billing compatibility may break existing installs.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "currency",
+    oldPayload.currency,
+    newPayload.currency,
+    "Manifest currency changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "jurisdiction",
+    oldPayload.jurisdiction,
+    newPayload.jurisdiction,
+    "Manifest jurisdiction changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.INFO,
+    "version",
+    oldPayload.version,
+    newPayload.version,
+    "Manifest version changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.INFO,
+    "name",
+    oldPayload.name,
+    newPayload.name,
+    "Manifest display name changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.INFO,
+    "short_description",
+    oldPayload.short_description,
+    newPayload.short_description,
+    "Manifest short_description changed.",
+  );
+
+  for (const key of [...new Set([...Object.keys(oldPayload), ...Object.keys(newPayload)])].sort()) {
+    if (emittedKeys.has(key) || SPECIAL_MANIFEST_KEYS.has(key)) {
+      continue;
+    }
+    const oldValue = oldPayload[key];
+    const newValue = newPayload[key];
+    if (valuesDiffer(oldValue, newValue)) {
+      changes.push(createChange(ChangeLevel.INFO, key, oldValue, newValue, `Manifest field '${key}' changed.`));
+    }
+  }
+
+  return sortChanges(changes);
+}
+
+export function diff_tool_manual(options: {
+  old: ToolManual | Record<string, unknown>;
+  new: ToolManual | Record<string, unknown>;
+}): Change[] {
+  const oldPayload = normalizeToolManual(options.old);
+  const newPayload = normalizeToolManual(options.new);
+  const changes: Change[] = [];
+  const emittedKeys = new Set<string>();
+
+  const oldRequired = stringList(toRecordValue(oldPayload.input_schema).required);
+  const newRequired = stringList(toRecordValue(newPayload.input_schema).required);
+  const addedRequired = [...new Set(newRequired.filter((fieldName) => !oldRequired.includes(fieldName)))].sort();
+  const removedRequired = [...new Set(oldRequired.filter((fieldName) => !newRequired.includes(fieldName)))].sort();
+  if (addedRequired.length > 0) {
+    changes.push(
+      createChange(
+        ChangeLevel.BREAKING,
+        "input_schema.required",
+        oldRequired,
+        newRequired,
+        `input_schema.required added new required fields: ${addedRequired.join(", ")}.`,
+      ),
+    );
+    emittedKeys.add("input_schema");
+  }
+  if (removedRequired.length > 0) {
+    changes.push(
+      createChange(
+        ChangeLevel.INFO,
+        "input_schema.required",
+        oldRequired,
+        newRequired,
+        `input_schema.required removed fields: ${removedRequired.join(", ")}.`,
+      ),
+    );
+    emittedKeys.add("input_schema");
+  }
+
+  appendPermissionClassChange(
+    changes,
+    emittedKeys,
+    "permission_class",
+    oldPayload.permission_class,
+    newPayload.permission_class,
+    TOOL_MANUAL_PERMISSION_ORDER,
+    "ToolManual permission_class escalated; existing callers may now require stronger approval.",
+    "ToolManual permission_class downgraded.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "settlement_mode",
+    oldPayload.settlement_mode,
+    newPayload.settlement_mode,
+    "ToolManual settlement_mode changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "currency",
+    oldPayload.currency,
+    newPayload.currency,
+    "ToolManual currency changed.",
+  );
+  if (valuesDiffer(oldPayload.side_effect_summary, newPayload.side_effect_summary)) {
+    const oldSideEffect = oldPayload.side_effect_summary ?? null;
+    const newSideEffect = newPayload.side_effect_summary ?? null;
+    const level =
+      isBlank(oldSideEffect) && !isBlank(newSideEffect)
+        ? ChangeLevel.BREAKING
+        : !isBlank(oldSideEffect) && isBlank(newSideEffect)
+          ? ChangeLevel.INFO
+          : ChangeLevel.BREAKING;
+    const message =
+      isBlank(oldSideEffect) && !isBlank(newSideEffect)
+        ? "ToolManual side_effect_summary was added, introducing a new side-effect contract."
+        : !isBlank(oldSideEffect) && isBlank(newSideEffect)
+          ? "ToolManual side_effect_summary was removed."
+          : "ToolManual side_effect_summary changed.";
+    changes.push(
+      createChange(
+        level,
+        "side_effect_summary",
+        oldSideEffect,
+        newSideEffect,
+        message,
+      ),
+    );
+    emittedKeys.add("side_effect_summary");
+  }
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.BREAKING,
+    "jurisdiction",
+    oldPayload.jurisdiction,
+    newPayload.jurisdiction,
+    "ToolManual jurisdiction changed.",
+  );
+
+  const oldOutputProperties = toRecordValue(toRecordValue(oldPayload.output_schema).properties);
+  const newOutputProperties = toRecordValue(toRecordValue(newPayload.output_schema).properties);
+  const oldOutputFields = Object.keys(oldOutputProperties).sort();
+  const newOutputFields = Object.keys(newOutputProperties).sort();
+  const addedOutputFields = [...new Set(newOutputFields.filter((fieldName) => !oldOutputFields.includes(fieldName)))].sort();
+  const removedOutputFields = [...new Set(oldOutputFields.filter((fieldName) => !newOutputFields.includes(fieldName)))].sort();
+  const changedOutputFields = [...new Set(
+    oldOutputFields
+      .filter((fieldName) => newOutputFields.includes(fieldName))
+      .filter((fieldName) => valuesDiffer(oldOutputProperties[fieldName], newOutputProperties[fieldName])),
+  )].sort();
+  if (addedOutputFields.length > 0) {
+    changes.push(
+      createChange(
+        ChangeLevel.WARNING,
+        "output_schema.properties",
+        oldOutputFields,
+        newOutputFields,
+        `output_schema added fields: ${addedOutputFields.join(", ")}.`,
+      ),
+    );
+    emittedKeys.add("output_schema");
+  }
+  if (removedOutputFields.length > 0) {
+    changes.push(
+      createChange(
+        ChangeLevel.BREAKING,
+        "output_schema.properties",
+        oldOutputFields,
+        newOutputFields,
+        `output_schema removed fields: ${removedOutputFields.join(", ")}.`,
+      ),
+    );
+    emittedKeys.add("output_schema");
+  }
+  if (changedOutputFields.length > 0) {
+    changes.push(
+      createChange(
+        ChangeLevel.WARNING,
+        "output_schema.properties",
+        oldOutputFields,
+        newOutputFields,
+        `output_schema changed field definitions: ${changedOutputFields.join(", ")}.`,
+      ),
+    );
+    emittedKeys.add("output_schema");
+  }
+
+  appendLargeListChange(
+    changes,
+    emittedKeys,
+    "trigger_conditions",
+    stringList(oldPayload.trigger_conditions),
+    stringList(newPayload.trigger_conditions),
+    "trigger_conditions changed substantially.",
+    "trigger_conditions changed.",
+  );
+  appendLargeListChange(
+    changes,
+    emittedKeys,
+    "do_not_use_when",
+    stringList(oldPayload.do_not_use_when),
+    stringList(newPayload.do_not_use_when),
+    "do_not_use_when changed substantially.",
+    "do_not_use_when changed.",
+  );
+  appendValueChange(
+    changes,
+    emittedKeys,
+    ChangeLevel.WARNING,
+    "approval_summary_template",
+    oldPayload.approval_summary_template,
+    newPayload.approval_summary_template,
+    "approval_summary_template changed.",
+  );
+
+  for (const key of [...new Set([...Object.keys(oldPayload), ...Object.keys(newPayload)])].sort()) {
+    if (emittedKeys.has(key) || SPECIAL_TOOL_MANUAL_KEYS.has(key)) {
+      continue;
+    }
+    const oldValue = oldPayload[key];
+    const newValue = newPayload[key];
+    if (valuesDiffer(oldValue, newValue)) {
+      changes.push(createChange(ChangeLevel.INFO, key, oldValue, newValue, `ToolManual field '${key}' changed.`));
+    }
+  }
+
+  return sortChanges(changes);
+}
+
+function appendLargeListChange(
+  changes: Change[],
+  emittedKeys: Set<string>,
+  key: string,
+  oldItems: string[],
+  newItems: string[],
+  warningMessage: string,
+  infoMessage: string,
+): void {
+  if (sameArray(oldItems, newItems)) {
+    return;
+  }
+  const level = isMajorListChange(oldItems, newItems) ? ChangeLevel.WARNING : ChangeLevel.INFO;
+  changes.push(createChange(level, key, oldItems, newItems, level === ChangeLevel.WARNING ? warningMessage : infoMessage));
+  emittedKeys.add(key);
+}
+
+function appendPermissionClassChange(
+  changes: Change[],
+  emittedKeys: Set<string>,
+  key: string,
+  oldValue: unknown,
+  newValue: unknown,
+  rankMap: Record<string, number>,
+  escalateMessage: string,
+  downgradeMessage: string,
+): void {
+  if (!valuesDiffer(oldValue, newValue)) {
+    return;
+  }
+  const oldRank = typeof oldValue === "string" ? rankMap[oldValue] : undefined;
+  const newRank = typeof newValue === "string" ? rankMap[newValue] : undefined;
+  const level =
+    oldRank !== undefined && newRank !== undefined && newRank > oldRank
+      ? ChangeLevel.BREAKING
+      : ChangeLevel.INFO;
+  const message =
+    oldRank !== undefined && newRank !== undefined && newRank > oldRank
+      ? escalateMessage
+      : oldRank !== undefined && newRank !== undefined && newRank < oldRank
+        ? downgradeMessage
+        : `${key} changed.`;
+  changes.push(createChange(level, key, oldValue, newValue, message));
+  emittedKeys.add(key);
+}
+
+function appendValueChange(
+  changes: Change[],
+  emittedKeys: Set<string>,
+  level: ChangeLevel,
+  key: string,
+  oldValue: unknown,
+  newValue: unknown,
+  message: string,
+): void {
+  if (valuesDiffer(oldValue, newValue)) {
+    changes.push(createChange(level, key, oldValue, newValue, message));
+    emittedKeys.add(key);
+  }
+}
+
+function normalizeManifest(value: AppManifest | Record<string, unknown>): Record<string, unknown> {
+  const payload = coerceMapping(value, "manifest");
+  return {
+    ...payload,
+    price_model: payload.price_model ?? "free",
+    currency: payload.currency ?? "USD",
+  };
+}
+
+function normalizeToolManual(value: ToolManual | Record<string, unknown>): Record<string, unknown> {
+  const payload = coerceMapping(value, "tool manual");
+  return {
+    ...payload,
+    permission_class: payload.permission_class ?? "read_only",
+    requires_connected_accounts: stringList(payload.requires_connected_accounts),
+  };
+}
+
+function createChange(
+  level: ChangeLevel,
+  path: string,
+  oldValue: unknown,
+  newValue: unknown,
+  message: string,
+): Change {
+  return {
+    level,
+    path,
+    old: normalizeForChange(oldValue),
+    new: normalizeForChange(newValue),
+    message,
+    is_breaking: level === ChangeLevel.BREAKING,
+  };
+}
+
+function normalizeForChange(value: unknown): JsonValue | Record<string, unknown> | unknown[] | null {
+  if (value === undefined) {
+    return null;
+  }
+  const normalized = toJsonable(value);
+  if (normalized === undefined) {
+    return null;
+  }
+  return normalized as JsonValue | Record<string, unknown> | unknown[] | null;
+}
+
+function toRecordValue(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? { ...value } : {};
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function valuesDiffer(left: unknown, right: unknown): boolean {
+  return JSON.stringify(stableValue(normalizeForChange(left))) !== JSON.stringify(stableValue(normalizeForChange(right)));
+}
+
+function sameArray(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function isBlank(value: unknown): boolean {
+  return typeof value !== "string" || value.trim().length === 0;
+}
+
+function isMajorListChange(oldItems: string[], newItems: string[]): boolean {
+  const oldSet = new Set(oldItems.map((item) => item.trim().toLowerCase()).filter(Boolean));
+  const newSet = new Set(newItems.map((item) => item.trim().toLowerCase()).filter(Boolean));
+  if (oldSet.size === newSet.size && [...oldSet].every((item) => newSet.has(item))) {
+    return false;
+  }
+  if (oldSet.size === 0 || newSet.size === 0) {
+    return true;
+  }
+  const union = new Set([...oldSet, ...newSet]);
+  const intersection = [...oldSet].filter((item) => newSet.has(item));
+  const similarity = intersection.length / union.size;
+  return similarity < 0.5 || (similarity === 0.5 && Math.abs(oldSet.size - newSet.size) >= 1);
+}
+
+function sortChanges(changes: Change[]): Change[] {
+  const priority: Record<ChangeLevel, number> = {
+    [ChangeLevel.BREAKING]: 0,
+    [ChangeLevel.WARNING]: 1,
+    [ChangeLevel.INFO]: 2,
+  };
+  return [...changes].sort((left, right) => {
+    const levelDelta = priority[left.level] - priority[right.level];
+    return levelDelta !== 0 ? levelDelta : left.path.localeCompare(right.path);
+  });
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableValue(item));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
+}

--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client";
+export * from "./diff";
 export * from "./errors";
 export * from "./runtime";
 export * from "./tool-manual-assist";

--- a/siglume-api-sdk-ts/test/diff-cli.test.ts
+++ b/siglume-api-sdk-ts/test/diff-cli.test.ts
@@ -1,0 +1,192 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../src/cli/index";
+
+async function writePair(oldPayload: Record<string, unknown>, newPayload: Record<string, unknown>): Promise<{ oldPath: string; newPath: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "siglume-ts-diff-cli-"));
+  const oldPath = join(dir, "old.json");
+  const newPath = join(dir, "new.json");
+  await writeFile(oldPath, JSON.stringify(oldPayload, null, 2), "utf8");
+  await writeFile(newPath, JSON.stringify(newPayload, null, 2), "utf8");
+  return { oldPath, newPath };
+}
+
+describe("siglume diff CLI", () => {
+  it("returns exit code 1 for breaking changes in text mode", async () => {
+    const stdout: string[] = [];
+    const { oldPath, newPath } = await writePair(
+      {
+        capability_key: "echo-helper",
+        version: "1.0.0",
+        name: "Echo Helper",
+        job_to_be_done: "Echo the provided text back to the owner.",
+        permission_class: "read-only",
+        approval_mode: "auto",
+        dry_run_supported: true,
+        required_connected_accounts: [],
+        price_model: "free",
+        currency: "USD",
+        jurisdiction: "US",
+      },
+      {
+        capability_key: "echo-helper",
+        version: "1.0.0",
+        name: "Echo Helper",
+        job_to_be_done: "Echo the provided text back to the owner.",
+        permission_class: "action",
+        approval_mode: "auto",
+        dry_run_supported: true,
+        required_connected_accounts: [],
+        price_model: "subscription",
+        currency: "USD",
+        jurisdiction: "US",
+      },
+    );
+
+    const exitCode = await runCli(["diff", oldPath, newPath], { stdout: (line) => stdout.push(line) });
+
+    expect(exitCode).toBe(1);
+    expect(stdout.some((line) => line.includes("BREAKING"))).toBe(true);
+    expect(stdout.some((line) => line.includes("price_model"))).toBe(true);
+  });
+
+  it("returns exit code 2 and machine-readable JSON for warning-only changes", async () => {
+    const stdout: string[] = [];
+    const { oldPath, newPath } = await writePair(
+      {
+        tool_name: "publish_post",
+        job_to_be_done: "Publish a post after the owner approves the action.",
+        summary_for_model: "Creates a post after approval.",
+        trigger_conditions: [
+          "owner asks the agent to publish a drafted post",
+          "agent has final post content ready for submission",
+          "request is to send prepared copy to an external publishing tool",
+        ],
+        do_not_use_when: ["the owner has not approved the outbound post"],
+        permission_class: "action",
+        dry_run_supported: true,
+        requires_connected_accounts: ["publisher"],
+        input_schema: { type: "object", properties: { body: { type: "string" } }, required: ["body"], additionalProperties: false },
+        output_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"], additionalProperties: false },
+        usage_hints: ["Use only after the final post body is ready."],
+        result_hints: ["Confirm where the post was published."],
+        error_hints: ["Explain any provider rejection clearly."],
+        approval_summary_template: "Publish the prepared post.",
+        preview_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"], additionalProperties: false },
+        idempotency_support: true,
+        side_effect_summary: "Creates a new post in the connected provider.",
+        jurisdiction: "US",
+      },
+      {
+        tool_name: "publish_post",
+        job_to_be_done: "Publish a post after the owner approves the action.",
+        summary_for_model: "Creates a post after approval.",
+        trigger_conditions: [
+          "owner asks to broadcast a release announcement",
+          "agent needs to fan out prepared messaging to an external channel",
+          "request is to push already-approved content to a live audience",
+        ],
+        do_not_use_when: [
+          "the content still needs editing or legal review",
+          "the owner has not approved the outbound post",
+        ],
+        permission_class: "action",
+        dry_run_supported: true,
+        requires_connected_accounts: ["publisher"],
+        input_schema: { type: "object", properties: { body: { type: "string" } }, required: ["body"], additionalProperties: false },
+        output_schema: {
+          type: "object",
+          properties: { summary: { type: "string" }, provider_status: { type: "string" } },
+          required: ["summary"],
+          additionalProperties: false,
+        },
+        usage_hints: ["Use only after the final post body is ready."],
+        result_hints: ["Confirm where the post was published."],
+        error_hints: ["Explain any provider rejection clearly."],
+        approval_summary_template: "Publish the approved post to the selected channel.",
+        preview_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"], additionalProperties: false },
+        idempotency_support: true,
+        side_effect_summary: "Creates a new post in the connected provider.",
+        jurisdiction: "US",
+      },
+    );
+
+    const exitCode = await runCli(["diff", oldPath, newPath, "--json"], { stdout: (line) => stdout.push(line) });
+
+    expect(exitCode).toBe(2);
+    const payload = JSON.parse(stdout.join("\n")) as { exit_code: number; changes: Array<{ level: string; path: string }> };
+    expect(payload.exit_code).toBe(2);
+    expect(payload.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ level: "warning", path: "output_schema.properties" }),
+        expect.objectContaining({ level: "warning", path: "approval_summary_template" }),
+      ]),
+    );
+  });
+
+  it("returns exit code 0 for unchanged documents", async () => {
+    const { oldPath, newPath } = await writePair(
+      {
+        capability_key: "echo-helper",
+        version: "1.0.0",
+        name: "Echo Helper",
+        job_to_be_done: "Echo the provided text back to the owner.",
+        permission_class: "read-only",
+        approval_mode: "auto",
+        dry_run_supported: true,
+        required_connected_accounts: [],
+        price_model: "free",
+        currency: "USD",
+        jurisdiction: "US",
+      },
+      {
+        capability_key: "echo-helper",
+        version: "1.0.0",
+        name: "Echo Helper",
+        job_to_be_done: "Echo the provided text back to the owner.",
+        permission_class: "read-only",
+        approval_mode: "auto",
+        dry_run_supported: true,
+        required_connected_accounts: [],
+        price_model: "free",
+        currency: "USD",
+        jurisdiction: "US",
+      },
+    );
+    const stdout: string[] = [];
+
+    const exitCode = await runCli(["diff", oldPath, newPath], { stdout: (line) => stdout.push(line) });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual(["No differences detected."]);
+    expect(await readFile(oldPath, "utf8")).toContain("Echo Helper");
+  });
+
+  it("rejects partial documents whose kind cannot be detected safely", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const { oldPath, newPath } = await writePair(
+      {
+        capability_key: "partial",
+        permission_class: "read-only",
+      },
+      {
+        capability_key: "partial",
+        permission_class: "read-only",
+      },
+    );
+
+    const exitCode = await runCli(["diff", oldPath, newPath], {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("Could not detect document type");
+  });
+});

--- a/siglume-api-sdk-ts/test/diff.test.ts
+++ b/siglume-api-sdk-ts/test/diff.test.ts
@@ -1,0 +1,199 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { BreakingChange, ChangeLevel, diff_manifest, diff_tool_manual } from "../src/diff";
+
+interface FixtureCase {
+  name: string;
+  kind: "manifest" | "tool_manual";
+  old: Record<string, unknown>;
+  new: Record<string, unknown>;
+  expected: Array<{ level: string; path: string }>;
+  exit_code: number;
+}
+
+async function loadCases(): Promise<FixtureCase[]> {
+  const raw = await readFile(join(process.cwd(), "..", "tests", "fixtures", "diff_cases.json"), "utf8");
+  return JSON.parse(raw) as FixtureCase[];
+}
+
+describe("diff rules", () => {
+  it("exports the breaking level constant", () => {
+    expect(BreakingChange).toBe(ChangeLevel.BREAKING);
+  });
+
+  it("matches the manifest and tool-manual golden fixtures", async () => {
+    const cases = await loadCases();
+    for (const fixture of cases) {
+      const changes =
+        fixture.kind === "manifest"
+          ? diff_manifest({ old: fixture.old, new: fixture.new })
+          : diff_tool_manual({ old: fixture.old, new: fixture.new });
+      expect(
+        changes.map((change) => ({ level: change.level, path: change.path })),
+        fixture.name,
+      ).toEqual(fixture.expected);
+    }
+  });
+
+  it("marks breaking changes with is_breaking", async () => {
+    const caseData = (await loadCases())[0]!;
+    const changes = diff_manifest({ old: caseData.old, new: caseData.new });
+
+    expect(changes.some((change) => change.level === ChangeLevel.BREAKING)).toBe(true);
+    expect(changes.every((change) => change.is_breaking === (change.level === ChangeLevel.BREAKING))).toBe(true);
+  });
+
+  it("treats identical documents as no-op", async () => {
+    const caseData = (await loadCases())[0]!;
+    expect(diff_manifest({ old: caseData.old, new: caseData.old })).toEqual([]);
+  });
+
+  it("classifies smaller trigger changes as info instead of warning", () => {
+    const oldManual = {
+      tool_name: "echo_helper",
+      job_to_be_done: "Echo the provided query in a structured response.",
+      summary_for_model: "Returns the provided query inside a stable echo result.",
+      trigger_conditions: [
+        "owner asks the agent to echo a request payload",
+        "agent needs a trivial read-only smoke-test helper",
+        "request is to mirror a provided string in a structured result",
+      ],
+      do_not_use_when: ["the request needs fresh external data rather than a local echo response"],
+      permission_class: "read_only",
+      dry_run_supported: true,
+      requires_connected_accounts: [],
+      input_schema: { type: "object", properties: { query: { type: "string" } }, required: ["query"], additionalProperties: false },
+      output_schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"], additionalProperties: false },
+      usage_hints: ["Use for simple echo smoke tests."],
+      result_hints: ["Return the echoed string clearly."],
+      error_hints: ["If query is missing, ask for the text to echo."],
+    };
+    const newManual = {
+      ...oldManual,
+      trigger_conditions: [
+        "owner asks the agent to echo a request payload",
+        "agent needs a trivial read-only helper for a smoke test",
+        "request is to mirror a provided string in a structured result",
+      ],
+    };
+
+    const changes = diff_tool_manual({ old: oldManual, new: newManual });
+
+    expect(changes).toEqual([
+      expect.objectContaining({ level: ChangeLevel.INFO, path: "trigger_conditions" }),
+    ]);
+  });
+
+  it("ignores key-order-only changes inside nested schemas", () => {
+    const oldManual = {
+      tool_name: "schema_echo",
+      job_to_be_done: "Echo structured data.",
+      summary_for_model: "Returns structured data without mutating state.",
+      trigger_conditions: ["owner asks for schema echo"],
+      do_not_use_when: ["the request needs side effects"],
+      permission_class: "read_only",
+      dry_run_supported: true,
+      requires_connected_accounts: [],
+      input_schema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Echo payload.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      output_schema: {
+        type: "object",
+        properties: {
+          summary: {
+            description: "Summary text.",
+            type: "string",
+          },
+        },
+        required: ["summary"],
+        additionalProperties: false,
+      },
+      usage_hints: ["Use for schema smoke tests."],
+      result_hints: ["Return the summary first."],
+      error_hints: ["Explain missing input clearly."],
+    };
+    const newManual = {
+      ...oldManual,
+      output_schema: {
+        type: "object",
+        properties: {
+          summary: {
+            type: "string",
+            description: "Summary text.",
+          },
+        },
+        required: ["summary"],
+        additionalProperties: false,
+      },
+    };
+
+    expect(diff_tool_manual({ old: oldManual, new: newManual })).toEqual([]);
+  });
+
+  it("reports required-field additions and removals together", () => {
+    const oldManual = {
+      tool_name: "echo_helper",
+      job_to_be_done: "Echo the provided query in a structured response.",
+      summary_for_model: "Returns the provided query inside a stable echo result.",
+      trigger_conditions: [
+        "owner asks the agent to echo a request payload",
+        "agent needs a trivial read-only smoke-test helper",
+        "request is to mirror a provided string in a structured result",
+      ],
+      do_not_use_when: ["the request needs fresh external data rather than a local echo response"],
+      permission_class: "read_only",
+      dry_run_supported: true,
+      requires_connected_accounts: [],
+      input_schema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          locale: { type: "string" },
+        },
+        required: ["query", "locale"],
+        additionalProperties: false,
+      },
+      output_schema: {
+        type: "object",
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+        additionalProperties: false,
+      },
+      usage_hints: ["Use for simple echo smoke tests."],
+      result_hints: ["Return the echoed string clearly."],
+      error_hints: ["If query is missing, ask for the text to echo."],
+    };
+    const newManual = {
+      ...oldManual,
+      input_schema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          timezone: { type: "string" },
+        },
+        required: ["query", "timezone"],
+        additionalProperties: false,
+      },
+    };
+
+    const changes = diff_tool_manual({ old: oldManual, new: newManual });
+
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ level: ChangeLevel.BREAKING, path: "input_schema.required" }),
+        expect.objectContaining({ level: ChangeLevel.INFO, path: "input_schema.required" }),
+      ]),
+    );
+  });
+});

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -76,6 +76,13 @@ from .client import (  # noqa: E402, F401
     SupportCaseRecord,
     UsageEventRecord,
 )
+from .diff import (  # noqa: E402, F401
+    BreakingChange,
+    Change,
+    ChangeLevel,
+    diff_manifest,
+    diff_tool_manual,
+)
 from .tool_manual_assist import (  # noqa: E402, F401
     AnthropicProvider,
     LLMProvider,
@@ -98,12 +105,15 @@ __all__ = sorted(
             "AppListingRecord",
             "AutoRegistrationReceipt",
             "CapabilityBindingRecord",
+            "Change",
+            "ChangeLevel",
             "ConnectedAccountRecord",
             "CursorPage",
             "DEFAULT_SIGLUME_API_BASE",
             "DeveloperPortalSummary",
             "EnvelopeMeta",
             "GrantBindingResult",
+            "BreakingChange",
             "RegistrationConfirmation",
             "RegistrationQuality",
             "SandboxSession",
@@ -117,6 +127,8 @@ __all__ = sorted(
             "AnthropicProvider",
             "LLMProvider",
             "OpenAIProvider",
+            "diff_manifest",
+            "diff_tool_manual",
             "ToolManualAssistAttempt",
             "ToolManualAssistMetadata",
             "ToolManualAssistResult",

--- a/siglume_api_sdk/cli/__init__.py
+++ b/siglume_api_sdk/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import click
 
+from siglume_api_sdk.cli.commands.diff_cmd import diff_command
 from siglume_api_sdk.cli.commands.init_cmd import init_command
 from siglume_api_sdk.cli.commands.register_cmd import register_command
 from siglume_api_sdk.cli.commands.score_cmd import score_command
@@ -17,6 +18,7 @@ def main() -> None:
 
 
 main.add_command(init_command)
+main.add_command(diff_command)
 main.add_command(validate_command)
 main.add_command(test_command)
 main.add_command(score_command)

--- a/siglume_api_sdk/cli/commands/diff_cmd.py
+++ b/siglume_api_sdk/cli/commands/diff_cmd.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+import click
+
+from siglume_api_sdk.diff import Change, ChangeLevel, diff_manifest, diff_tool_manual
+
+
+_CAPABILITY_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$")
+_MANIFEST_REQUIRED_KEYS = {
+    "capability_key",
+    "name",
+    "job_to_be_done",
+    "permission_class",
+    "approval_mode",
+    "dry_run_supported",
+    "required_connected_accounts",
+    "price_model",
+    "jurisdiction",
+}
+_TOOL_MANUAL_REQUIRED_KEYS = {
+    "tool_name",
+    "job_to_be_done",
+    "summary_for_model",
+    "trigger_conditions",
+    "do_not_use_when",
+    "permission_class",
+    "dry_run_supported",
+    "requires_connected_accounts",
+    "input_schema",
+    "output_schema",
+    "usage_hints",
+    "result_hints",
+    "error_hints",
+}
+
+
+@click.command("diff")
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@click.argument("old_path")
+@click.argument("new_path")
+def diff_command(json_output: bool, old_path: str, new_path: str) -> None:
+    old_payload = _load_json_file(old_path)
+    new_payload = _load_json_file(new_path)
+    kind = _detect_kind(old_payload, new_payload)
+    changes = diff_manifest(old=old_payload, new=new_payload) if kind == "manifest" else diff_tool_manual(old=old_payload, new=new_payload)
+    summary = _build_summary(kind, changes, old_path, new_path)
+
+    if json_output:
+        click.echo(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        _render_text(summary)
+
+    raise SystemExit(summary["exit_code"])
+
+
+def _load_json_file(path: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise click.ClickException(f"{path} must contain a top-level JSON object.")
+    return payload
+
+
+def _detect_kind(old_payload: dict[str, Any], new_payload: dict[str, Any]) -> str:
+    old_kind = _payload_kind(old_payload)
+    new_kind = _payload_kind(new_payload)
+    if old_kind != new_kind:
+        raise click.ClickException("Both files must be the same document type (manifest or tool_manual).")
+    if old_kind is None:
+        raise click.ClickException("Could not detect document type. Expected AppManifest or ToolManual JSON.")
+    return old_kind
+
+
+def _payload_kind(payload: dict[str, Any]) -> str | None:
+    if _is_manifest_payload(payload):
+        return "manifest"
+    if _is_tool_manual_payload(payload):
+        return "tool_manual"
+    return None
+
+
+def _is_manifest_payload(payload: dict[str, Any]) -> bool:
+    if not _MANIFEST_REQUIRED_KEYS.issubset(payload):
+        return False
+    if not isinstance(payload.get("capability_key"), str) or not _CAPABILITY_KEY_RE.match(payload["capability_key"]):
+        return False
+    if not isinstance(payload.get("name"), str) or not payload["name"].strip():
+        return False
+    if not isinstance(payload.get("job_to_be_done"), str) or not payload["job_to_be_done"].strip():
+        return False
+    if not isinstance(payload.get("permission_class"), str):
+        return False
+    if not isinstance(payload.get("approval_mode"), str):
+        return False
+    if not isinstance(payload.get("dry_run_supported"), bool):
+        return False
+    if not isinstance(payload.get("required_connected_accounts"), list):
+        return False
+    if not isinstance(payload.get("price_model"), str):
+        return False
+    if not isinstance(payload.get("jurisdiction"), str) or not payload["jurisdiction"].strip():
+        return False
+    return True
+
+
+def _is_tool_manual_payload(payload: dict[str, Any]) -> bool:
+    if not _TOOL_MANUAL_REQUIRED_KEYS.issubset(payload):
+        return False
+    if not isinstance(payload.get("tool_name"), str) or not payload["tool_name"].strip():
+        return False
+    if not isinstance(payload.get("job_to_be_done"), str) or not payload["job_to_be_done"].strip():
+        return False
+    if not isinstance(payload.get("summary_for_model"), str) or not payload["summary_for_model"].strip():
+        return False
+    if not isinstance(payload.get("permission_class"), str):
+        return False
+    if not isinstance(payload.get("dry_run_supported"), bool):
+        return False
+    if not isinstance(payload.get("trigger_conditions"), list):
+        return False
+    if not isinstance(payload.get("do_not_use_when"), list):
+        return False
+    if not isinstance(payload.get("requires_connected_accounts"), list):
+        return False
+    if not isinstance(payload.get("usage_hints"), list):
+        return False
+    if not isinstance(payload.get("result_hints"), list):
+        return False
+    if not isinstance(payload.get("error_hints"), list):
+        return False
+    if not isinstance(payload.get("input_schema"), dict):
+        return False
+    if not isinstance(payload.get("output_schema"), dict):
+        return False
+    return True
+
+
+def _build_summary(kind: str, changes: list[Change], old_path: str, new_path: str) -> dict[str, Any]:
+    counts = {
+        "breaking": sum(1 for change in changes if change.level == ChangeLevel.BREAKING),
+        "warning": sum(1 for change in changes if change.level == ChangeLevel.WARNING),
+        "info": sum(1 for change in changes if change.level == ChangeLevel.INFO),
+    }
+    exit_code = 1 if counts["breaking"] else 2 if counts["warning"] else 0
+    return {
+        "kind": kind,
+        "old_path": str(Path(old_path)),
+        "new_path": str(Path(new_path)),
+        "exit_code": exit_code,
+        "counts": counts,
+        "changes": [change.to_dict() for change in changes],
+    }
+
+
+def _render_text(summary: dict[str, Any]) -> None:
+    if not summary["changes"]:
+        click.echo("No differences detected.")
+        return
+    for level in (ChangeLevel.BREAKING.value, ChangeLevel.WARNING.value, ChangeLevel.INFO.value):
+        items = [item for item in summary["changes"] if item["level"] == level]
+        if not items:
+            continue
+        click.secho(level.upper(), bold=True)
+        for item in items:
+            click.echo(f"- {item['path']}: {item['message']}")
+        click.echo("")

--- a/siglume_api_sdk/diff.py
+++ b/siglume_api_sdk/diff.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ChangeLevel(str, Enum):
+    BREAKING = "breaking"
+    WARNING = "warning"
+    INFO = "info"
+
+
+BreakingChange = ChangeLevel.BREAKING
+
+
+@dataclass(frozen=True)
+class Change:
+    level: ChangeLevel
+    path: str
+    old: Any
+    new: Any
+    message: str
+
+    @property
+    def is_breaking(self) -> bool:
+        return self.level == ChangeLevel.BREAKING
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "level": self.level.value,
+            "path": self.path,
+            "old": self.old,
+            "new": self.new,
+            "message": self.message,
+            "is_breaking": self.is_breaking,
+        }
+
+
+_MANIFEST_PERMISSION_ORDER = {
+    "read-only": 0,
+    "recommendation": 0,
+    "action": 1,
+    "payment": 2,
+}
+_TOOL_MANUAL_PERMISSION_ORDER = {
+    "read_only": 0,
+    "action": 1,
+    "payment": 2,
+}
+_SPECIAL_MANIFEST_KEYS = {
+    "version",
+    "name",
+    "short_description",
+    "permission_class",
+    "price_model",
+    "currency",
+    "jurisdiction",
+}
+_SPECIAL_TOOL_MANUAL_KEYS = {
+    "input_schema",
+    "output_schema",
+    "permission_class",
+    "settlement_mode",
+    "currency",
+    "side_effect_summary",
+    "jurisdiction",
+    "trigger_conditions",
+    "do_not_use_when",
+    "approval_summary_template",
+}
+
+
+def diff_manifest(*, old: Any, new: Any) -> list[Change]:
+    old_payload = _normalize_manifest(old)
+    new_payload = _normalize_manifest(new)
+    changes: list[Change] = []
+    emitted_keys: set[str] = set()
+
+    _append_permission_class_change(
+        changes,
+        emitted_keys,
+        key="permission_class",
+        old_value=old_payload.get("permission_class"),
+        new_value=new_payload.get("permission_class"),
+        rank_map=_MANIFEST_PERMISSION_ORDER,
+        escalate_message="Manifest permission_class escalated; existing callers may now require stronger approval.",
+        downgrade_message="Manifest permission_class downgraded.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="price_model",
+        old_value=old_payload.get("price_model"),
+        new_value=new_payload.get("price_model"),
+        message="Manifest price_model changed; billing compatibility may break existing installs.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="currency",
+        old_value=old_payload.get("currency"),
+        new_value=new_payload.get("currency"),
+        message="Manifest currency changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="jurisdiction",
+        old_value=old_payload.get("jurisdiction"),
+        new_value=new_payload.get("jurisdiction"),
+        message="Manifest jurisdiction changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.INFO,
+        key="version",
+        old_value=old_payload.get("version"),
+        new_value=new_payload.get("version"),
+        message="Manifest version changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.INFO,
+        key="name",
+        old_value=old_payload.get("name"),
+        new_value=new_payload.get("name"),
+        message="Manifest display name changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.INFO,
+        key="short_description",
+        old_value=old_payload.get("short_description"),
+        new_value=new_payload.get("short_description"),
+        message="Manifest short_description changed.",
+    )
+
+    for key in sorted(set(old_payload) | set(new_payload)):
+        if key in emitted_keys or key in _SPECIAL_MANIFEST_KEYS:
+            continue
+        old_value = old_payload.get(key)
+        new_value = new_payload.get(key)
+        if _values_differ(old_value, new_value):
+            changes.append(
+                Change(
+                    level=ChangeLevel.INFO,
+                    path=key,
+                    old=old_value,
+                    new=new_value,
+                    message=f"Manifest field '{key}' changed.",
+                )
+            )
+
+    return _sort_changes(changes)
+
+
+def diff_tool_manual(*, old: Any, new: Any) -> list[Change]:
+    old_payload = _normalize_tool_manual(old)
+    new_payload = _normalize_tool_manual(new)
+    changes: list[Change] = []
+    emitted_keys: set[str] = set()
+
+    old_required = _string_list(_mapping(old_payload.get("input_schema")).get("required"))
+    new_required = _string_list(_mapping(new_payload.get("input_schema")).get("required"))
+    added_required = sorted(set(new_required) - set(old_required))
+    removed_required = sorted(set(old_required) - set(new_required))
+    if added_required:
+        changes.append(
+            Change(
+                level=ChangeLevel.BREAKING,
+                path="input_schema.required",
+                old=old_required,
+                new=new_required,
+                message=f"input_schema.required added new required fields: {', '.join(added_required)}.",
+            )
+        )
+        emitted_keys.add("input_schema")
+    if removed_required:
+        changes.append(
+            Change(
+                level=ChangeLevel.INFO,
+                path="input_schema.required",
+                old=old_required,
+                new=new_required,
+                message=f"input_schema.required removed fields: {', '.join(removed_required)}.",
+            )
+        )
+        emitted_keys.add("input_schema")
+
+    _append_permission_class_change(
+        changes,
+        emitted_keys,
+        key="permission_class",
+        old_value=old_payload.get("permission_class"),
+        new_value=new_payload.get("permission_class"),
+        rank_map=_TOOL_MANUAL_PERMISSION_ORDER,
+        escalate_message="ToolManual permission_class escalated; existing callers may now require stronger approval.",
+        downgrade_message="ToolManual permission_class downgraded.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="settlement_mode",
+        old_value=old_payload.get("settlement_mode"),
+        new_value=new_payload.get("settlement_mode"),
+        message="ToolManual settlement_mode changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="currency",
+        old_value=old_payload.get("currency"),
+        new_value=new_payload.get("currency"),
+        message="ToolManual currency changed.",
+    )
+    if _values_differ(old_payload.get("side_effect_summary"), new_payload.get("side_effect_summary")):
+        old_side_effect = old_payload.get("side_effect_summary")
+        new_side_effect = new_payload.get("side_effect_summary")
+        if _is_blank(old_side_effect) and not _is_blank(new_side_effect):
+            level = ChangeLevel.BREAKING
+            message = "ToolManual side_effect_summary was added, introducing a new side-effect contract."
+        elif not _is_blank(old_side_effect) and _is_blank(new_side_effect):
+            level = ChangeLevel.INFO
+            message = "ToolManual side_effect_summary was removed."
+        else:
+            level = ChangeLevel.BREAKING
+            message = "ToolManual side_effect_summary changed."
+        changes.append(
+            Change(
+                level=level,
+                path="side_effect_summary",
+                old=old_side_effect,
+                new=new_side_effect,
+                message=message,
+            )
+        )
+        emitted_keys.add("side_effect_summary")
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="jurisdiction",
+        old_value=old_payload.get("jurisdiction"),
+        new_value=new_payload.get("jurisdiction"),
+        message="ToolManual jurisdiction changed.",
+    )
+
+    old_output_fields = sorted(_mapping(_mapping(old_payload.get("output_schema")).get("properties")).keys())
+    new_output_fields = sorted(_mapping(_mapping(new_payload.get("output_schema")).get("properties")).keys())
+    added_output_fields = sorted(set(new_output_fields) - set(old_output_fields))
+    removed_output_fields = sorted(set(old_output_fields) - set(new_output_fields))
+    changed_output_fields = sorted(
+        field_name
+        for field_name in set(old_output_fields) & set(new_output_fields)
+        if _values_differ(
+            _mapping(_mapping(old_payload.get("output_schema")).get("properties")).get(field_name),
+            _mapping(_mapping(new_payload.get("output_schema")).get("properties")).get(field_name),
+        )
+    )
+    if added_output_fields:
+        changes.append(
+            Change(
+                level=ChangeLevel.WARNING,
+                path="output_schema.properties",
+                old=old_output_fields,
+                new=new_output_fields,
+                message=f"output_schema added fields: {', '.join(added_output_fields)}.",
+            )
+        )
+        emitted_keys.add("output_schema")
+    if removed_output_fields:
+        changes.append(
+            Change(
+                level=ChangeLevel.BREAKING,
+                path="output_schema.properties",
+                old=old_output_fields,
+                new=new_output_fields,
+                message=f"output_schema removed fields: {', '.join(removed_output_fields)}.",
+            )
+        )
+        emitted_keys.add("output_schema")
+    if changed_output_fields:
+        changes.append(
+            Change(
+                level=ChangeLevel.WARNING,
+                path="output_schema.properties",
+                old=old_output_fields,
+                new=new_output_fields,
+                message=f"output_schema changed field definitions: {', '.join(changed_output_fields)}.",
+            )
+        )
+        emitted_keys.add("output_schema")
+
+    _append_large_list_change(
+        changes,
+        emitted_keys,
+        key="trigger_conditions",
+        old_items=_string_list(old_payload.get("trigger_conditions")),
+        new_items=_string_list(new_payload.get("trigger_conditions")),
+        warning_message="trigger_conditions changed substantially.",
+        info_message="trigger_conditions changed.",
+    )
+    _append_large_list_change(
+        changes,
+        emitted_keys,
+        key="do_not_use_when",
+        old_items=_string_list(old_payload.get("do_not_use_when")),
+        new_items=_string_list(new_payload.get("do_not_use_when")),
+        warning_message="do_not_use_when changed substantially.",
+        info_message="do_not_use_when changed.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.WARNING,
+        key="approval_summary_template",
+        old_value=old_payload.get("approval_summary_template"),
+        new_value=new_payload.get("approval_summary_template"),
+        message="approval_summary_template changed.",
+    )
+
+    for key in sorted(set(old_payload) | set(new_payload)):
+        if key in emitted_keys or key in _SPECIAL_TOOL_MANUAL_KEYS:
+            continue
+        old_value = old_payload.get(key)
+        new_value = new_payload.get(key)
+        if _values_differ(old_value, new_value):
+            changes.append(
+                Change(
+                    level=ChangeLevel.INFO,
+                    path=key,
+                    old=old_value,
+                    new=new_value,
+                    message=f"ToolManual field '{key}' changed.",
+                )
+            )
+
+    return _sort_changes(changes)
+
+
+def _append_large_list_change(
+    changes: list[Change],
+    emitted_keys: set[str],
+    *,
+    key: str,
+    old_items: list[str],
+    new_items: list[str],
+    warning_message: str,
+    info_message: str,
+) -> None:
+    if old_items == new_items:
+        return
+    if _is_major_list_change(old_items, new_items):
+        level = ChangeLevel.WARNING
+        message = warning_message
+    else:
+        level = ChangeLevel.INFO
+        message = info_message
+    changes.append(Change(level=level, path=key, old=old_items, new=new_items, message=message))
+    emitted_keys.add(key)
+
+
+def _append_permission_class_change(
+    changes: list[Change],
+    emitted_keys: set[str],
+    *,
+    key: str,
+    old_value: Any,
+    new_value: Any,
+    rank_map: Mapping[str, int],
+    escalate_message: str,
+    downgrade_message: str,
+) -> None:
+    if not _values_differ(old_value, new_value):
+        return
+    old_rank = rank_map.get(str(old_value)) if old_value is not None else None
+    new_rank = rank_map.get(str(new_value)) if new_value is not None else None
+    if old_rank is not None and new_rank is not None and new_rank > old_rank:
+        level = ChangeLevel.BREAKING
+        message = escalate_message
+    elif old_rank is not None and new_rank is not None and new_rank < old_rank:
+        level = ChangeLevel.INFO
+        message = downgrade_message
+    else:
+        level = ChangeLevel.INFO
+        message = f"{key} changed."
+    changes.append(Change(level=level, path=key, old=old_value, new=new_value, message=message))
+    emitted_keys.add(key)
+
+
+def _append_value_change(
+    changes: list[Change],
+    emitted_keys: set[str],
+    *,
+    level: ChangeLevel,
+    key: str,
+    old_value: Any,
+    new_value: Any,
+    message: str,
+) -> None:
+    if _values_differ(old_value, new_value):
+        changes.append(Change(level=level, path=key, old=old_value, new=new_value, message=message))
+        emitted_keys.add(key)
+
+
+def _normalize_manifest(value: Any) -> dict[str, Any]:
+    payload = _mapping(_normalize_value(value))
+    normalized = dict(payload)
+    normalized["price_model"] = normalized.get("price_model") or "free"
+    normalized["currency"] = normalized.get("currency") or "USD"
+    return normalized
+
+
+def _normalize_tool_manual(value: Any) -> dict[str, Any]:
+    payload = _mapping(_normalize_value(value))
+    normalized = dict(payload)
+    normalized["permission_class"] = normalized.get("permission_class") or "read_only"
+    normalized["requires_connected_accounts"] = _string_list(normalized.get("requires_connected_accounts"))
+    return normalized
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return {key: _normalize_value(item) for key, item in asdict(value).items()}
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return _normalize_value(to_dict())
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_normalize_value(item) for item in value]
+    return value
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def _values_differ(left: Any, right: Any) -> bool:
+    return _stable_value(_normalize_value(left)) != _stable_value(_normalize_value(right))
+
+
+def _is_blank(value: Any) -> bool:
+    return not isinstance(value, str) or value.strip() == ""
+
+
+def _is_major_list_change(old_items: list[str], new_items: list[str]) -> bool:
+    old_set = {item.strip().lower() for item in old_items if item.strip()}
+    new_set = {item.strip().lower() for item in new_items if item.strip()}
+    if old_set == new_set:
+        return False
+    if not old_set or not new_set:
+        return True
+    union = old_set | new_set
+    if not union:
+        return False
+    similarity = len(old_set & new_set) / len(union)
+    return similarity < 0.5 or (similarity == 0.5 and abs(len(old_set) - len(new_set)) >= 1)
+
+
+def _sort_changes(changes: list[Change]) -> list[Change]:
+    priority = {
+        ChangeLevel.BREAKING: 0,
+        ChangeLevel.WARNING: 1,
+        ChangeLevel.INFO: 2,
+    }
+    return sorted(changes, key=lambda item: (priority[item.level], item.path))
+
+
+def _stable_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: _stable_value(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, list):
+        return [_stable_value(item) for item in value]
+    return value
+
+
+__all__ = [
+    "BreakingChange",
+    "Change",
+    "ChangeLevel",
+    "diff_manifest",
+    "diff_tool_manual",
+]

--- a/tests/fixtures/diff_cases.json
+++ b/tests/fixtures/diff_cases.json
@@ -1,0 +1,664 @@
+[
+  {
+    "name": "manifest_breaking_escalation_and_price_model",
+    "kind": "manifest",
+    "old": {
+      "capability_key": "echo-helper",
+      "version": "1.0.0",
+      "name": "Echo Helper",
+      "job_to_be_done": "Echo the provided text back to the owner.",
+      "permission_class": "read-only",
+      "approval_mode": "auto",
+      "dry_run_supported": true,
+      "required_connected_accounts": [],
+      "price_model": "free",
+      "currency": "USD",
+      "jurisdiction": "US",
+      "short_description": "Echo text back to the owner."
+    },
+    "new": {
+      "capability_key": "echo-helper",
+      "version": "1.0.0",
+      "name": "Echo Helper",
+      "job_to_be_done": "Echo the provided text back to the owner.",
+      "permission_class": "action",
+      "approval_mode": "auto",
+      "dry_run_supported": true,
+      "required_connected_accounts": [],
+      "price_model": "subscription",
+      "currency": "USD",
+      "jurisdiction": "US",
+      "short_description": "Echo text back to the owner."
+    },
+    "expected": [
+      {"level": "breaking", "path": "permission_class"},
+      {"level": "breaking", "path": "price_model"}
+    ],
+    "exit_code": 1
+  },
+  {
+    "name": "manifest_info_version_name_short_description_and_downgrade",
+    "kind": "manifest",
+    "old": {
+      "capability_key": "wallet-pay",
+      "version": "1.0.0",
+      "name": "Wallet Pay",
+      "job_to_be_done": "Pay invoices with a connected wallet.",
+      "permission_class": "payment",
+      "approval_mode": "always-ask",
+      "dry_run_supported": true,
+      "required_connected_accounts": ["wallet"],
+      "price_model": "subscription",
+      "currency": "USD",
+      "jurisdiction": "US",
+      "short_description": "Pay invoices with a wallet."
+    },
+    "new": {
+      "capability_key": "wallet-pay",
+      "version": "1.1.0",
+      "name": "Wallet Pay v2",
+      "job_to_be_done": "Pay invoices with a connected wallet.",
+      "permission_class": "action",
+      "approval_mode": "always-ask",
+      "dry_run_supported": true,
+      "required_connected_accounts": ["wallet"],
+      "price_model": "subscription",
+      "currency": "USD",
+      "jurisdiction": "US",
+      "short_description": "Pay and track invoices with a wallet."
+    },
+    "expected": [
+      {"level": "info", "path": "name"},
+      {"level": "info", "path": "permission_class"},
+      {"level": "info", "path": "short_description"},
+      {"level": "info", "path": "version"}
+    ],
+    "exit_code": 0
+  },
+  {
+    "name": "tool_manual_breaking_input_required_addition",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "echo_helper",
+      "job_to_be_done": "Echo the provided query in a structured response.",
+      "summary_for_model": "Returns the provided query inside a stable echo result.",
+      "trigger_conditions": [
+        "owner asks the agent to echo a request payload",
+        "agent needs a trivial read-only smoke-test helper",
+        "request is to mirror a provided string in a structured result"
+      ],
+      "do_not_use_when": [
+        "the request needs fresh external data rather than a local echo response"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string"}
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use for simple echo smoke tests."],
+      "result_hints": ["Return the echoed string clearly."],
+      "error_hints": ["If query is missing, ask for the text to echo."]
+    },
+    "new": {
+      "tool_name": "echo_helper",
+      "job_to_be_done": "Echo the provided query in a structured response.",
+      "summary_for_model": "Returns the provided query inside a stable echo result.",
+      "trigger_conditions": [
+        "owner asks the agent to echo a request payload",
+        "agent needs a trivial read-only smoke-test helper",
+        "request is to mirror a provided string in a structured result"
+      ],
+      "do_not_use_when": [
+        "the request needs fresh external data rather than a local echo response"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string"},
+          "locale": {"type": "string"}
+        },
+        "required": ["query", "locale"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use for simple echo smoke tests."],
+      "result_hints": ["Return the echoed string clearly."],
+      "error_hints": ["If query is missing, ask for the text to echo."]
+    },
+    "expected": [
+      {"level": "breaking", "path": "input_schema.required"}
+    ],
+    "exit_code": 1
+  },
+  {
+    "name": "tool_manual_warning_output_template_and_list_drift",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "publish_post",
+      "job_to_be_done": "Publish a post after the owner approves the action.",
+      "summary_for_model": "Creates a post in the connected publishing system after approval.",
+      "trigger_conditions": [
+        "owner asks the agent to publish a drafted post",
+        "agent has final post content ready for submission",
+        "request is to send prepared copy to an external publishing tool"
+      ],
+      "do_not_use_when": [
+        "the owner has not approved the outbound post"
+      ],
+      "permission_class": "action",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["publisher"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "body": {"type": "string"}
+        },
+        "required": ["body"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use only after the final post body is ready."],
+      "result_hints": ["Confirm where the post was published."],
+      "error_hints": ["If the provider rejects the post, explain the provider response."],
+      "approval_summary_template": "Publish the prepared post.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Creates a new post in the connected provider.",
+      "jurisdiction": "US"
+    },
+    "new": {
+      "tool_name": "publish_post",
+      "job_to_be_done": "Publish a post after the owner approves the action.",
+      "summary_for_model": "Creates a post in the connected publishing system after approval.",
+      "trigger_conditions": [
+        "owner asks to broadcast a release announcement",
+        "agent needs to fan out prepared messaging to an external channel",
+        "request is to push already-approved content to a live audience"
+      ],
+      "do_not_use_when": [
+        "the content still needs editing or legal review",
+        "the owner has not approved the outbound post"
+      ],
+      "permission_class": "action",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["publisher"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "body": {"type": "string"}
+        },
+        "required": ["body"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"},
+          "provider_status": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use only after the final post body is ready."],
+      "result_hints": ["Confirm where the post was published."],
+      "error_hints": ["If the provider rejects the post, explain the provider response."],
+      "approval_summary_template": "Publish the approved post to the selected channel.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Creates a new post in the connected provider.",
+      "jurisdiction": "US"
+    },
+    "expected": [
+      {"level": "warning", "path": "approval_summary_template"},
+      {"level": "warning", "path": "do_not_use_when"},
+      {"level": "warning", "path": "output_schema.properties"},
+      {"level": "warning", "path": "trigger_conditions"}
+    ],
+    "exit_code": 2
+  },
+  {
+    "name": "tool_manual_breaking_side_effect_and_jurisdiction",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "invoice_lookup",
+      "job_to_be_done": "Look up invoice metadata by identifier.",
+      "summary_for_model": "Returns invoice details without changing external state.",
+      "trigger_conditions": [
+        "owner asks for invoice metadata by identifier",
+        "agent needs invoice status before taking another step",
+        "request is to inspect an invoice rather than mutate it"
+      ],
+      "do_not_use_when": [
+        "the request is to modify or pay the invoice"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "invoice_id": {"type": "string"}
+        },
+        "required": ["invoice_id"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use when the owner needs invoice status."],
+      "result_hints": ["Lead with invoice status and amount."],
+      "error_hints": ["If the invoice is missing, ask the owner to verify the identifier."],
+      "side_effect_summary": "",
+      "jurisdiction": "US"
+    },
+    "new": {
+      "tool_name": "invoice_lookup",
+      "job_to_be_done": "Look up invoice metadata by identifier.",
+      "summary_for_model": "Returns invoice details without changing external state.",
+      "trigger_conditions": [
+        "owner asks for invoice metadata by identifier",
+        "agent needs invoice status before taking another step",
+        "request is to inspect an invoice rather than mutate it"
+      ],
+      "do_not_use_when": [
+        "the request is to modify or pay the invoice"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "invoice_id": {"type": "string"}
+        },
+        "required": ["invoice_id"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use when the owner needs invoice status."],
+      "result_hints": ["Lead with invoice status and amount."],
+      "error_hints": ["If the invoice is missing, ask the owner to verify the identifier."],
+      "side_effect_summary": "Creates an outbound audit record in the billing provider.",
+      "jurisdiction": "JP"
+    },
+    "expected": [
+      {"level": "breaking", "path": "jurisdiction"},
+      {"level": "breaking", "path": "side_effect_summary"}
+    ],
+    "exit_code": 1
+  },
+  {
+    "name": "tool_manual_info_downgrade_and_name_change",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "wallet_charge",
+      "job_to_be_done": "Charge a stored wallet after owner approval.",
+      "summary_for_model": "Executes a stored-value wallet charge after approval.",
+      "trigger_conditions": [
+        "owner asks to charge a stored wallet",
+        "agent has a finalized amount and approval context",
+        "request is to complete a wallet payment"
+      ],
+      "do_not_use_when": [
+        "the owner has not approved the charge"
+      ],
+      "permission_class": "payment",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {"type": "number"}
+        },
+        "required": ["amount_usd"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"},
+          "amount_usd": {"type": "number"},
+          "currency": {"type": "string"}
+        },
+        "required": ["summary", "amount_usd", "currency"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use only for approved wallet charges."],
+      "result_hints": ["Confirm the settled amount and status."],
+      "error_hints": ["If the payment fails, include the provider failure reason."],
+      "approval_summary_template": "Charge the stored wallet.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Captures a wallet payment.",
+      "quote_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {"type": "number"},
+          "currency": {"type": "string"}
+        },
+        "required": ["amount_usd", "currency"],
+        "additionalProperties": false
+      },
+      "currency": "USD",
+      "settlement_mode": "embedded_wallet_charge",
+      "refund_or_cancellation_note": "Refunds follow the merchant policy.",
+      "jurisdiction": "US"
+    },
+    "new": {
+      "tool_name": "wallet_quote",
+      "job_to_be_done": "Charge a stored wallet after owner approval.",
+      "summary_for_model": "Executes a stored-value wallet charge after approval.",
+      "trigger_conditions": [
+        "owner asks to charge a stored wallet",
+        "agent has a finalized amount and approval context",
+        "request is to complete a wallet payment"
+      ],
+      "do_not_use_when": [
+        "the owner has not approved the charge"
+      ],
+      "permission_class": "action",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {"type": "number"}
+        },
+        "required": ["amount_usd"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"},
+          "amount_usd": {"type": "number"},
+          "currency": {"type": "string"}
+        },
+        "required": ["summary", "amount_usd", "currency"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use only for approved wallet charges."],
+      "result_hints": ["Confirm the settled amount and status."],
+      "error_hints": ["If the payment fails, include the provider failure reason."],
+      "approval_summary_template": "Charge the stored wallet.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Captures a wallet payment.",
+      "quote_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {"type": "number"},
+          "currency": {"type": "string"}
+        },
+        "required": ["amount_usd", "currency"],
+        "additionalProperties": false
+      },
+      "currency": "USD",
+      "settlement_mode": "embedded_wallet_charge",
+      "refund_or_cancellation_note": "Refunds follow the merchant policy.",
+      "jurisdiction": "US"
+    },
+    "expected": [
+      {"level": "info", "path": "permission_class"},
+      {"level": "info", "path": "tool_name"}
+    ],
+    "exit_code": 0
+  },
+  {
+    "name": "tool_manual_breaking_output_removal_and_side_effect_rewrite",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "invoice_sync",
+      "job_to_be_done": "Sync invoice status into the CRM.",
+      "summary_for_model": "Pushes invoice metadata into a connected CRM record.",
+      "trigger_conditions": [
+        "owner asks to sync invoice metadata into CRM",
+        "agent already has the invoice details ready for export",
+        "request is to update an external CRM record with invoice status"
+      ],
+      "do_not_use_when": [
+        "the invoice details are incomplete",
+        "the CRM connection is missing"
+      ],
+      "permission_class": "action",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["crm"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "invoice_id": {"type": "string"}
+        },
+        "required": ["invoice_id"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"},
+          "crm_record_id": {"type": "string"}
+        },
+        "required": ["summary", "crm_record_id"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use after validating the invoice is final."],
+      "result_hints": ["Show the CRM record identifier that was updated."],
+      "error_hints": ["Explain whether the sync failed because of invoice data or CRM auth."],
+      "approval_summary_template": "Sync invoice status into CRM.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Updates an existing CRM invoice record.",
+      "jurisdiction": "US"
+    },
+    "new": {
+      "tool_name": "invoice_sync",
+      "job_to_be_done": "Sync invoice status into the CRM.",
+      "summary_for_model": "Pushes invoice metadata into a connected CRM record.",
+      "trigger_conditions": [
+        "owner asks to sync invoice metadata into CRM",
+        "agent already has the invoice details ready for export",
+        "request is to update an external CRM record with invoice status"
+      ],
+      "do_not_use_when": [
+        "the invoice details are incomplete",
+        "the CRM connection is missing"
+      ],
+      "permission_class": "action",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["crm"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "invoice_id": {"type": "string"}
+        },
+        "required": ["invoice_id"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use after validating the invoice is final."],
+      "result_hints": ["Show the CRM record identifier that was updated."],
+      "error_hints": ["Explain whether the sync failed because of invoice data or CRM auth."],
+      "approval_summary_template": "Sync invoice status into CRM.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Creates a CRM task and updates the invoice record.",
+      "jurisdiction": "US"
+    },
+    "expected": [
+      {"level": "breaking", "path": "output_schema.properties"},
+      {"level": "breaking", "path": "side_effect_summary"}
+    ],
+    "exit_code": 1
+  },
+  {
+    "name": "tool_manual_info_required_removal",
+    "kind": "tool_manual",
+    "old": {
+      "tool_name": "contact_lookup",
+      "job_to_be_done": "Look up a CRM contact.",
+      "summary_for_model": "Returns CRM contact details for the provided identifier.",
+      "trigger_conditions": [
+        "owner asks for contact details from CRM",
+        "agent needs CRM metadata for a known contact",
+        "request is to inspect a CRM contact rather than mutate it"
+      ],
+      "do_not_use_when": [
+        "the request is to update the contact"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["crm"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "contact_id": {"type": "string"},
+          "include_notes": {"type": "boolean"}
+        },
+        "required": ["contact_id", "include_notes"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use when the contact identifier is already known."],
+      "result_hints": ["Lead with contact status and owner."],
+      "error_hints": ["If the contact is missing, ask the owner to verify the identifier."]
+    },
+    "new": {
+      "tool_name": "contact_lookup",
+      "job_to_be_done": "Look up a CRM contact.",
+      "summary_for_model": "Returns CRM contact details for the provided identifier.",
+      "trigger_conditions": [
+        "owner asks for contact details from CRM",
+        "agent needs CRM metadata for a known contact",
+        "request is to inspect a CRM contact rather than mutate it"
+      ],
+      "do_not_use_when": [
+        "the request is to update the contact"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": ["crm"],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "contact_id": {"type": "string"},
+          "include_notes": {"type": "boolean"}
+        },
+        "required": ["contact_id"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {"type": "string"}
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+      },
+      "usage_hints": ["Use when the contact identifier is already known."],
+      "result_hints": ["Lead with contact status and owner."],
+      "error_hints": ["If the contact is missing, ask the owner to verify the identifier."]
+    },
+    "expected": [
+      {"level": "info", "path": "input_schema.required"}
+    ],
+    "exit_code": 0
+  }
+]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk.cli import main  # noqa: E402
+from siglume_api_sdk.diff import ChangeLevel, diff_manifest, diff_tool_manual  # noqa: E402
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "diff_cases.json"
+CASES = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+def test_diff_rules_match_golden_cases(case: dict[str, object]) -> None:
+    diff_fn = diff_manifest if case["kind"] == "manifest" else diff_tool_manual
+    changes = diff_fn(old=case["old"], new=case["new"])
+
+    assert [
+        {"level": change.level.value, "path": change.path}
+        for change in changes
+    ] == case["expected"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[f"cli-{case['name']}" for case in CASES])
+def test_diff_cli_json_exit_codes(case: dict[str, object]) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("old.json").write_text(json.dumps(case["old"], indent=2), encoding="utf-8")
+        Path("new.json").write_text(json.dumps(case["new"], indent=2), encoding="utf-8")
+
+        result = runner.invoke(main, ["diff", "old.json", "new.json", "--json"])
+
+        assert result.exit_code == case["exit_code"], result.output
+        payload = json.loads(result.output)
+        assert payload["exit_code"] == case["exit_code"]
+        assert [
+            {"level": item["level"], "path": item["path"]}
+            for item in payload["changes"]
+        ] == case["expected"]
+
+
+def test_diff_cli_text_groups_levels() -> None:
+    runner = CliRunner()
+    warning_case = next(case for case in CASES if case["name"] == "tool_manual_warning_output_template_and_list_drift")
+    with runner.isolated_filesystem():
+        Path("old.json").write_text(json.dumps(warning_case["old"], indent=2), encoding="utf-8")
+        Path("new.json").write_text(json.dumps(warning_case["new"], indent=2), encoding="utf-8")
+
+        result = runner.invoke(main, ["diff", "old.json", "new.json"])
+
+        assert result.exit_code == 2, result.output
+        assert "WARNING" in result.output
+        assert "output_schema.properties" in result.output
+        assert "approval_summary_template" in result.output
+
+
+def test_diff_cli_reports_no_changes() -> None:
+    runner = CliRunner()
+    unchanged_case = CASES[0]
+    with runner.isolated_filesystem():
+        Path("old.json").write_text(json.dumps(unchanged_case["old"], indent=2), encoding="utf-8")
+        Path("new.json").write_text(json.dumps(unchanged_case["old"], indent=2), encoding="utf-8")
+
+        result = runner.invoke(main, ["diff", "old.json", "new.json"])
+
+        assert result.exit_code == 0, result.output
+        assert "No differences detected." in result.output
+
+
+def test_diff_manifest_returns_breaking_change_members() -> None:
+    case = CASES[0]
+    changes = diff_manifest(old=case["old"], new=case["new"])
+
+    assert any(change.level == ChangeLevel.BREAKING for change in changes)
+    assert all(change.is_breaking == (change.level == ChangeLevel.BREAKING) for change in changes)
+
+
+def test_diff_tool_manual_ignores_key_order_only_changes() -> None:
+    old_manual = {
+        "tool_name": "schema_echo",
+        "job_to_be_done": "Echo structured data.",
+        "summary_for_model": "Returns structured data without mutating state.",
+        "trigger_conditions": ["owner asks for schema echo"],
+        "do_not_use_when": ["the request needs side effects"],
+        "permission_class": "read_only",
+        "dry_run_supported": True,
+        "requires_connected_accounts": [],
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Echo payload.",
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "description": "Summary text.",
+                    "type": "string",
+                }
+            },
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+        "usage_hints": ["Use for schema smoke tests."],
+        "result_hints": ["Return the summary first."],
+        "error_hints": ["Explain missing input clearly."],
+    }
+    new_manual = {
+        **old_manual,
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Summary text.",
+                }
+            },
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+    }
+
+    assert diff_tool_manual(old=old_manual, new=new_manual) == []
+
+
+def test_diff_tool_manual_reports_required_add_and_remove_together() -> None:
+    old_manual = {
+        "tool_name": "echo_helper",
+        "job_to_be_done": "Echo the provided query in a structured response.",
+        "summary_for_model": "Returns the provided query inside a stable echo result.",
+        "trigger_conditions": [
+            "owner asks the agent to echo a request payload",
+            "agent needs a trivial read-only smoke-test helper",
+            "request is to mirror a provided string in a structured result",
+        ],
+        "do_not_use_when": ["the request needs fresh external data rather than a local echo response"],
+        "permission_class": "read_only",
+        "dry_run_supported": True,
+        "requires_connected_accounts": [],
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "locale": {"type": "string"},
+            },
+            "required": ["query", "locale"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+        "usage_hints": ["Use for simple echo smoke tests."],
+        "result_hints": ["Return the echoed string clearly."],
+        "error_hints": ["If query is missing, ask for the text to echo."],
+    }
+    new_manual = {
+        **old_manual,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "timezone": {"type": "string"},
+            },
+            "required": ["query", "timezone"],
+            "additionalProperties": False,
+        },
+    }
+
+    changes = diff_tool_manual(old=old_manual, new=new_manual)
+
+    assert any(change.level == ChangeLevel.BREAKING and change.path == "input_schema.required" for change in changes)
+    assert any(change.level == ChangeLevel.INFO and change.path == "input_schema.required" for change in changes)
+
+
+def test_diff_cli_rejects_partial_documents_with_unknown_kind() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("old.json").write_text(
+            json.dumps(
+                {
+                    "capability_key": "partial",
+                    "permission_class": "read-only",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        Path("new.json").write_text(
+            json.dumps(
+                {
+                    "capability_key": "partial",
+                    "permission_class": "read-only",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(main, ["diff", "old.json", "new.json"])
+
+        assert result.exit_code == 1
+        assert "Could not detect document type" in result.output


### PR DESCRIPTION
## Summary
- add pure-function Manifest / ToolManual diff helpers in Python and TypeScript
- classify changes into breaking / warning / info and expose `siglume diff <old.json> <new.json>` in both CLIs
- add shared golden fixtures so Python and TS keep parity on the same rule set

## Test plan
- [x] `py -3.11 -m ruff check .`
- [x] `py -3.11 -m pytest` -> 77 passed
- [x] `py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\contract_sync.py`
- [x] `py -3.11 scripts\contract_sync.py`
- [x] `npm run lint`
- [x] `npm test` -> 95 passed, coverage >= 85%
- [x] `npm run build`
- [x] reviewer agent (Sagan): no critical / warning