### PR TITLE
feat(exporters): Tool schema exporter for Anthropic/OpenAI/MCP (PR-K)

### DIFF
--- a/siglume-api-sdk-ts/src/exporters.ts
+++ b/siglume-api-sdk-ts/src/exporters.ts
@@ -1,0 +1,342 @@
+import type { ToolManual } from "./types";
+import { coerceMapping, isRecord, toJsonable } from "./utils";
+
+export interface ToolSchemaExport<TSchema = Record<string, unknown>> {
+  schema: TSchema;
+  lossy_fields: string[];
+  warnings: string[];
+}
+
+export interface AnthropicToolDefinition {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface OpenAIFunctionDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  strict: true;
+}
+
+export interface OpenAIResponsesToolDefinition {
+  type: "function";
+  function: OpenAIFunctionDefinition;
+}
+
+export interface McpToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  annotations: {
+    readOnlyHint: boolean;
+    destructiveHint: boolean;
+    idempotentHint: boolean;
+  };
+}
+
+const SECTION_ORDER = [
+  "summary",
+  "permission",
+  "when_to_use",
+  "avoid_when",
+  "usage_hints",
+  "result_hints",
+  "error_hints",
+  "connected_accounts",
+  "dry_run",
+  "approval_summary_template",
+  "side_effect_summary",
+  "jurisdiction",
+  "legal_notes",
+  "idempotency_support",
+  "currency",
+  "settlement_mode",
+  "refund_or_cancellation_note",
+] as const;
+
+const LOSSY_WARNING_MESSAGES = {
+  anthropic: {
+    output_schema: "output_schema omitted - Anthropic tool definitions do not model output schemas.",
+    approval_summary_template: "approval_summary_template merged into description - Anthropic tool definitions do not model approval summaries.",
+    preview_schema: "preview_schema omitted - Anthropic tool definitions do not model previews.",
+    idempotency_support: "idempotency_support merged into description - Anthropic tool definitions do not model idempotency hints.",
+    side_effect_summary: "side_effect_summary merged into description - Anthropic tool definitions do not model side-effect summaries.",
+    quote_schema: "quote_schema omitted - Anthropic tool definitions do not model payment quote schemas.",
+    currency: "currency merged into description - Anthropic tool definitions do not model settlement currency metadata.",
+    settlement_mode: "settlement_mode merged into description - Anthropic tool definitions do not model settlement-mode metadata.",
+    refund_or_cancellation_note: "refund_or_cancellation_note merged into description - Anthropic tool definitions do not model refund policy metadata.",
+    jurisdiction: "jurisdiction merged into description - Anthropic tool definitions do not model jurisdiction metadata.",
+    legal_notes: "legal_notes merged into description - Anthropic tool definitions do not model legal note metadata.",
+  },
+  openai_function: {
+    output_schema: "output_schema omitted - OpenAI function definitions do not model output schemas.",
+    approval_summary_template: "approval_summary_template merged into description - OpenAI function definitions do not model approval summaries.",
+    preview_schema: "preview_schema omitted - OpenAI function definitions do not model previews.",
+    idempotency_support: "idempotency_support merged into description - OpenAI function definitions do not model idempotency hints.",
+    side_effect_summary: "side_effect_summary merged into description - OpenAI function definitions do not model side-effect summaries.",
+    quote_schema: "quote_schema omitted - OpenAI function definitions do not model payment quote schemas.",
+    currency: "currency merged into description - OpenAI function definitions do not model settlement currency metadata.",
+    settlement_mode: "settlement_mode merged into description - OpenAI function definitions do not model settlement-mode metadata.",
+    refund_or_cancellation_note: "refund_or_cancellation_note merged into description - OpenAI function definitions do not model refund policy metadata.",
+    jurisdiction: "jurisdiction merged into description - OpenAI function definitions do not model jurisdiction metadata.",
+    legal_notes: "legal_notes merged into description - OpenAI function definitions do not model legal note metadata.",
+  },
+  openai_responses_tool: {
+    output_schema: "output_schema omitted - OpenAI Responses tool definitions do not model output schemas.",
+    approval_summary_template: "approval_summary_template merged into description - OpenAI Responses tool definitions do not model approval summaries.",
+    preview_schema: "preview_schema omitted - OpenAI Responses tool definitions do not model previews.",
+    idempotency_support: "idempotency_support merged into description - OpenAI Responses tool definitions do not model idempotency hints.",
+    side_effect_summary: "side_effect_summary merged into description - OpenAI Responses tool definitions do not model side-effect summaries.",
+    quote_schema: "quote_schema omitted - OpenAI Responses tool definitions do not model payment quote schemas.",
+    currency: "currency merged into description - OpenAI Responses tool definitions do not model settlement currency metadata.",
+    settlement_mode: "settlement_mode merged into description - OpenAI Responses tool definitions do not model settlement-mode metadata.",
+    refund_or_cancellation_note: "refund_or_cancellation_note merged into description - OpenAI Responses tool definitions do not model refund policy metadata.",
+    jurisdiction: "jurisdiction merged into description - OpenAI Responses tool definitions do not model jurisdiction metadata.",
+    legal_notes: "legal_notes merged into description - OpenAI Responses tool definitions do not model legal note metadata.",
+  },
+  mcp: {
+    approval_summary_template: "approval_summary_template merged into description - MCP tool descriptors do not model approval summaries.",
+    preview_schema: "preview_schema omitted - MCP tool descriptors do not model previews.",
+    side_effect_summary: "side_effect_summary merged into description - MCP tool descriptors do not model side-effect summaries.",
+    quote_schema: "quote_schema omitted - MCP tool descriptors do not model payment quote schemas.",
+    currency: "currency merged into description - MCP tool descriptors do not model settlement currency metadata.",
+    settlement_mode: "settlement_mode merged into description - MCP tool descriptors do not model settlement-mode metadata.",
+    refund_or_cancellation_note: "refund_or_cancellation_note merged into description - MCP tool descriptors do not model refund policy metadata.",
+    jurisdiction: "jurisdiction merged into description - MCP tool descriptors do not model jurisdiction metadata.",
+    legal_notes: "legal_notes merged into description - MCP tool descriptors do not model legal note metadata.",
+  },
+} as const;
+
+type LossyProvider = keyof typeof LOSSY_WARNING_MESSAGES;
+
+export function to_anthropic_tool(tool_manual: ToolManual | Record<string, unknown>): ToolSchemaExport<AnthropicToolDefinition> {
+  const manual = coerceToolManual(tool_manual);
+  const tool_name = requiredNonEmptyString(manual, "tool_name");
+  const lossy_fields = lossyFields("anthropic", manual);
+  return {
+    schema: {
+      name: tool_name,
+      description: buildDescription(manual),
+      input_schema: toRecord(manual.input_schema),
+    },
+    lossy_fields,
+    warnings: warningsFor("anthropic", lossy_fields),
+  };
+}
+
+export function to_openai_function(tool_manual: ToolManual | Record<string, unknown>): ToolSchemaExport<OpenAIFunctionDefinition> {
+  const manual = coerceToolManual(tool_manual);
+  const tool_name = requiredNonEmptyString(manual, "tool_name");
+  const lossy_fields = lossyFields("openai_function", manual);
+  return {
+    schema: {
+      name: tool_name,
+      description: buildDescription(manual),
+      parameters: toRecord(manual.input_schema),
+      strict: true,
+    },
+    lossy_fields,
+    warnings: warningsFor("openai_function", lossy_fields),
+  };
+}
+
+export function to_openai_responses_tool(
+  tool_manual: ToolManual | Record<string, unknown>,
+): ToolSchemaExport<OpenAIResponsesToolDefinition> {
+  const manual = coerceToolManual(tool_manual);
+  const tool_name = requiredNonEmptyString(manual, "tool_name");
+  const lossy_fields = lossyFields("openai_responses_tool", manual);
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: tool_name,
+        description: buildDescription(manual),
+        parameters: toRecord(manual.input_schema),
+        strict: true,
+      },
+    },
+    lossy_fields,
+    warnings: warningsFor("openai_responses_tool", lossy_fields),
+  };
+}
+
+export function to_mcp_tool(tool_manual: ToolManual | Record<string, unknown>): ToolSchemaExport<McpToolDescriptor> {
+  const manual = coerceToolManual(tool_manual);
+  const tool_name = requiredNonEmptyString(manual, "tool_name");
+  const permission_class = stringValue(manual.permission_class) ?? "read_only";
+  const lossy_fields = lossyFields("mcp", manual);
+  return {
+    schema: {
+      name: tool_name,
+      description: buildDescription(manual),
+      inputSchema: toRecord(manual.input_schema),
+      outputSchema: toRecord(manual.output_schema),
+      annotations: {
+        readOnlyHint: permission_class === "read_only",
+        destructiveHint: permission_class !== "read_only",
+        idempotentHint:
+          manual.idempotency_support !== undefined && manual.idempotency_support !== null
+            ? Boolean(manual.idempotency_support)
+            : permission_class === "read_only",
+      },
+    },
+    lossy_fields,
+    warnings: warningsFor("mcp", lossy_fields),
+  };
+}
+
+function coerceToolManual(tool_manual: ToolManual | Record<string, unknown>): Record<string, unknown> {
+  return coerceMapping(tool_manual, "tool_manual");
+}
+
+function buildDescription(manual: Record<string, unknown>): string {
+  const sections: Record<string, string> = {};
+  const summary = stringValue(manual.summary_for_model);
+  if (summary) {
+    sections.summary = summary;
+  }
+
+  const permission_class = stringValue(manual.permission_class);
+  if (permission_class) {
+    sections.permission = `Permission class: ${permission_class}.`;
+  }
+
+  const trigger_conditions = stringList(manual.trigger_conditions);
+  if (trigger_conditions.length > 0) {
+    sections.when_to_use = renderListSection("When to use", trigger_conditions);
+  }
+
+  const do_not_use_when = stringList(manual.do_not_use_when);
+  if (do_not_use_when.length > 0) {
+    sections.avoid_when = renderListSection("Avoid when", do_not_use_when);
+  }
+
+  const usage_hints = stringList(manual.usage_hints);
+  if (usage_hints.length > 0) {
+    sections.usage_hints = renderListSection("Usage hints", usage_hints);
+  }
+
+  const result_hints = stringList(manual.result_hints);
+  if (result_hints.length > 0) {
+    sections.result_hints = renderListSection("Result hints", result_hints);
+  }
+
+  const error_hints = stringList(manual.error_hints);
+  if (error_hints.length > 0) {
+    sections.error_hints = renderListSection("Error hints", error_hints);
+  }
+
+  const connected_accounts = stringList(manual.requires_connected_accounts);
+  if (connected_accounts.length > 0) {
+    sections.connected_accounts = renderListSection("Requires connected accounts", connected_accounts);
+  }
+
+  if ("dry_run_supported" in manual) {
+    sections.dry_run = `Dry run supported: ${manual.dry_run_supported ? "yes" : "no"}.`;
+  }
+
+  const approval_summary_template = stringValue(manual.approval_summary_template);
+  if (approval_summary_template) {
+    sections.approval_summary_template = `Approval summary template: ${approval_summary_template}`;
+  }
+
+  const side_effect_summary = stringValue(manual.side_effect_summary);
+  if (side_effect_summary) {
+    sections.side_effect_summary = `Side effects: ${side_effect_summary}`;
+  }
+
+  const jurisdiction = stringValue(manual.jurisdiction);
+  if (jurisdiction) {
+    sections.jurisdiction = `Jurisdiction: ${jurisdiction}.`;
+  }
+
+  const legal_notes = stringValue(manual.legal_notes);
+  if (legal_notes) {
+    sections.legal_notes = `Legal notes: ${legal_notes}`;
+  }
+
+  if ("idempotency_support" in manual && manual.idempotency_support !== undefined && manual.idempotency_support !== null) {
+    sections.idempotency_support = `Idempotency support: ${manual.idempotency_support ? "yes" : "no"}.`;
+  }
+
+  const currency = stringValue(manual.currency);
+  if (currency) {
+    sections.currency = `Payment currency: ${currency}.`;
+  }
+
+  const settlement_mode = stringValue(manual.settlement_mode);
+  if (settlement_mode) {
+    sections.settlement_mode = `Settlement mode: ${settlement_mode}.`;
+  }
+
+  const refund_or_cancellation_note = stringValue(manual.refund_or_cancellation_note);
+  if (refund_or_cancellation_note) {
+    sections.refund_or_cancellation_note = `Refund or cancellation: ${refund_or_cancellation_note}`;
+  }
+
+  return SECTION_ORDER
+    .filter((key) => key in sections)
+    .map((key) => sections[key]!)
+    .join("\n\n");
+}
+
+function renderListSection(title: string, items: string[]): string {
+  return [title + ":", ...items.map((item) => `- ${item}`)].join("\n");
+}
+
+function lossyFields(provider: LossyProvider, manual: Record<string, unknown>): string[] {
+  return Object.keys(LOSSY_WARNING_MESSAGES[provider]).filter((field_name) => hasMeaningfulValue(manual[field_name]));
+}
+
+function warningsFor(provider: LossyProvider, lossy_fields: string[]): string[] {
+  const messages = LOSSY_WARNING_MESSAGES[provider];
+  return lossy_fields.map((field_name) => messages[field_name as keyof typeof messages]);
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (isRecord(value)) {
+    return Object.keys(value).length > 0;
+  }
+  return true;
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function stringValue(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const text = value.trim();
+  return text.length > 0 ? text : null;
+}
+
+function requiredNonEmptyString(payload: Record<string, unknown>, field_name: string): string {
+  const value = stringValue(payload[field_name]);
+  if (value === null) {
+    throw new TypeError(`tool_manual.${field_name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  const payload = toJsonable(value);
+  return isRecord(payload) ? { ...payload } : {};
+}

--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./client";
 export * from "./diff";
 export * from "./errors";
+export * from "./exporters";
 export * from "./runtime";
 export * from "./tool-manual-assist";
 export * from "./tool-manual-grader";

--- a/siglume-api-sdk-ts/test/exporters.test.ts
+++ b/siglume-api-sdk-ts/test/exporters.test.ts
@@ -1,0 +1,128 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  to_anthropic_tool,
+  to_mcp_tool,
+  to_openai_function,
+  to_openai_responses_tool,
+} from "../src/exporters";
+import type { ToolSchemaExport } from "../src/exporters";
+import {
+  to_anthropic_tool as root_anthropic_tool,
+  to_mcp_tool as root_mcp_tool,
+  to_openai_function as root_openai_function,
+  to_openai_responses_tool as root_openai_responses_tool,
+} from "../src/index";
+
+interface ExporterCase {
+  name: string;
+  tool_manual: Record<string, unknown>;
+  expected: Record<string, { schema: Record<string, unknown>; lossy_fields: string[]; warnings: string[] }>;
+}
+
+async function loadCases(): Promise<ExporterCase[]> {
+  const raw = await readFile(join(process.cwd(), "..", "tests", "fixtures", "exporter_cases.json"), "utf8");
+  return JSON.parse(raw) as ExporterCase[];
+}
+
+const EXPORTERS = {
+  anthropic: to_anthropic_tool,
+  openai_function: to_openai_function,
+  openai_responses_tool: to_openai_responses_tool,
+  mcp: to_mcp_tool,
+} as const;
+
+describe("tool schema exporters", () => {
+  it("re-exports the exporter helpers from the package root", () => {
+    expect(root_anthropic_tool).toBe(to_anthropic_tool);
+    expect(root_openai_function).toBe(to_openai_function);
+    expect(root_openai_responses_tool).toBe(to_openai_responses_tool);
+    expect(root_mcp_tool).toBe(to_mcp_tool);
+  });
+
+  it.each([
+    ["read_only_price_lookup", "anthropic"],
+    ["read_only_price_lookup", "openai_function"],
+    ["read_only_price_lookup", "openai_responses_tool"],
+    ["read_only_price_lookup", "mcp"],
+    ["payment_wallet_charge", "anthropic"],
+    ["payment_wallet_charge", "openai_function"],
+    ["payment_wallet_charge", "openai_responses_tool"],
+    ["payment_wallet_charge", "mcp"],
+  ] as const)("matches the golden fixture for %s via %s", async (caseName, provider) => {
+    const cases = await loadCases();
+    const fixture = cases.find((item) => item.name === caseName);
+    expect(fixture).toBeDefined();
+
+    const result = EXPORTERS[provider](fixture!.tool_manual);
+    const typedResult: ToolSchemaExport<unknown> = result;
+
+    expect(typedResult).toEqual(fixture!.expected[provider]);
+  });
+
+  it.each([
+    ["anthropic", to_anthropic_tool],
+    ["openai_function", to_openai_function],
+    ["openai_responses_tool", to_openai_responses_tool],
+    ["mcp", to_mcp_tool],
+  ] as const)("rejects non-mapping input for %s", (_label, exporter) => {
+    expect(() => exporter(["not", "a", "tool"] as unknown as Record<string, unknown>)).toThrow(
+      /tool_manual must be a mapping-like object/,
+    );
+  });
+
+  it.each([
+    ["anthropic", to_anthropic_tool],
+    ["openai_function", to_openai_function],
+    ["openai_responses_tool", to_openai_responses_tool],
+    ["mcp", to_mcp_tool],
+  ] as const)("requires a non-empty tool_name for %s", (_label, exporter) => {
+    expect(() =>
+      exporter({
+        summary_for_model: "Missing tool_name should fail consistently.",
+        input_schema: { type: "object" },
+        output_schema: { type: "object" },
+      }),
+    ).toThrow(/tool_manual\.tool_name must be a non-empty string/);
+  });
+
+  it("keeps the MCP output schema intact", async () => {
+    const cases = await loadCases();
+    const fixture = cases.find((item) => item.name === "payment_wallet_charge")!;
+
+    const exported = to_mcp_tool(fixture.tool_manual);
+
+    expect(exported.schema.outputSchema).toEqual(fixture.tool_manual.output_schema);
+  });
+
+  it("maps MCP annotations from permission and idempotency semantics", async () => {
+    const cases = await loadCases();
+    const readOnly = cases.find((item) => item.name === "read_only_price_lookup")!;
+    const payment = cases.find((item) => item.name === "payment_wallet_charge")!;
+
+    expect(to_mcp_tool(readOnly.tool_manual).schema.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+    expect(to_mcp_tool(payment.tool_manual).schema.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+    });
+  });
+
+  it("wraps the OpenAI Responses export in a function tool envelope", async () => {
+    const cases = await loadCases();
+    const fixture = cases.find((item) => item.name === "read_only_price_lookup")!;
+
+    const exported = to_openai_responses_tool(fixture.tool_manual);
+
+    expect(exported.schema.type).toBe("function");
+    expect(exported.schema.function.name).toBe("product_price_lookup");
+    expect(exported.schema.function.strict).toBe(true);
+  });
+});

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -83,6 +83,13 @@ from .diff import (  # noqa: E402, F401
     diff_manifest,
     diff_tool_manual,
 )
+from .exporters import (  # noqa: E402, F401
+    ToolSchemaExport,
+    to_anthropic_tool,
+    to_mcp_tool,
+    to_openai_function,
+    to_openai_responses_tool,
+)
 from .tool_manual_assist import (  # noqa: E402, F401
     AnthropicProvider,
     LLMProvider,
@@ -123,12 +130,17 @@ __all__ = sorted(
             "SiglumeClientError",
             "SiglumeNotFoundError",
             "SupportCaseRecord",
+            "ToolSchemaExport",
             "UsageEventRecord",
             "AnthropicProvider",
             "LLMProvider",
             "OpenAIProvider",
             "diff_manifest",
             "diff_tool_manual",
+            "to_anthropic_tool",
+            "to_mcp_tool",
+            "to_openai_function",
+            "to_openai_responses_tool",
             "ToolManualAssistAttempt",
             "ToolManualAssistMetadata",
             "ToolManualAssistResult",

--- a/siglume_api_sdk/exporters.py
+++ b/siglume_api_sdk/exporters.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ToolSchemaExport:
+    schema: dict[str, Any]
+    lossy_fields: list[str]
+    warnings: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "lossy_fields": list(self.lossy_fields),
+            "warnings": list(self.warnings),
+        }
+
+
+_SECTION_ORDER = (
+    "summary",
+    "permission",
+    "when_to_use",
+    "avoid_when",
+    "usage_hints",
+    "result_hints",
+    "error_hints",
+    "connected_accounts",
+    "dry_run",
+    "approval_summary_template",
+    "side_effect_summary",
+    "jurisdiction",
+    "legal_notes",
+    "idempotency_support",
+    "currency",
+    "settlement_mode",
+    "refund_or_cancellation_note",
+)
+
+_LOSSY_WARNING_MESSAGES = {
+    "anthropic": {
+        "output_schema": "output_schema omitted - Anthropic tool definitions do not model output schemas.",
+        "approval_summary_template": "approval_summary_template merged into description - Anthropic tool definitions do not model approval summaries.",
+        "preview_schema": "preview_schema omitted - Anthropic tool definitions do not model previews.",
+        "idempotency_support": "idempotency_support merged into description - Anthropic tool definitions do not model idempotency hints.",
+        "side_effect_summary": "side_effect_summary merged into description - Anthropic tool definitions do not model side-effect summaries.",
+        "quote_schema": "quote_schema omitted - Anthropic tool definitions do not model payment quote schemas.",
+        "currency": "currency merged into description - Anthropic tool definitions do not model settlement currency metadata.",
+        "settlement_mode": "settlement_mode merged into description - Anthropic tool definitions do not model settlement-mode metadata.",
+        "refund_or_cancellation_note": "refund_or_cancellation_note merged into description - Anthropic tool definitions do not model refund policy metadata.",
+        "jurisdiction": "jurisdiction merged into description - Anthropic tool definitions do not model jurisdiction metadata.",
+        "legal_notes": "legal_notes merged into description - Anthropic tool definitions do not model legal note metadata.",
+    },
+    "openai_function": {
+        "output_schema": "output_schema omitted - OpenAI function definitions do not model output schemas.",
+        "approval_summary_template": "approval_summary_template merged into description - OpenAI function definitions do not model approval summaries.",
+        "preview_schema": "preview_schema omitted - OpenAI function definitions do not model previews.",
+        "idempotency_support": "idempotency_support merged into description - OpenAI function definitions do not model idempotency hints.",
+        "side_effect_summary": "side_effect_summary merged into description - OpenAI function definitions do not model side-effect summaries.",
+        "quote_schema": "quote_schema omitted - OpenAI function definitions do not model payment quote schemas.",
+        "currency": "currency merged into description - OpenAI function definitions do not model settlement currency metadata.",
+        "settlement_mode": "settlement_mode merged into description - OpenAI function definitions do not model settlement-mode metadata.",
+        "refund_or_cancellation_note": "refund_or_cancellation_note merged into description - OpenAI function definitions do not model refund policy metadata.",
+        "jurisdiction": "jurisdiction merged into description - OpenAI function definitions do not model jurisdiction metadata.",
+        "legal_notes": "legal_notes merged into description - OpenAI function definitions do not model legal note metadata.",
+    },
+    "openai_responses_tool": {
+        "output_schema": "output_schema omitted - OpenAI Responses tool definitions do not model output schemas.",
+        "approval_summary_template": "approval_summary_template merged into description - OpenAI Responses tool definitions do not model approval summaries.",
+        "preview_schema": "preview_schema omitted - OpenAI Responses tool definitions do not model previews.",
+        "idempotency_support": "idempotency_support merged into description - OpenAI Responses tool definitions do not model idempotency hints.",
+        "side_effect_summary": "side_effect_summary merged into description - OpenAI Responses tool definitions do not model side-effect summaries.",
+        "quote_schema": "quote_schema omitted - OpenAI Responses tool definitions do not model payment quote schemas.",
+        "currency": "currency merged into description - OpenAI Responses tool definitions do not model settlement currency metadata.",
+        "settlement_mode": "settlement_mode merged into description - OpenAI Responses tool definitions do not model settlement-mode metadata.",
+        "refund_or_cancellation_note": "refund_or_cancellation_note merged into description - OpenAI Responses tool definitions do not model refund policy metadata.",
+        "jurisdiction": "jurisdiction merged into description - OpenAI Responses tool definitions do not model jurisdiction metadata.",
+        "legal_notes": "legal_notes merged into description - OpenAI Responses tool definitions do not model legal note metadata.",
+    },
+    "mcp": {
+        "approval_summary_template": "approval_summary_template merged into description - MCP tool descriptors do not model approval summaries.",
+        "preview_schema": "preview_schema omitted - MCP tool descriptors do not model previews.",
+        "side_effect_summary": "side_effect_summary merged into description - MCP tool descriptors do not model side-effect summaries.",
+        "quote_schema": "quote_schema omitted - MCP tool descriptors do not model payment quote schemas.",
+        "currency": "currency merged into description - MCP tool descriptors do not model settlement currency metadata.",
+        "settlement_mode": "settlement_mode merged into description - MCP tool descriptors do not model settlement-mode metadata.",
+        "refund_or_cancellation_note": "refund_or_cancellation_note merged into description - MCP tool descriptors do not model refund policy metadata.",
+        "jurisdiction": "jurisdiction merged into description - MCP tool descriptors do not model jurisdiction metadata.",
+        "legal_notes": "legal_notes merged into description - MCP tool descriptors do not model legal note metadata.",
+    },
+}
+
+
+def to_anthropic_tool(tool_manual: Any) -> ToolSchemaExport:
+    manual = _coerce_tool_manual(tool_manual)
+    tool_name = _required_non_empty_string(manual, "tool_name")
+    lossy_fields = _lossy_fields("anthropic", manual)
+    return ToolSchemaExport(
+        schema={
+            "name": tool_name,
+            "description": _build_description(manual),
+            "input_schema": _mapping(manual.get("input_schema")),
+        },
+        lossy_fields=lossy_fields,
+        warnings=_warnings_for("anthropic", lossy_fields),
+    )
+
+
+def to_openai_function(tool_manual: Any) -> ToolSchemaExport:
+    manual = _coerce_tool_manual(tool_manual)
+    tool_name = _required_non_empty_string(manual, "tool_name")
+    lossy_fields = _lossy_fields("openai_function", manual)
+    return ToolSchemaExport(
+        schema={
+            "name": tool_name,
+            "description": _build_description(manual),
+            "parameters": _mapping(manual.get("input_schema")),
+            "strict": True,
+        },
+        lossy_fields=lossy_fields,
+        warnings=_warnings_for("openai_function", lossy_fields),
+    )
+
+
+def to_openai_responses_tool(tool_manual: Any) -> ToolSchemaExport:
+    manual = _coerce_tool_manual(tool_manual)
+    tool_name = _required_non_empty_string(manual, "tool_name")
+    lossy_fields = _lossy_fields("openai_responses_tool", manual)
+    return ToolSchemaExport(
+        schema={
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": _build_description(manual),
+                "parameters": _mapping(manual.get("input_schema")),
+                "strict": True,
+            },
+        },
+        lossy_fields=lossy_fields,
+        warnings=_warnings_for("openai_responses_tool", lossy_fields),
+    )
+
+
+def to_mcp_tool(tool_manual: Any) -> ToolSchemaExport:
+    manual = _coerce_tool_manual(tool_manual)
+    tool_name = _required_non_empty_string(manual, "tool_name")
+    lossy_fields = _lossy_fields("mcp", manual)
+    permission_class = str(manual.get("permission_class") or "read_only")
+    idempotency_support = manual.get("idempotency_support")
+    annotations = {
+        "readOnlyHint": permission_class == "read_only",
+        "destructiveHint": permission_class != "read_only",
+        "idempotentHint": bool(idempotency_support) if idempotency_support is not None else permission_class == "read_only",
+    }
+    return ToolSchemaExport(
+        schema={
+            "name": tool_name,
+            "description": _build_description(manual),
+            "inputSchema": _mapping(manual.get("input_schema")),
+            "outputSchema": _mapping(manual.get("output_schema")),
+            "annotations": annotations,
+        },
+        lossy_fields=lossy_fields,
+        warnings=_warnings_for("mcp", lossy_fields),
+    )
+
+
+def _coerce_tool_manual(tool_manual: Any) -> dict[str, Any]:
+    payload = _to_plain_jsonable(tool_manual)
+    if not isinstance(payload, dict):
+        raise TypeError("tool_manual must be a mapping-like object")
+    return payload
+
+
+def _to_plain_jsonable(value: Any) -> Any:
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _to_plain_jsonable(value.to_dict())
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return _to_plain_jsonable(asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): _to_plain_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain_jsonable(item) for item in value]
+    return value
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def _non_empty_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _required_non_empty_string(payload: Mapping[str, Any], field_name: str) -> str:
+    value = _non_empty_string(payload.get(field_name))
+    if value is None:
+        raise ValueError(f"tool_manual.{field_name} must be a non-empty string")
+    return value
+
+
+def _build_description(manual: Mapping[str, Any]) -> str:
+    sections: dict[str, str] = {}
+    summary = _non_empty_string(manual.get("summary_for_model"))
+    if summary:
+        sections["summary"] = summary
+
+    permission_class = _non_empty_string(manual.get("permission_class"))
+    if permission_class:
+        sections["permission"] = f"Permission class: {permission_class}."
+
+    trigger_conditions = _string_list(manual.get("trigger_conditions"))
+    if trigger_conditions:
+        sections["when_to_use"] = _render_list_section("When to use", trigger_conditions)
+
+    do_not_use_when = _string_list(manual.get("do_not_use_when"))
+    if do_not_use_when:
+        sections["avoid_when"] = _render_list_section("Avoid when", do_not_use_when)
+
+    usage_hints = _string_list(manual.get("usage_hints"))
+    if usage_hints:
+        sections["usage_hints"] = _render_list_section("Usage hints", usage_hints)
+
+    result_hints = _string_list(manual.get("result_hints"))
+    if result_hints:
+        sections["result_hints"] = _render_list_section("Result hints", result_hints)
+
+    error_hints = _string_list(manual.get("error_hints"))
+    if error_hints:
+        sections["error_hints"] = _render_list_section("Error hints", error_hints)
+
+    requires_connected_accounts = _string_list(manual.get("requires_connected_accounts"))
+    if requires_connected_accounts:
+        sections["connected_accounts"] = _render_list_section("Requires connected accounts", requires_connected_accounts)
+
+    if "dry_run_supported" in manual:
+        sections["dry_run"] = f"Dry run supported: {'yes' if bool(manual.get('dry_run_supported')) else 'no'}."
+
+    approval_summary_template = _non_empty_string(manual.get("approval_summary_template"))
+    if approval_summary_template:
+        sections["approval_summary_template"] = f"Approval summary template: {approval_summary_template}"
+
+    side_effect_summary = _non_empty_string(manual.get("side_effect_summary"))
+    if side_effect_summary:
+        sections["side_effect_summary"] = f"Side effects: {side_effect_summary}"
+
+    jurisdiction = _non_empty_string(manual.get("jurisdiction"))
+    if jurisdiction:
+        sections["jurisdiction"] = f"Jurisdiction: {jurisdiction}."
+
+    legal_notes = _non_empty_string(manual.get("legal_notes"))
+    if legal_notes:
+        sections["legal_notes"] = f"Legal notes: {legal_notes}"
+
+    if "idempotency_support" in manual and manual.get("idempotency_support") is not None:
+        sections["idempotency_support"] = (
+            f"Idempotency support: {'yes' if bool(manual.get('idempotency_support')) else 'no'}."
+        )
+
+    currency = _non_empty_string(manual.get("currency"))
+    if currency:
+        sections["currency"] = f"Payment currency: {currency}."
+
+    settlement_mode = _non_empty_string(manual.get("settlement_mode"))
+    if settlement_mode:
+        sections["settlement_mode"] = f"Settlement mode: {settlement_mode}."
+
+    refund_or_cancellation_note = _non_empty_string(manual.get("refund_or_cancellation_note"))
+    if refund_or_cancellation_note:
+        sections["refund_or_cancellation_note"] = f"Refund or cancellation: {refund_or_cancellation_note}"
+
+    ordered_sections = [sections[key] for key in _SECTION_ORDER if key in sections]
+    return "\n\n".join(ordered_sections)
+
+
+def _render_list_section(title: str, items: list[str]) -> str:
+    lines = [title + ":"]
+    lines.extend(f"- {item}" for item in items)
+    return "\n".join(lines)
+
+
+def _lossy_fields(provider: str, manual: Mapping[str, Any]) -> list[str]:
+    present = []
+    for field_name in _LOSSY_WARNING_MESSAGES[provider]:
+        value = manual.get(field_name)
+        if isinstance(value, Mapping) and not value:
+            continue
+        if isinstance(value, list) and not value:
+            continue
+        if value is None:
+            continue
+        if isinstance(value, str) and value.strip() == "":
+            continue
+        present.append(field_name)
+    return present
+
+
+def _warnings_for(provider: str, lossy_fields: list[str]) -> list[str]:
+    messages = _LOSSY_WARNING_MESSAGES[provider]
+    return [messages[field_name] for field_name in lossy_fields]
+
+
+__all__ = [
+    "ToolSchemaExport",
+    "to_anthropic_tool",
+    "to_mcp_tool",
+    "to_openai_function",
+    "to_openai_responses_tool",
+]

--- a/tests/fixtures/exporter_cases.json
+++ b/tests/fixtures/exporter_cases.json
@@ -1,0 +1,543 @@
+[
+  {
+    "name": "read_only_price_lookup",
+    "tool_manual": {
+      "tool_name": "product_price_lookup",
+      "job_to_be_done": "Look up current retailer pricing for a product and return a structured comparison.",
+      "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+      "trigger_conditions": [
+        "owner asks to compare prices for a product before deciding where to buy",
+        "agent needs retailer offer data to support a shopping recommendation",
+        "request is to find the cheapest or best-value option for a product query"
+      ],
+      "do_not_use_when": [
+        "the request is to complete checkout or place an order instead of comparing offers"
+      ],
+      "permission_class": "read_only",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Product name, model number, or search phrase."
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "One-line overview of the best available deal."
+          },
+          "offers": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Ranked retailer offers."
+          }
+        },
+        "required": [
+          "summary",
+          "offers"
+        ],
+        "additionalProperties": false
+      },
+      "usage_hints": [
+        "Use this tool after the owner has named a product and wants evidence-backed price comparison."
+      ],
+      "result_hints": [
+        "Lead with the best offer and then summarize notable trade-offs."
+      ],
+      "error_hints": [
+        "If no offers are found, ask for a clearer product name or model number."
+      ]
+    },
+    "expected": {
+      "anthropic": {
+        "schema": {
+          "name": "product_price_lookup",
+          "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Product name, model number, or search phrase."
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "lossy_fields": [
+          "output_schema"
+        ],
+        "warnings": [
+          "output_schema omitted - Anthropic tool definitions do not model output schemas."
+        ]
+      },
+      "openai_function": {
+        "schema": {
+          "name": "product_price_lookup",
+          "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Product name, model number, or search phrase."
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        },
+        "lossy_fields": [
+          "output_schema"
+        ],
+        "warnings": [
+          "output_schema omitted - OpenAI function definitions do not model output schemas."
+        ]
+      },
+      "openai_responses_tool": {
+        "schema": {
+          "type": "function",
+          "function": {
+            "name": "product_price_lookup",
+            "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "description": "Product name, model number, or search phrase."
+                }
+              },
+              "required": [
+                "query"
+              ],
+              "additionalProperties": false
+            },
+            "strict": true
+          }
+        },
+        "lossy_fields": [
+          "output_schema"
+        ],
+        "warnings": [
+          "output_schema omitted - OpenAI Responses tool definitions do not model output schemas."
+        ]
+      },
+      "mcp": {
+        "schema": {
+          "name": "product_price_lookup",
+          "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Product name, model number, or search phrase."
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false
+          },
+          "outputSchema": {
+            "type": "object",
+            "properties": {
+              "summary": {
+                "type": "string",
+                "description": "One-line overview of the best available deal."
+              },
+              "offers": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Ranked retailer offers."
+              }
+            },
+            "required": [
+              "summary",
+              "offers"
+            ],
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true
+          }
+        },
+        "lossy_fields": [],
+        "warnings": []
+      }
+    }
+  },
+  {
+    "name": "payment_wallet_charge",
+    "tool_manual": {
+      "tool_name": "wallet_charge_quote",
+      "job_to_be_done": "Quote and capture an approved USD wallet charge for a known customer.",
+      "summary_for_model": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.",
+      "trigger_conditions": [
+        "owner asks to charge a known customer wallet for a specific USD amount",
+        "agent already has the finalized amount and needs an approval-gated payment tool",
+        "request is to quote or capture a stored-wallet payment instead of only describing pricing"
+      ],
+      "do_not_use_when": [
+        "the owner has not approved the charge yet",
+        "the request needs a non-USD payment rail or a manual invoice workflow"
+      ],
+      "permission_class": "payment",
+      "dry_run_supported": true,
+      "requires_connected_accounts": [
+        "wallet_provider"
+      ],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {
+            "type": "number",
+            "description": "USD amount to charge."
+          },
+          "customer_ref": {
+            "type": "string",
+            "description": "Stable customer wallet reference."
+          }
+        },
+        "required": [
+          "amount_usd",
+          "customer_ref"
+        ],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Outcome summary for the quoted or captured payment."
+          },
+          "amount_usd": {
+            "type": "number",
+            "description": "USD amount quoted or captured."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Currency code for the quote or capture."
+          },
+          "payment_id": {
+            "type": "string",
+            "description": "Provider payment identifier when capture succeeds."
+          }
+        },
+        "required": [
+          "summary",
+          "amount_usd",
+          "currency"
+        ],
+        "additionalProperties": false
+      },
+      "usage_hints": [
+        "Use this tool only after the amount and customer wallet reference are both finalized."
+      ],
+      "result_hints": [
+        "Confirm whether the response is only a quote or a captured payment before citing identifiers."
+      ],
+      "error_hints": [
+        "If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy."
+      ],
+      "approval_summary_template": "Charge USD {amount_usd} to the stored wallet for {customer_ref}.",
+      "preview_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Preview of the payment attempt."
+          }
+        },
+        "required": [
+          "summary"
+        ],
+        "additionalProperties": false
+      },
+      "idempotency_support": true,
+      "side_effect_summary": "Captures a USD wallet payment and creates a provider-side ledger entry.",
+      "quote_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {
+            "type": "number",
+            "description": "Quoted USD amount."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Currency code for the quote."
+          }
+        },
+        "required": [
+          "amount_usd",
+          "currency"
+        ],
+        "additionalProperties": false
+      },
+      "currency": "USD",
+      "settlement_mode": "embedded_wallet_charge",
+      "refund_or_cancellation_note": "Refunds follow the merchant cancellation policy.",
+      "jurisdiction": "US",
+      "legal_notes": "Only charge wallets owned by the approving customer."
+    },
+    "expected": {
+      "anthropic": {
+        "schema": {
+          "name": "wallet_charge_quote",
+          "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "amount_usd": {
+                "type": "number",
+                "description": "USD amount to charge."
+              },
+              "customer_ref": {
+                "type": "string",
+                "description": "Stable customer wallet reference."
+              }
+            },
+            "required": [
+              "amount_usd",
+              "customer_ref"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "lossy_fields": [
+          "output_schema",
+          "approval_summary_template",
+          "preview_schema",
+          "idempotency_support",
+          "side_effect_summary",
+          "quote_schema",
+          "currency",
+          "settlement_mode",
+          "refund_or_cancellation_note",
+          "jurisdiction",
+          "legal_notes"
+        ],
+        "warnings": [
+          "output_schema omitted - Anthropic tool definitions do not model output schemas.",
+          "approval_summary_template merged into description - Anthropic tool definitions do not model approval summaries.",
+          "preview_schema omitted - Anthropic tool definitions do not model previews.",
+          "idempotency_support merged into description - Anthropic tool definitions do not model idempotency hints.",
+          "side_effect_summary merged into description - Anthropic tool definitions do not model side-effect summaries.",
+          "quote_schema omitted - Anthropic tool definitions do not model payment quote schemas.",
+          "currency merged into description - Anthropic tool definitions do not model settlement currency metadata.",
+          "settlement_mode merged into description - Anthropic tool definitions do not model settlement-mode metadata.",
+          "refund_or_cancellation_note merged into description - Anthropic tool definitions do not model refund policy metadata.",
+          "jurisdiction merged into description - Anthropic tool definitions do not model jurisdiction metadata.",
+          "legal_notes merged into description - Anthropic tool definitions do not model legal note metadata."
+        ]
+      },
+      "openai_function": {
+        "schema": {
+          "name": "wallet_charge_quote",
+          "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "amount_usd": {
+                "type": "number",
+                "description": "USD amount to charge."
+              },
+              "customer_ref": {
+                "type": "string",
+                "description": "Stable customer wallet reference."
+              }
+            },
+            "required": [
+              "amount_usd",
+              "customer_ref"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
+        },
+        "lossy_fields": [
+          "output_schema",
+          "approval_summary_template",
+          "preview_schema",
+          "idempotency_support",
+          "side_effect_summary",
+          "quote_schema",
+          "currency",
+          "settlement_mode",
+          "refund_or_cancellation_note",
+          "jurisdiction",
+          "legal_notes"
+        ],
+        "warnings": [
+          "output_schema omitted - OpenAI function definitions do not model output schemas.",
+          "approval_summary_template merged into description - OpenAI function definitions do not model approval summaries.",
+          "preview_schema omitted - OpenAI function definitions do not model previews.",
+          "idempotency_support merged into description - OpenAI function definitions do not model idempotency hints.",
+          "side_effect_summary merged into description - OpenAI function definitions do not model side-effect summaries.",
+          "quote_schema omitted - OpenAI function definitions do not model payment quote schemas.",
+          "currency merged into description - OpenAI function definitions do not model settlement currency metadata.",
+          "settlement_mode merged into description - OpenAI function definitions do not model settlement-mode metadata.",
+          "refund_or_cancellation_note merged into description - OpenAI function definitions do not model refund policy metadata.",
+          "jurisdiction merged into description - OpenAI function definitions do not model jurisdiction metadata.",
+          "legal_notes merged into description - OpenAI function definitions do not model legal note metadata."
+        ]
+      },
+      "openai_responses_tool": {
+        "schema": {
+          "type": "function",
+          "function": {
+            "name": "wallet_charge_quote",
+            "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "amount_usd": {
+                  "type": "number",
+                  "description": "USD amount to charge."
+                },
+                "customer_ref": {
+                  "type": "string",
+                  "description": "Stable customer wallet reference."
+                }
+              },
+              "required": [
+                "amount_usd",
+                "customer_ref"
+              ],
+              "additionalProperties": false
+            },
+            "strict": true
+          }
+        },
+        "lossy_fields": [
+          "output_schema",
+          "approval_summary_template",
+          "preview_schema",
+          "idempotency_support",
+          "side_effect_summary",
+          "quote_schema",
+          "currency",
+          "settlement_mode",
+          "refund_or_cancellation_note",
+          "jurisdiction",
+          "legal_notes"
+        ],
+        "warnings": [
+          "output_schema omitted - OpenAI Responses tool definitions do not model output schemas.",
+          "approval_summary_template merged into description - OpenAI Responses tool definitions do not model approval summaries.",
+          "preview_schema omitted - OpenAI Responses tool definitions do not model previews.",
+          "idempotency_support merged into description - OpenAI Responses tool definitions do not model idempotency hints.",
+          "side_effect_summary merged into description - OpenAI Responses tool definitions do not model side-effect summaries.",
+          "quote_schema omitted - OpenAI Responses tool definitions do not model payment quote schemas.",
+          "currency merged into description - OpenAI Responses tool definitions do not model settlement currency metadata.",
+          "settlement_mode merged into description - OpenAI Responses tool definitions do not model settlement-mode metadata.",
+          "refund_or_cancellation_note merged into description - OpenAI Responses tool definitions do not model refund policy metadata.",
+          "jurisdiction merged into description - OpenAI Responses tool definitions do not model jurisdiction metadata.",
+          "legal_notes merged into description - OpenAI Responses tool definitions do not model legal note metadata."
+        ]
+      },
+      "mcp": {
+        "schema": {
+          "name": "wallet_charge_quote",
+          "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "amount_usd": {
+                "type": "number",
+                "description": "USD amount to charge."
+              },
+              "customer_ref": {
+                "type": "string",
+                "description": "Stable customer wallet reference."
+              }
+            },
+            "required": [
+              "amount_usd",
+              "customer_ref"
+            ],
+            "additionalProperties": false
+          },
+          "outputSchema": {
+            "type": "object",
+            "properties": {
+              "summary": {
+                "type": "string",
+                "description": "Outcome summary for the quoted or captured payment."
+              },
+              "amount_usd": {
+                "type": "number",
+                "description": "USD amount quoted or captured."
+              },
+              "currency": {
+                "type": "string",
+                "description": "Currency code for the quote or capture."
+              },
+              "payment_id": {
+                "type": "string",
+                "description": "Provider payment identifier when capture succeeds."
+              }
+            },
+            "required": [
+              "summary",
+              "amount_usd",
+              "currency"
+            ],
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": true
+          }
+        },
+        "lossy_fields": [
+          "approval_summary_template",
+          "preview_schema",
+          "side_effect_summary",
+          "quote_schema",
+          "currency",
+          "settlement_mode",
+          "refund_or_cancellation_note",
+          "jurisdiction",
+          "legal_notes"
+        ],
+        "warnings": [
+          "approval_summary_template merged into description - MCP tool descriptors do not model approval summaries.",
+          "preview_schema omitted - MCP tool descriptors do not model previews.",
+          "side_effect_summary merged into description - MCP tool descriptors do not model side-effect summaries.",
+          "quote_schema omitted - MCP tool descriptors do not model payment quote schemas.",
+          "currency merged into description - MCP tool descriptors do not model settlement currency metadata.",
+          "settlement_mode merged into description - MCP tool descriptors do not model settlement-mode metadata.",
+          "refund_or_cancellation_note merged into description - MCP tool descriptors do not model refund policy metadata.",
+          "jurisdiction merged into description - MCP tool descriptors do not model jurisdiction metadata.",
+          "legal_notes merged into description - MCP tool descriptors do not model legal note metadata."
+        ]
+      }
+    }
+  }
+]

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk import (  # noqa: E402
+    ToolSchemaExport,
+    to_anthropic_tool,
+    to_mcp_tool,
+    to_openai_function,
+    to_openai_responses_tool,
+)
+from siglume_api_sdk.exporters import (  # noqa: E402
+    to_anthropic_tool as module_anthropic_tool,
+    to_mcp_tool as module_mcp_tool,
+    to_openai_function as module_openai_function,
+    to_openai_responses_tool as module_openai_responses_tool,
+)
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "exporter_cases.json"
+CASES = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+EXPORTERS = {
+    "anthropic": to_anthropic_tool,
+    "openai_function": to_openai_function,
+    "openai_responses_tool": to_openai_responses_tool,
+    "mcp": to_mcp_tool,
+}
+
+
+@pytest.mark.parametrize(
+    ("case", "provider"),
+    [(case, provider) for case in CASES for provider in EXPORTERS],
+    ids=[
+        f"{case['name']}-{provider}"
+        for case in CASES
+        for provider in EXPORTERS
+    ],
+)
+def test_exporter_outputs_match_golden_fixtures(case: dict[str, object], provider: str) -> None:
+    exporter = EXPORTERS[provider]
+
+    result = exporter(case["tool_manual"])
+
+    assert isinstance(result, ToolSchemaExport)
+    assert result.to_dict() == case["expected"][provider]
+
+
+@pytest.mark.parametrize(
+    ("exporter", "label"),
+    [
+        (to_anthropic_tool, "anthropic"),
+        (to_openai_function, "openai_function"),
+        (to_openai_responses_tool, "openai_responses_tool"),
+        (to_mcp_tool, "mcp"),
+    ],
+    ids=["anthropic", "openai-function", "openai-responses", "mcp"],
+)
+def test_exporters_reject_non_mapping_inputs(exporter, label: str) -> None:
+    with pytest.raises(TypeError, match="tool_manual must be a mapping-like object"):
+        exporter(["not", "a", "tool", label])
+
+
+def test_root_exports_match_module_exports() -> None:
+    assert to_anthropic_tool is module_anthropic_tool
+    assert to_openai_function is module_openai_function
+    assert to_openai_responses_tool is module_openai_responses_tool
+    assert to_mcp_tool is module_mcp_tool
+
+
+@pytest.mark.parametrize(
+    "exporter",
+    [to_anthropic_tool, to_openai_function, to_openai_responses_tool, to_mcp_tool],
+    ids=["anthropic", "openai-function", "openai-responses", "mcp"],
+)
+def test_exporters_require_non_empty_tool_name(exporter) -> None:
+    with pytest.raises(ValueError, match="tool_manual.tool_name must be a non-empty string"):
+        exporter(
+            {
+                "summary_for_model": "Missing tool_name should fail consistently.",
+                "input_schema": {"type": "object"},
+                "output_schema": {"type": "object"},
+            }
+        )
+
+
+def test_mcp_exporter_preserves_output_schema() -> None:
+    case = next(item for item in CASES if item["name"] == "payment_wallet_charge")
+
+    exported = to_mcp_tool(case["tool_manual"])
+
+    assert "outputSchema" in exported.schema
+    assert exported.schema["outputSchema"] == case["tool_manual"]["output_schema"]
+
+
+def test_mcp_annotations_track_permission_and_idempotency() -> None:
+    read_only_case = next(item for item in CASES if item["name"] == "read_only_price_lookup")
+    payment_case = next(item for item in CASES if item["name"] == "payment_wallet_charge")
+
+    read_only_export = to_mcp_tool(read_only_case["tool_manual"])
+    payment_export = to_mcp_tool(payment_case["tool_manual"])
+
+    assert read_only_export.schema["annotations"] == {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    }
+    assert payment_export.schema["annotations"] == {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    }
+
+
+def test_openai_responses_export_wraps_function_definition() -> None:
+    case = next(item for item in CASES if item["name"] == "read_only_price_lookup")
+
+    exported = to_openai_responses_tool(case["tool_manual"])
+
+    assert exported.schema["type"] == "function"
+    assert exported.schema["function"]["name"] == case["tool_manual"]["tool_name"]
+    assert exported.schema["function"]["strict"] is True


### PR DESCRIPTION
## Summary
- add pure-function ToolManual exporters for Anthropic, OpenAI function calling, OpenAI Responses, and MCP
- return provider-native schema plus `lossy_fields` and `warnings` so missing native fields stay explicit
- add shared golden fixtures so Python and TypeScript emit bit-identical exporter output

## Test plan
- [x] `py -3.11 -m ruff check .`
- [x] `py -3.11 -m pytest` -> 98 passed
- [x] `py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\contract_sync.py`
- [x] `py -3.11 scripts\contract_sync.py`
- [x] `npm run lint`
- [x] `npm test` -> 116 passed, coverage >= 85%
- [x] `npm run build`
- [x] reviewer agent (Sagan): no critical / warning