### PR TITLE
fix(diff): prefer tool_manual over manifest for ambiguous payloads (Codex P2 on #101)

### DIFF
--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -454,11 +454,17 @@ function detectDocumentKind(
 }
 
 function payloadKind(payload: Record<string, unknown>): "manifest" | "tool_manual" | null {
-  if (isManifestPayload(payload)) {
-    return "manifest";
-  }
+  // ToolManual takes precedence over AppManifest when both identity keys
+  // are present: a manifest has no `tool_name` field, so the presence of
+  // `tool_name` is a stronger signal. This avoids misclassifying a
+  // ToolManual payload (that happens to carry capability_key metadata)
+  // as a manifest, which would silently hide ToolManual-specific
+  // breaking changes (e.g. input_schema.required additions).
   if (isToolManualPayload(payload)) {
     return "tool_manual";
+  }
+  if (isManifestPayload(payload)) {
+    return "manifest";
   }
   return null;
 }

--- a/siglume-api-sdk-ts/test/diff-cli.test.ts
+++ b/siglume-api-sdk-ts/test/diff-cli.test.ts
@@ -206,4 +206,47 @@ describe("siglume diff CLI", () => {
     expect(stdout).toEqual([]);
     expect(stderr.join("\n")).toContain("Could not detect document type");
   });
+
+  it("prefers tool_manual over manifest when both identity keys are present (Codex P2 on PR #101)", async () => {
+    // A ToolManual JSON may carry capability_key metadata; the detector must
+    // prefer ToolManual (tool_name wins) so tool-manual-specific breaking
+    // changes are not silently downgraded to the manifest diff path.
+    const stdout: string[] = [];
+    const { oldPath, newPath } = await writePair(
+      {
+        capability_key: "ambiguous-capability",
+        tool_name: "ambiguous_tool",
+        input_schema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+          additionalProperties: false,
+        },
+      },
+      {
+        capability_key: "ambiguous-capability",
+        tool_name: "ambiguous_tool",
+        input_schema: {
+          type: "object",
+          properties: { query: { type: "string" }, region: { type: "string" } },
+          required: ["query", "region"],
+          additionalProperties: false,
+        },
+      },
+    );
+
+    const exitCode = await runCli(["diff", oldPath, newPath, "--json"], {
+      stdout: (line) => stdout.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(stdout.join("\n")) as {
+      kind: string;
+      changes: Array<{ level: string; path: string }>;
+    };
+    expect(payload.kind).toBe("tool_manual");
+    expect(
+      payload.changes.some((change) => change.level === "breaking" && change.path === "input_schema.required"),
+    ).toBe(true);
+  });
 });

--- a/siglume_api_sdk/cli/commands/diff_cmd.py
+++ b/siglume_api_sdk/cli/commands/diff_cmd.py
@@ -50,10 +50,16 @@ def _detect_kind(old_payload: dict[str, Any], new_payload: dict[str, Any]) -> st
 
 
 def _payload_kind(payload: dict[str, Any]) -> str | None:
-    if _is_manifest_payload(payload):
-        return "manifest"
+    # ToolManual takes precedence over AppManifest when both identity keys
+    # are present: a manifest has no `tool_name` field, so the presence of
+    # `tool_name` is a stronger signal. This avoids misclassifying a
+    # ToolManual payload (that happens to carry capability_key metadata)
+    # as a manifest, which would silently hide ToolManual-specific
+    # breaking changes (e.g. input_schema.required additions).
     if _is_tool_manual_payload(payload):
         return "tool_manual"
+    if _is_manifest_payload(payload):
+        return "manifest"
     return None
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -224,3 +224,44 @@ def test_diff_cli_rejects_truly_unknown_document_kind() -> None:
 
         assert result.exit_code == 1
         assert "Could not detect document type" in result.output
+
+
+def test_diff_cli_prefers_tool_manual_when_ambiguous_keys_present() -> None:
+    # Codex bot P2 on PR #101: a ToolManual JSON may carry capability_key
+    # as metadata. The detector must prefer ToolManual (tool_name wins),
+    # otherwise ToolManual-specific breaking changes (e.g. input_schema.required
+    # additions) would be silently suppressed.
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        old_payload = {
+            "capability_key": "ambiguous-capability",
+            "tool_name": "ambiguous_tool",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        }
+        new_payload = {
+            "capability_key": "ambiguous-capability",
+            "tool_name": "ambiguous_tool",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}, "region": {"type": "string"}},
+                "required": ["query", "region"],  # breaking in tool_manual diff, noise in manifest diff
+                "additionalProperties": False,
+            },
+        }
+        Path("old.json").write_text(json.dumps(old_payload), encoding="utf-8")
+        Path("new.json").write_text(json.dumps(new_payload), encoding="utf-8")
+
+        result = runner.invoke(main, ["diff", "old.json", "new.json", "--json"])
+
+        assert result.exit_code == 1, result.output  # BREAKING detected via tool_manual path
+        payload = json.loads(result.output)
+        assert payload["kind"] == "tool_manual"
+        assert any(
+            change["level"] == "breaking" and change["path"] == "input_schema.required"
+            for change in payload["changes"]
+        )


### PR DESCRIPTION
## Summary
Codex bot P2 (x2) follow-up on PR #101. A ToolManual JSON that happens to carry \`capability_key\` metadata was being classified as an AppManifest because the detector checked manifest first. As a result, \`siglume diff\` ran \`diff_manifest\` on tool-manual payloads and silently suppressed tool-manual-specific breaking changes (most importantly \`input_schema.required\` additions).

## Fix
Swap the discriminator order: check \`tool_name\` first, fall back to \`capability_key\`. A manifest never has \`tool_name\`, so \`tool_name\` presence is a strictly stronger signal.

## Tests
Added regression tests (Python + TS) that construct a payload with both \`capability_key\` and \`tool_name\` plus a breaking \`input_schema.required\` change. The test asserts:
- Exit code 1 (breaking detected)
- JSON output \`kind\` is \`tool_manual\`
- \`input_schema.required\` is reported as \`breaking\`

Pre-fix, this test would have reported no breaking change because the manifest diff has no \`input_schema.required\` rule.

## Verification
- \`py -3.11 -m ruff check .\` → passed
- \`py -3.11 -m pytest\` → 99 passed
- \`npm test\` → 117 passed