### PR TITLE
fix(sdk): Codex P1 — Responses API tool shape + manifest permission_class default

### DIFF
--- a/siglume-api-sdk-ts/src/diff.ts
+++ b/siglume-api-sdk-ts/src/diff.ts
@@ -399,6 +399,13 @@ function normalizeManifest(value: AppManifest | Record<string, unknown>): Record
     ...payload,
     price_model: payload.price_model ?? "free",
     currency: payload.currency ?? "USD",
+    // AppManifest defaults permission_class to "read-only" (hyphen form,
+    // PermissionClass.READ_ONLY). Without this default, a legacy / minimal
+    // manifest without permission_class compared against an upgraded one
+    // would leave oldRank undefined and appendPermissionClassChange would
+    // downgrade the permission escalation from BREAKING to INFO — letting
+    // the diff CLI exit 0 on a genuinely breaking change.
+    permission_class: payload.permission_class ?? "read-only",
   };
 }
 

--- a/siglume-api-sdk-ts/src/exporters.ts
+++ b/siglume-api-sdk-ts/src/exporters.ts
@@ -20,9 +20,16 @@ export interface OpenAIFunctionDefinition {
   strict: true;
 }
 
+// OpenAI Responses API flattens the function tool shape: type / name /
+// description / parameters / strict live at the top level of the tool
+// object. The nested `function: {...}` envelope belongs to the Chat
+// Completions API only and is rejected by `responses.create(..., tools=[...])`.
 export interface OpenAIResponsesToolDefinition {
   type: "function";
-  function: OpenAIFunctionDefinition;
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  strict: true;
 }
 
 export interface McpToolDescriptor {
@@ -152,12 +159,10 @@ export function to_openai_responses_tool(
   return {
     schema: {
       type: "function",
-      function: {
-        name: tool_name,
-        description: buildDescription(manual),
-        parameters: toRecord(manual.input_schema),
-        strict: true,
-      },
+      name: tool_name,
+      description: buildDescription(manual),
+      parameters: toRecord(manual.input_schema),
+      strict: true,
     },
     lossy_fields,
     warnings: warningsFor("openai_responses_tool", lossy_fields),

--- a/siglume-api-sdk-ts/test/diff.test.ts
+++ b/siglume-api-sdk-ts/test/diff.test.ts
@@ -196,4 +196,26 @@ describe("diff rules", () => {
       ]),
     );
   });
+
+  it("defaults manifest permission_class to read-only so upgrades from missing are BREAKING (Codex P1 on PR #60)", () => {
+    // When an old / legacy manifest omits permission_class, the new
+    // manifest escalating to action must still register as BREAKING.
+    // Pre-fix, normaliseManifest did not default permission_class, leaving
+    // oldRank undefined and downgrading the change to INFO — letting
+    // `siglume diff` exit 0 on a genuinely breaking permission escalation.
+    const changes = diff_manifest({
+      old: { capability_key: "legacy-app", jurisdiction: "US" },
+      new: {
+        capability_key: "legacy-app",
+        jurisdiction: "US",
+        permission_class: "action",
+      },
+    });
+
+    expect(
+      changes.some(
+        (change) => change.path === "permission_class" && change.level === ChangeLevel.BREAKING,
+      ),
+    ).toBe(true);
+  });
 });

--- a/siglume-api-sdk-ts/test/exporters.test.ts
+++ b/siglume-api-sdk-ts/test/exporters.test.ts
@@ -115,14 +115,22 @@ describe("tool schema exporters", () => {
     });
   });
 
-  it("wraps the OpenAI Responses export in a function tool envelope", async () => {
+  it("exports a flat function-tool shape for the OpenAI Responses API", async () => {
+    // Codex bot P1 on PR #102: the Responses API requires { type, name,
+    // description, parameters, strict } at the top level; the Chat
+    // Completions { type, function: {...} } envelope is rejected by
+    // client.responses.create(..., tools=[...]).
     const cases = await loadCases();
     const fixture = cases.find((item) => item.name === "read_only_price_lookup")!;
 
     const exported = to_openai_responses_tool(fixture.tool_manual);
 
     expect(exported.schema.type).toBe("function");
-    expect(exported.schema.function.name).toBe("product_price_lookup");
-    expect(exported.schema.function.strict).toBe(true);
+    expect(exported.schema.name).toBe("product_price_lookup");
+    expect(exported.schema.strict).toBe(true);
+    expect(exported.schema.description).toBeTypeOf("string");
+    expect(exported.schema.parameters).toBeTypeOf("object");
+    // The nested Chat-Completions envelope MUST be absent.
+    expect((exported.schema as unknown as { function?: unknown }).function).toBeUndefined();
   });
 });

--- a/siglume_api_sdk/diff.py
+++ b/siglume_api_sdk/diff.py
@@ -417,6 +417,13 @@ def _normalize_manifest(value: Any) -> dict[str, Any]:
     normalized = dict(payload)
     normalized["price_model"] = normalized.get("price_model") or "free"
     normalized["currency"] = normalized.get("currency") or "USD"
+    # AppManifest defaults permission_class to "read-only" (hyphen form,
+    # PermissionClass.READ_ONLY). Without this default, a legacy/minimal
+    # manifest without permission_class compared against an upgraded
+    # manifest would leave oldRank undefined and appendPermissionClassChange
+    # would downgrade the permission escalation from BREAKING to INFO —
+    # letting the diff CLI exit 0 on a genuinely breaking change.
+    normalized["permission_class"] = normalized.get("permission_class") or "read-only"
     return normalized
 
 

--- a/siglume_api_sdk/exporters.py
+++ b/siglume_api_sdk/exporters.py
@@ -128,15 +128,17 @@ def to_openai_responses_tool(tool_manual: Any) -> ToolSchemaExport:
     manual = _coerce_tool_manual(tool_manual)
     tool_name = _required_non_empty_string(manual, "tool_name")
     lossy_fields = _lossy_fields("openai_responses_tool", manual)
+    # OpenAI Responses API wants a flat function-tool shape (type / name /
+    # description / parameters / strict at the top level), not the nested
+    # Chat Completions envelope. Nesting `function: {...}` causes
+    # `client.responses.create(tools=[...])` to reject the payload.
     return ToolSchemaExport(
         schema={
             "type": "function",
-            "function": {
-                "name": tool_name,
-                "description": _build_description(manual),
-                "parameters": _mapping(manual.get("input_schema")),
-                "strict": True,
-            },
+            "name": tool_name,
+            "description": _build_description(manual),
+            "parameters": _mapping(manual.get("input_schema")),
+            "strict": True,
         },
         lossy_fields=lossy_fields,
         warnings=_warnings_for("openai_responses_tool", lossy_fields),

--- a/tests/fixtures/exporter_cases.json
+++ b/tests/fixtures/exporter_cases.json
@@ -115,24 +115,22 @@
       "openai_responses_tool": {
         "schema": {
           "type": "function",
-          "function": {
-            "name": "product_price_lookup",
-            "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
-            "parameters": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string",
-                  "description": "Product name, model number, or search phrase."
-                }
-              },
-              "required": [
-                "query"
-              ],
-              "additionalProperties": false
+          "name": "product_price_lookup",
+          "description": "Looks up current retailer offers and returns a structured comparison with the best deal first.\n\nPermission class: read_only.\n\nWhen to use:\n- owner asks to compare prices for a product before deciding where to buy\n- agent needs retailer offer data to support a shopping recommendation\n- request is to find the cheapest or best-value option for a product query\n\nAvoid when:\n- the request is to complete checkout or place an order instead of comparing offers\n\nUsage hints:\n- Use this tool after the owner has named a product and wants evidence-backed price comparison.\n\nResult hints:\n- Lead with the best offer and then summarize notable trade-offs.\n\nError hints:\n- If no offers are found, ask for a clearer product name or model number.\n\nDry run supported: yes.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Product name, model number, or search phrase."
+              }
             },
-            "strict": true
-          }
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
         },
         "lossy_fields": [
           "output_schema"
@@ -409,29 +407,27 @@
       "openai_responses_tool": {
         "schema": {
           "type": "function",
-          "function": {
-            "name": "wallet_charge_quote",
-            "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
-            "parameters": {
-              "type": "object",
-              "properties": {
-                "amount_usd": {
-                  "type": "number",
-                  "description": "USD amount to charge."
-                },
-                "customer_ref": {
-                  "type": "string",
-                  "description": "Stable customer wallet reference."
-                }
+          "name": "wallet_charge_quote",
+          "description": "Quotes the USD amount and captures a stored-wallet payment after the owner approves.\n\nPermission class: payment.\n\nWhen to use:\n- owner asks to charge a known customer wallet for a specific USD amount\n- agent already has the finalized amount and needs an approval-gated payment tool\n- request is to quote or capture a stored-wallet payment instead of only describing pricing\n\nAvoid when:\n- the owner has not approved the charge yet\n- the request needs a non-USD payment rail or a manual invoice workflow\n\nUsage hints:\n- Use this tool only after the amount and customer wallet reference are both finalized.\n\nResult hints:\n- Confirm whether the response is only a quote or a captured payment before citing identifiers.\n\nError hints:\n- If the wallet provider rejects the charge, explain whether the failure came from balance, auth, or policy.\n\nRequires connected accounts:\n- wallet_provider\n\nDry run supported: yes.\n\nApproval summary template: Charge USD {amount_usd} to the stored wallet for {customer_ref}.\n\nSide effects: Captures a USD wallet payment and creates a provider-side ledger entry.\n\nJurisdiction: US.\n\nLegal notes: Only charge wallets owned by the approving customer.\n\nIdempotency support: yes.\n\nPayment currency: USD.\n\nSettlement mode: embedded_wallet_charge.\n\nRefund or cancellation: Refunds follow the merchant cancellation policy.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "amount_usd": {
+                "type": "number",
+                "description": "USD amount to charge."
               },
-              "required": [
-                "amount_usd",
-                "customer_ref"
-              ],
-              "additionalProperties": false
+              "customer_ref": {
+                "type": "string",
+                "description": "Stable customer wallet reference."
+              }
             },
-            "strict": true
-          }
+            "required": [
+              "amount_usd",
+              "customer_ref"
+            ],
+            "additionalProperties": false
+          },
+          "strict": true
         },
         "lossy_fields": [
           "output_schema",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -265,3 +265,30 @@ def test_diff_cli_prefers_tool_manual_when_ambiguous_keys_present() -> None:
             change["level"] == "breaking" and change["path"] == "input_schema.required"
             for change in payload["changes"]
         )
+
+
+def test_diff_manifest_defaults_permission_class_for_missing_old_value() -> None:
+    # Codex bot P1 on PR #60: when an old/legacy manifest omits
+    # permission_class and the new one escalates to action, the permission
+    # escalation must be BREAKING. Previously the normaliser did not default
+    # permission_class, so oldRank was undefined and the change was
+    # downgraded to INFO — making `siglume diff` exit 0 on a real
+    # permission escalation.
+    changes = diff_manifest(
+        old={"capability_key": "legacy-app", "jurisdiction": "US"},
+        new={
+            "capability_key": "legacy-app",
+            "jurisdiction": "US",
+            "permission_class": "action",
+        },
+    )
+
+    breaking_permission = [
+        change
+        for change in changes
+        if change.path == "permission_class" and change.level == ChangeLevel.BREAKING
+    ]
+    assert breaking_permission, [
+        {"path": change.path, "level": change.level.value, "old": change.old, "new": change.new}
+        for change in changes
+    ]

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -120,11 +120,19 @@ def test_mcp_annotations_track_permission_and_idempotency() -> None:
     }
 
 
-def test_openai_responses_export_wraps_function_definition() -> None:
+def test_openai_responses_export_uses_flat_function_tool_shape() -> None:
+    # Codex bot P1 on PR #102: the OpenAI Responses API expects a flat
+    # { type, name, description, parameters, strict } tool object, not the
+    # Chat Completions { type, function: { ... } } envelope. The nested
+    # form is rejected by client.responses.create(..., tools=[...]).
     case = next(item for item in CASES if item["name"] == "read_only_price_lookup")
 
     exported = to_openai_responses_tool(case["tool_manual"])
 
     assert exported.schema["type"] == "function"
-    assert exported.schema["function"]["name"] == case["tool_manual"]["tool_name"]
-    assert exported.schema["function"]["strict"] is True
+    assert exported.schema["name"] == case["tool_manual"]["tool_name"]
+    assert exported.schema["strict"] is True
+    assert "description" in exported.schema
+    assert "parameters" in exported.schema
+    # The nested function envelope MUST be absent — that is the bug we fixed.
+    assert "function" not in exported.schema


### PR DESCRIPTION
## Summary
Two independent Codex bot P1 findings. Bundled so the downstream mirror re-sync picks them up together.

### 1. OpenAI Responses API tool shape (Codex P1 on [#102](https://github.com/taihei-05/siglume-api-sdk/pull/102))
The Responses API expects \`{ type, name, description, parameters, strict }\` at the top level. The exporter was emitting the Chat Completions \`{ type, function: { ... } }\` envelope, which \`client.responses.create(..., tools=[...])\` rejects as malformed.

- \`siglume_api_sdk/exporters.py\` / \`siglume-api-sdk-ts/src/exporters.ts\`: flatten the payload
- \`siglume-api-sdk-ts/src/exporters.ts\`: update \`OpenAIResponsesToolDefinition\` interface
- \`tests/fixtures/exporter_cases.json\`: update two golden cases to the flat shape
- regression tests in Python and TS assert the nested \`function\` key is absent

### 2. Manifest permission_class default (Codex P1 on [#60](https://github.com/taihei-05/siglume/pull/60))
When a legacy / minimal manifest omits \`permission_class\`, an upgrade to action / payment was downgraded from BREAKING to INFO because \`_normalize_manifest\` did not default the old value. \`appendPermissionClassChange\` then saw \`oldRank=undefined\` and took the INFO branch, letting \`siglume diff\` exit 0 on a genuinely breaking permission escalation.

- \`siglume_api_sdk/diff.py\` / \`siglume-api-sdk-ts/src/diff.ts\`: default \`permission_class\` to \`\"read-only\"\` (hyphen form, matching \`PermissionClass.READ_ONLY\`)
- regression tests in Python and TS assert the escalation is reported as BREAKING

## Verification
- \`py -3.11 -m ruff check .\` → passed
- \`py -3.11 -m pytest\` → 100 passed
- \`npm test\` → 118 passed