### PR TITLE
feat(testing): recording harness for deterministic SDK tests (PR-L)

### DIFF
--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -3,6 +3,7 @@ export * from "./diff";
 export * from "./errors";
 export * from "./exporters";
 export * from "./runtime";
+export * from "./testing/recorder";
 export * from "./tool-manual-assist";
 export * from "./tool-manual-grader";
 export * from "./tool-manual-validator";

--- a/siglume-api-sdk-ts/src/runtime.ts
+++ b/siglume-api-sdk-ts/src/runtime.ts
@@ -10,6 +10,7 @@ import type {
   ToolManualIssue,
 } from "./types";
 import { ApprovalMode, Environment, PermissionClass } from "./types";
+import { Recorder, RecordMode } from "./testing/recorder";
 import { validate_tool_manual } from "./tool-manual-validator";
 
 const CAPABILITY_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
@@ -222,5 +223,37 @@ export class AppTestHarness {
       ...options,
       connected_accounts: {},
     });
+  }
+
+  async record<T>(
+    cassettePath: string,
+    fn: (harness: AppTestHarness) => Promise<T> | T,
+    options: { ignore_body_fields?: string[] } = {},
+  ): Promise<T> {
+    const recorder = await Recorder.open(cassettePath, {
+      mode: RecordMode.RECORD,
+      ignore_body_fields: options.ignore_body_fields,
+    });
+    try {
+      return await recorder.withGlobalFetch(() => fn(this));
+    } finally {
+      await recorder.close();
+    }
+  }
+
+  async replay<T>(
+    cassettePath: string,
+    fn: (harness: AppTestHarness) => Promise<T> | T,
+    options: { ignore_body_fields?: string[] } = {},
+  ): Promise<T> {
+    const recorder = await Recorder.open(cassettePath, {
+      mode: RecordMode.REPLAY,
+      ignore_body_fields: options.ignore_body_fields,
+    });
+    try {
+      return await recorder.withGlobalFetch(() => fn(this));
+    } finally {
+      await recorder.close();
+    }
   }
 }

--- a/siglume-api-sdk-ts/src/testing/recorder.ts
+++ b/siglume-api-sdk-ts/src/testing/recorder.ts
@@ -1,0 +1,462 @@
+type FetchLike = typeof fetch;
+type CassetteHeaderValue = string | string[];
+declare const Deno:
+  | {
+      stat(path: string): Promise<unknown>;
+      readTextFile(path: string): Promise<string>;
+      writeTextFile(path: string, content: string): Promise<void>;
+      mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+    }
+  | undefined;
+
+const CASSETTE_VERSION = 1;
+const SECRET_KEY_RE = /(api[_-]?key|secret|private[_-]?key|access[_-]?token|refresh[_-]?token)/i;
+const PRIVKEY_RE = /0x[a-f0-9]{64}/g;
+const TOKEN_RE = /(pypi|ghp|gho|ghu|ghs)-[A-Za-z0-9]+/g;
+const BOUNDARY_RE = /boundary="?([^";]+)"?/i;
+
+export enum RecordMode {
+  RECORD = "record",
+  REPLAY = "replay",
+  AUTO = "auto",
+}
+
+export interface RecorderOptions {
+  mode?: RecordMode;
+  ignore_body_fields?: string[];
+}
+
+export interface CassetteInteraction {
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, CassetteHeaderValue>;
+    body: unknown;
+  };
+  response: {
+    status: number;
+    headers: Record<string, CassetteHeaderValue>;
+    body: unknown;
+    duration_ms: number;
+  };
+}
+
+export interface CassetteFile {
+  version: number;
+  interactions: CassetteInteraction[];
+}
+
+function redactString(value: string): string {
+  return value.replace(PRIVKEY_RE, "<REDACTED_PRIVKEY>").replace(TOKEN_RE, "<REDACTED_TOKEN>");
+}
+
+function appendHeader(result: Record<string, CassetteHeaderValue>, key: string, value: string): void {
+  const existing = result[key];
+  if (existing === undefined) {
+    result[key] = value;
+    return;
+  }
+  if (Array.isArray(existing)) {
+    existing.push(value);
+    return;
+  }
+  result[key] = [existing, value];
+}
+
+function redactHeaderValue(key: string, value: string): string {
+  if (key === "content-type" && value.toLowerCase().includes("multipart/form-data")) {
+    return normalizeMultipartContentType(value);
+  }
+  if (key === "authorization" && value.toLowerCase().startsWith("bearer ")) {
+    return "Bearer <REDACTED>";
+  }
+  if (key === "cookie" || key === "set-cookie" || SECRET_KEY_RE.test(key)) {
+    const redacted = redactString(value);
+    return redacted !== value ? redacted : "<REDACTED>";
+  }
+  return redactString(value);
+}
+
+function redactHeaders(headers: Headers): Record<string, CassetteHeaderValue> {
+  const result: Record<string, CassetteHeaderValue> = {};
+  headers.forEach((value, key) => {
+    const normalizedKey = key.toLowerCase();
+    appendHeader(result, normalizedKey, redactHeaderValue(normalizedKey, value));
+  });
+  const getSetCookie = Reflect.get(headers as object, "getSetCookie");
+  if (typeof getSetCookie === "function") {
+    const setCookies = (getSetCookie as () => string[]).call(headers)
+      .map((value) => redactHeaderValue("set-cookie", value));
+    if (setCookies.length === 1 && setCookies[0] !== undefined) {
+      result["set-cookie"] = setCookies[0];
+    } else if (setCookies.length > 1) {
+      result["set-cookie"] = setCookies;
+    }
+  }
+  return result;
+}
+
+function redactUrl(urlText: string): string {
+  const url = new URL(urlText);
+  const nextParams = new URLSearchParams();
+  for (const [key, value] of Array.from(url.searchParams.entries())) {
+    if (SECRET_KEY_RE.test(key)) {
+      const redacted = redactString(value);
+      nextParams.append(key, redacted !== value ? redacted : "<REDACTED>");
+    } else {
+      nextParams.append(key, redactString(value));
+    }
+  }
+  url.search = nextParams.toString();
+  return url.toString();
+}
+
+function redactBody(value: unknown, keyName?: string): unknown {
+  if (keyName && SECRET_KEY_RE.test(keyName)) {
+    if (typeof value === "string") {
+      const redacted = redactString(value);
+      return redacted !== value ? redacted : "<REDACTED>";
+    }
+    return "<REDACTED>";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactBody(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, redactBody(child, key)]),
+    );
+  }
+  if (typeof value === "string") {
+    return redactString(value);
+  }
+  return value;
+}
+
+function sortKeysDeep<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortKeysDeep(item)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
+    ) as T;
+  }
+  return value;
+}
+
+function normalizeTopLevelBody(body: unknown, ignoreBodyFields: Set<string>): unknown {
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+  if (Array.isArray(body)) {
+    return body.map((item) => normalizeTopLevelBody(item, new Set<string>()));
+  }
+  const record = body as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .filter((key) => !ignoreBodyFields.has(key))
+      .sort()
+      .map((key) => [key, normalizeTopLevelBody(record[key], new Set<string>())]),
+  );
+}
+
+function requestSignature(request: { method: string; url: string; body: unknown }, ignoreBodyFields: Set<string>): string {
+  return JSON.stringify({
+    method: request.method.toUpperCase(),
+    url: request.url,
+    body: normalizeTopLevelBody(request.body, ignoreBodyFields),
+  });
+}
+
+async function parseTextBody(text: string): Promise<unknown> {
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function normalizeMultipartText(text: string, contentType: string | null): string {
+  if (!contentType) {
+    return text;
+  }
+  const match = BOUNDARY_RE.exec(contentType);
+  if (!match?.[1]) {
+    return text;
+  }
+  return text.split(match[1]).join("<BOUNDARY>");
+}
+
+function replaceAllBytes(source: Uint8Array, search: Uint8Array, replacement: Uint8Array): Uint8Array {
+  if (search.length === 0) {
+    return source;
+  }
+  const parts: number[] = [];
+  for (let index = 0; index < source.length;) {
+    let matched = true;
+    for (let offset = 0; offset < search.length; offset += 1) {
+      if (source[index + offset] !== search[offset]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
+      parts.push(...replacement);
+      index += search.length;
+      continue;
+    }
+    parts.push(source[index] as number);
+    index += 1;
+  }
+  return Uint8Array.from(parts);
+}
+
+function normalizeMultipartBytes(bytes: Uint8Array, contentType: string | null): Uint8Array {
+  if (!contentType) {
+    return bytes;
+  }
+  const match = BOUNDARY_RE.exec(contentType);
+  if (!match?.[1]) {
+    return bytes;
+  }
+  return replaceAllBytes(bytes, new TextEncoder().encode(match[1]), new TextEncoder().encode("<BOUNDARY>"));
+}
+
+function normalizeMultipartContentType(contentType: string | null): string {
+  if (!contentType) {
+    return "multipart/form-data; boundary=<BOUNDARY>";
+  }
+  return contentType.replace(BOUNDARY_RE, "boundary=<BOUNDARY>");
+}
+
+function toBase64(bytes: Uint8Array): string {
+  const bufferCtor = Reflect.get(globalThis as object, "Buffer") as { from(data: Uint8Array): { toString(encoding: string): string } } | undefined;
+  if (bufferCtor?.from) {
+    return bufferCtor.from(bytes).toString("base64");
+  }
+  if (typeof btoa === "function") {
+    let binary = "";
+    bytes.forEach((value) => {
+      binary += String.fromCharCode(value);
+    });
+    return btoa(binary);
+  }
+  throw new Error("No base64 encoder available for multipart cassette recording.");
+}
+
+async function parseRequestBody(request: Request): Promise<unknown> {
+  const contentType = request.headers.get("content-type");
+  if (contentType?.toLowerCase().includes("multipart/form-data")) {
+    const bytes = new Uint8Array(await request.clone().arrayBuffer());
+    return {
+      content_type: normalizeMultipartContentType(contentType),
+      encoding: "base64",
+      base64: toBase64(normalizeMultipartBytes(bytes, contentType)),
+    };
+  }
+  const text = await request.clone().text();
+  if (!text) {
+    return null;
+  }
+  return parseTextBody(text);
+}
+
+function buildResponseFromCassette(interaction: CassetteInteraction, request: Request): Response {
+  const headers = new Headers();
+  Object.entries(interaction.response.headers).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((entry) => headers.append(key, entry));
+      return;
+    }
+    headers.append(key, value);
+  });
+  const body = interaction.response.body;
+  const payload = typeof body === "string" ? body : body == null ? "" : JSON.stringify(body);
+  if (body !== null && body !== undefined && typeof body !== "string" && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  return new Response(payload, {
+    status: interaction.response.status,
+    headers,
+  });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  if (typeof Deno !== "undefined" && typeof Deno.stat === "function") {
+    try {
+      await Deno.stat(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  try {
+    const fs = await import("node:fs/promises");
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readTextFile(path: string): Promise<string> {
+  if (typeof Deno !== "undefined" && typeof Deno.readTextFile === "function") {
+    return Deno.readTextFile(path);
+  }
+  const fs = await import("node:fs/promises");
+  return fs.readFile(path, "utf8");
+}
+
+async function writeTextFile(path: string, content: string): Promise<void> {
+  if (typeof Deno !== "undefined" && typeof Deno.writeTextFile === "function") {
+    const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+    const dir = lastSlash >= 0 ? path.slice(0, lastSlash) : "";
+    if (dir) {
+      await Deno.mkdir(dir, { recursive: true });
+    }
+    await Deno.writeTextFile(path, content);
+    return;
+  }
+  const fs = await import("node:fs/promises");
+  const pathModule = await import("node:path");
+  await fs.mkdir(pathModule.dirname(path), { recursive: true });
+  await fs.writeFile(path, content, "utf8");
+}
+
+export class Recorder {
+  readonly cassettePath: string;
+  readonly mode: RecordMode;
+  readonly ignore_body_fields: string[];
+  private effectiveMode: RecordMode | null = null;
+  private interactions: CassetteInteraction[] = [];
+  private cursor = 0;
+  private wrappedClients: Array<{ client: object; fetchImpl: FetchLike }> = [];
+
+  constructor(cassettePath: string, options: RecorderOptions = {}) {
+    this.cassettePath = cassettePath;
+    this.mode = options.mode ?? RecordMode.AUTO;
+    this.ignore_body_fields = options.ignore_body_fields ?? [];
+  }
+
+  static async open(cassettePath: string, options: RecorderOptions = {}): Promise<Recorder> {
+    const recorder = new Recorder(cassettePath, options);
+    return recorder.start();
+  }
+
+  async start(): Promise<this> {
+    this.effectiveMode = await this.resolveMode();
+    this.interactions = this.effectiveMode === RecordMode.REPLAY ? await this.loadCassette() : [];
+    this.cursor = 0;
+    return this;
+  }
+
+  async close(): Promise<void> {
+    for (const wrapped of this.wrappedClients.splice(0)) {
+      Reflect.set(wrapped.client, "fetchImpl", wrapped.fetchImpl);
+    }
+    if (this.effectiveMode === RecordMode.RECORD) {
+      const payload: CassetteFile = { version: CASSETTE_VERSION, interactions: this.interactions };
+      await writeTextFile(this.cassettePath, `${JSON.stringify(sortKeysDeep(payload), null, 2)}\n`);
+    }
+  }
+
+  wrap<T extends object>(client: T): T {
+    if (!this.effectiveMode) {
+      throw new Error("Recorder.wrap() requires start() first.");
+    }
+    const currentFetch = Reflect.get(client, "fetchImpl");
+    if (typeof currentFetch !== "function") {
+      throw new Error("Recorder.wrap() expects a SiglumeClient-like object with fetchImpl.");
+    }
+    this.wrappedClients.push({ client, fetchImpl: currentFetch as FetchLike });
+    Reflect.set(client, "fetchImpl", this.createFetch(currentFetch as FetchLike));
+    return client;
+  }
+
+  async withGlobalFetch<T>(fn: () => Promise<T> | T): Promise<T> {
+    if (!this.effectiveMode) {
+      throw new Error("Recorder.withGlobalFetch() requires start() first.");
+    }
+    const originalFetch = globalThis.fetch;
+    if (typeof originalFetch !== "function") {
+      throw new Error("Global fetch is not available in this runtime.");
+    }
+    const recorderFetch = this.createFetch(originalFetch);
+    Reflect.set(globalThis as object, "fetch", recorderFetch);
+    try {
+      return await fn();
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+    }
+  }
+
+  private async resolveMode(): Promise<RecordMode> {
+    if (this.mode === RecordMode.AUTO) {
+      return await fileExists(this.cassettePath) ? RecordMode.REPLAY : RecordMode.RECORD;
+    }
+    return this.mode;
+  }
+
+  private async loadCassette(): Promise<CassetteInteraction[]> {
+    if (!(await fileExists(this.cassettePath))) {
+      throw new Error(`Cassette not found for replay: ${this.cassettePath}`);
+    }
+    const payload = JSON.parse(await readTextFile(this.cassettePath)) as Partial<CassetteFile>;
+    if (payload.version !== CASSETTE_VERSION || !Array.isArray(payload.interactions)) {
+      throw new Error(`Invalid cassette format: ${this.cassettePath}`);
+    }
+    return payload.interactions;
+  }
+
+  private createFetch(fetchImpl: FetchLike): FetchLike {
+    const ignoreBodyFields = new Set(this.ignore_body_fields);
+    return (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const requestBody = await parseRequestBody(request);
+      const requestRecord = {
+        method: request.method,
+        url: redactUrl(request.url),
+        headers: redactHeaders(request.headers),
+        body: redactBody(requestBody),
+      };
+
+      if (this.effectiveMode === RecordMode.REPLAY) {
+        if (this.cursor >= this.interactions.length) {
+          throw new Error(`Replay attempted unexpected fetch ${request.method} ${request.url}`);
+        }
+        const interaction = this.interactions[this.cursor];
+        if (!interaction) {
+          throw new Error(`Replay interaction missing at index ${this.cursor}`);
+        }
+        if (requestSignature(interaction.request, ignoreBodyFields) !== requestSignature(requestRecord, ignoreBodyFields)) {
+          throw new Error(
+            `Replay request mismatch.\nExpected: ${requestSignature(interaction.request, ignoreBodyFields)}\nActual:   ${requestSignature(requestRecord, ignoreBodyFields)}`,
+          );
+        }
+        this.cursor += 1;
+        return buildResponseFromCassette(interaction, request);
+      }
+
+      const started = Date.now();
+      const response = await fetchImpl(input, init);
+      const responseText = response.status === 204 ? "" : await response.clone().text();
+      const responseBody = await parseTextBody(responseText);
+      this.interactions.push({
+        request: requestRecord,
+        response: {
+          status: response.status,
+          headers: redactHeaders(response.headers),
+          body: redactBody(responseBody),
+          duration_ms: Date.now() - started,
+        },
+      });
+      return response;
+    }) satisfies FetchLike;
+  }
+}

--- a/siglume-api-sdk-ts/test/recorder.test.ts
+++ b/siglume-api-sdk-ts/test/recorder.test.ts
@@ -1,0 +1,549 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  RecordMode,
+  Recorder,
+  SiglumeClient,
+  ToolManualPermissionClass,
+} from "../src/index";
+import type { ExecutionContext, ExecutionResult } from "../src/index";
+
+const tempDirs: string[] = [];
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(String(input));
+}
+
+function envelope(data: Record<string, unknown>, meta: Record<string, unknown> = { request_id: "req_test", trace_id: "trc_test" }) {
+  return { data, meta, error: null };
+}
+
+function buildManifest() {
+  return {
+    capability_key: "price-compare-helper",
+    name: "Price Compare Helper",
+    job_to_be_done: "Compare retailer prices for a product and return the best current offer.",
+    category: AppCategory.COMMERCE,
+    permission_class: PermissionClass.READ_ONLY,
+    approval_mode: ApprovalMode.AUTO,
+    dry_run_supported: true,
+    required_connected_accounts: [],
+    price_model: PriceModel.FREE,
+    price_value_minor: 0,
+    jurisdiction: "US",
+    short_description: "Search multiple retailers and summarize the best current price.",
+    example_prompts: ["Compare prices for Sony WH-1000XM5."],
+  };
+}
+
+function buildToolManual() {
+  return {
+    tool_name: "price_compare_helper",
+    job_to_be_done: "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+    summary_for_model: "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+    trigger_conditions: [
+      "owner asks to compare prices for a product before deciding where to buy",
+      "agent needs retailer offer data to support a shopping recommendation",
+      "request is to find the cheapest or best-value option for a product query",
+    ],
+    do_not_use_when: [
+      "the request is to complete checkout or place an order instead of comparing offers",
+    ],
+    permission_class: ToolManualPermissionClass.READ_ONLY,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Product name, model number, or search phrase." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line overview of the best available deal." },
+        offers: { type: "array", items: { type: "object" }, description: "Ranked retailer offers." },
+      },
+      required: ["summary", "offers"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+    result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
+    error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+  };
+}
+
+async function makeTempCassette(name: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "siglume-recorder-"));
+  tempDirs.push(dir);
+  return join(dir, name);
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("Recorder", () => {
+  it("records and replays a SiglumeClient flow", async () => {
+    const cassettePath = await makeTempCassette("client-roundtrip.json");
+    const requests: Array<{ method: string; path: string }> = [];
+
+    const recorder = await Recorder.open(cassettePath, { mode: RecordMode.RECORD });
+    try {
+      const client = recorder.wrap(new SiglumeClient({
+        api_key: "sig_test_key",
+        base_url: "https://api.example.test/v1",
+        fetch: async (input, init) => {
+          const url = requestUrl(input);
+          requests.push({ method: String(init?.method ?? "GET"), path: url.pathname });
+          if (url.pathname === "/v1/market/capabilities/auto-register") {
+            return new Response(JSON.stringify(envelope({
+              listing_id: "lst_123",
+              status: "draft",
+              auto_manifest: { capability_key: "price-compare-helper" },
+              confidence: { overall: 0.94 },
+              review_url: "/owner/publish?listing=lst_123",
+            })), { status: 201, headers: { "content-type": "application/json" } });
+          }
+          if (url.pathname === "/v1/market/capabilities/lst_123/confirm-auto-register") {
+            return new Response(JSON.stringify(envelope({
+              listing_id: "lst_123",
+              status: "pending_review",
+              release: { release_id: "rel_123", release_status: "pending_review" },
+              quality: {
+                overall_score: 84,
+                grade: "B",
+                issues: [],
+                improvement_suggestions: ["Add one more retailer-specific trigger example."],
+              },
+            }, { request_id: "req_confirm", trace_id: "trc_confirm" })), { status: 200, headers: { "content-type": "application/json" } });
+          }
+          return new Response("{}", { status: 500 });
+        },
+      }));
+
+      const receipt = await client.auto_register(buildManifest(), buildToolManual(), { source_code: "# ts recorder stub" });
+      const confirmation = await client.confirm_registration(receipt.listing_id);
+      expect(receipt.listing_id).toBe("lst_123");
+      expect(confirmation.quality.grade).toBe("B");
+    } finally {
+      await recorder.close();
+    }
+
+    const replayRecorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    try {
+      const replayClient = replayRecorder.wrap(new SiglumeClient({
+        api_key: "sig_ignored",
+        base_url: "https://api.example.test/v1",
+        fetch: async () => {
+          throw new Error("Replay should not hit fetch");
+        },
+      }));
+
+      const replayReceipt = await replayClient.auto_register(buildManifest(), buildToolManual(), { source_code: "# ts recorder stub" });
+      const replayConfirmation = await replayClient.confirm_registration(replayReceipt.listing_id);
+      expect(replayReceipt.listing_id).toBe("lst_123");
+      expect(replayConfirmation.trace_id).toBe("trc_confirm");
+      expect(requests).toHaveLength(2);
+    } finally {
+      await replayRecorder.close();
+    }
+  });
+
+  it("replays the committed shared cassette in TypeScript", async () => {
+    const cassettePath = fileURLToPath(new URL("../../tests/cassettes/auto_register_flow.json", import.meta.url));
+    const recorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    try {
+      const client = recorder.wrap(new SiglumeClient({
+        api_key: "sig_ignored",
+        base_url: "https://api.example.test/v1",
+        fetch: async () => {
+          throw new Error("Replay should not hit fetch");
+        },
+      }));
+
+      const receipt = await client.auto_register(buildManifest(), buildToolManual(), { source_code: "# shared registration stub" });
+      const confirmation = await client.confirm_registration(receipt.listing_id);
+
+      expect(receipt.listing_id).toBe("lst_123");
+      expect(confirmation.status).toBe("pending_review");
+      expect(confirmation.quality.overall_score).toBe(84);
+    } finally {
+      await recorder.close();
+    }
+  });
+
+  it("redacts auth, token, and private-key values in cassettes", async () => {
+    const cassettePath = await makeTempCassette("redacted.json");
+    const recorder = await Recorder.open(cassettePath, { mode: RecordMode.RECORD });
+    const originalFetch = globalThis.fetch;
+    Reflect.set(globalThis as object, "fetch", async () => new Response(JSON.stringify(envelope({
+      refresh_token: "pypi-SECRET123",
+      private_key: `0x${"a".repeat(64)}`,
+      ok: true,
+    })), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer downstream",
+      },
+    }));
+    try {
+      await recorder.withGlobalFetch(() =>
+        fetch("https://api.example.test/secrets?api_key=query-secret&access_token=ghp-QUERYSECRET", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer sig_top_secret",
+            cookie: "session=ghp-COOKIESECRET",
+            "x-api-key": "sig_header_secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            api_key: "sig_private",
+            nested: { private_key: `0x${"b".repeat(64)}` },
+            access_token: "ghp-EXAMPLESECRET",
+          }),
+        }),
+      );
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await recorder.close();
+    }
+
+    const cassetteText = await readFile(cassettePath, "utf8");
+    expect(cassetteText).toContain("Bearer <REDACTED>");
+    expect(cassetteText).toContain("<REDACTED>");
+    expect(cassetteText).toContain("<REDACTED_PRIVKEY>");
+    expect(cassetteText).toContain("<REDACTED_TOKEN>");
+    expect(cassetteText).not.toContain("sig_top_secret");
+    expect(cassetteText).not.toContain("sig_header_secret");
+    expect(cassetteText).not.toContain("query-secret");
+    expect(cassetteText).not.toContain("ghp-QUERYSECRET");
+    expect(cassetteText).not.toContain("ghp-COOKIESECRET");
+    expect(cassetteText).not.toContain("ghp-EXAMPLESECRET");
+
+    const replayRecorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    Reflect.set(globalThis as object, "fetch", async () => {
+      throw new Error("Replay should not hit fetch");
+    });
+    try {
+      const replayed = await replayRecorder.withGlobalFetch(() =>
+        fetch("https://api.example.test/secrets?api_key=query-secret&access_token=ghp-QUERYSECRET", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer sig_top_secret",
+            cookie: "session=ghp-COOKIESECRET",
+            "x-api-key": "sig_header_secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            api_key: "sig_private",
+            nested: { private_key: `0x${"b".repeat(64)}` },
+            access_token: "ghp-EXAMPLESECRET",
+          }),
+        }),
+      );
+      expect(replayed.status).toBe(200);
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await replayRecorder.close();
+    }
+  });
+
+  it("ignores configured top-level body fields during replay matching", async () => {
+    const cassettePath = await makeTempCassette("ignore-fields.json");
+    const recordRecorder = await Recorder.open(cassettePath, {
+      mode: RecordMode.RECORD,
+      ignore_body_fields: ["request_id", "timestamp"],
+    });
+    const originalFetch = globalThis.fetch;
+    Reflect.set(globalThis as object, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {};
+      return new Response(JSON.stringify(envelope({ ok: true, echo: body })), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    try {
+      await recordRecorder.withGlobalFetch(() =>
+        fetch("https://api.example.test/events", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            query: "headphones",
+            request_id: "req_record",
+            timestamp: "2026-04-19T00:00:00Z",
+          }),
+        }),
+      );
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await recordRecorder.close();
+    }
+
+    const replayRecorder = await Recorder.open(cassettePath, {
+      mode: RecordMode.REPLAY,
+      ignore_body_fields: ["request_id", "timestamp"],
+    });
+    try {
+      const originalFetch = globalThis.fetch;
+      Reflect.set(globalThis as object, "fetch", async () => {
+        throw new Error("Replay should not hit fetch");
+      });
+      try {
+        const response = await replayRecorder.withGlobalFetch(() =>
+          fetch("https://api.example.test/events", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              query: "headphones",
+              request_id: "req_replay",
+              timestamp: "2026-04-19T01:00:00Z",
+            }),
+          }),
+        );
+        expect((await response.json()).data.ok).toBe(true);
+      } finally {
+        Reflect.set(globalThis as object, "fetch", originalFetch);
+      }
+    } finally {
+      await replayRecorder.close();
+    }
+  });
+
+  it("raises on replay mismatches", async () => {
+    const cassettePath = await makeTempCassette("mismatch.json");
+    const recordRecorder = await Recorder.open(cassettePath, { mode: RecordMode.RECORD });
+    const originalFetch = globalThis.fetch;
+    Reflect.set(globalThis as object, "fetch", async () =>
+      new Response(JSON.stringify(envelope({ ok: true })), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    try {
+      await recordRecorder.withGlobalFetch(() =>
+        fetch("https://api.example.test/events", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "camera" }),
+        }),
+      );
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await recordRecorder.close();
+    }
+
+    const replayRecorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    try {
+      await expect(
+        replayRecorder.withGlobalFetch(() =>
+          fetch("https://api.example.test/events", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ query: "laptop" }),
+          }),
+        ),
+      ).rejects.toThrow("Replay request mismatch");
+    } finally {
+      await replayRecorder.close();
+    }
+  });
+
+  it("preserves repeated query params and repeated response headers in cassettes", async () => {
+    const cassettePath = await makeTempCassette("repeat-values.json");
+    const recorder = await Recorder.open(cassettePath, { mode: RecordMode.RECORD });
+    const originalFetch = globalThis.fetch;
+    const upstreamHeaders = new Headers();
+    upstreamHeaders.append("set-cookie", "a=1");
+    upstreamHeaders.append("set-cookie", "b=2");
+    Reflect.set(globalThis as object, "fetch", async () =>
+      new Response(JSON.stringify(envelope({ ok: true })), {
+        status: 200,
+        headers: upstreamHeaders,
+      }));
+    try {
+      await recorder.withGlobalFetch(() =>
+        fetch("https://api.example.test/items?tag=a&tag=b&api_key=query-secret", {
+          headers: { authorization: "Bearer sig_secret" },
+        }),
+      );
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await recorder.close();
+    }
+
+    const cassette = JSON.parse(await readFile(cassettePath, "utf8")) as {
+      interactions: Array<{ request: { url: string }; response: { headers: Record<string, string | string[]> } }>;
+    };
+    expect(cassette.interactions[0]?.request.url).toContain("tag=a&tag=b");
+    expect(cassette.interactions[0]?.response.headers["set-cookie"]).toEqual(["<REDACTED>", "<REDACTED>"]);
+  });
+
+  it("replays multipart form-data uploads by normalizing boundaries", async () => {
+    const cassettePath = await makeTempCassette("multipart.json");
+    const recordRecorder = await Recorder.open(cassettePath, { mode: RecordMode.RECORD });
+    const originalFetch = globalThis.fetch;
+    const fileBytes = new Uint8Array([255, 0, 254, 16, 98, 105, 110, 97, 114, 121]);
+    Reflect.set(globalThis as object, "fetch", async () =>
+      new Response(JSON.stringify(envelope({ ok: true })), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    try {
+      await recordRecorder.withGlobalFetch(() => {
+        const formData = new FormData();
+        formData.set("note", "hello");
+        formData.set("file", new Blob([fileBytes], { type: "application/octet-stream" }), "hello.bin");
+        return fetch("https://api.example.test/upload", {
+          method: "POST",
+          body: formData,
+        });
+      });
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await recordRecorder.close();
+    }
+
+    const cassetteText = await readFile(cassettePath, "utf8");
+    expect(cassetteText).toContain("\"encoding\": \"base64\"");
+    expect(cassetteText).toContain("boundary=<BOUNDARY>");
+
+    const replayRecorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    Reflect.set(globalThis as object, "fetch", async () => {
+      throw new Error("Replay should not hit fetch");
+    });
+    try {
+      const replayed = await replayRecorder.withGlobalFetch(() => {
+        const formData = new FormData();
+        formData.set("note", "hello");
+        formData.set("file", new Blob([fileBytes], { type: "application/octet-stream" }), "hello.bin");
+        return fetch("https://api.example.test/upload", {
+          method: "POST",
+          body: formData,
+        });
+      });
+      expect((await replayed.json()).data.ok).toBe(true);
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await replayRecorder.close();
+    }
+
+    const mismatchRecorder = await Recorder.open(cassettePath, { mode: RecordMode.REPLAY });
+    Reflect.set(globalThis as object, "fetch", async () => {
+      throw new Error("Replay should not hit fetch");
+    });
+    try {
+      await expect(
+        mismatchRecorder.withGlobalFetch(() => {
+          const formData = new FormData();
+          formData.set("note", "hello");
+          formData.set("file", new Blob([new Uint8Array([0, 1, 2, 3])], { type: "application/octet-stream" }), "hello.bin");
+          return fetch("https://api.example.test/upload", {
+            method: "POST",
+            body: formData,
+          });
+        }),
+      ).rejects.toThrow("Replay request mismatch");
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+      await mismatchRecorder.close();
+    }
+  });
+});
+
+class FetchQuoteApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "fetch-quote",
+      name: "Fetch Quote",
+      job_to_be_done: "Quote a price from an upstream HTTP service.",
+      category: AppCategory.COMMERCE,
+      permission_class: PermissionClass.READ_ONLY,
+      approval_mode: ApprovalMode.AUTO,
+      dry_run_supported: true,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Calls a quote API via fetch.",
+      example_prompts: ["Quote this item."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const response = await fetch("https://api.example.test/quote", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer harness-secret" },
+      body: JSON.stringify({
+        query: String(ctx.input_params?.query ?? "headphones"),
+        timestamp: "2026-04-19T00:00:00Z",
+      }),
+    });
+    const payload = await response.json() as { data: Record<string, unknown> };
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: payload.data,
+    };
+  }
+}
+
+describe("AppTestHarness recorder helpers", () => {
+  it("records and replays fetch calls inside harness helpers", async () => {
+    const cassettePath = await makeTempCassette("harness.json");
+    const harness = new AppTestHarness(new FetchQuoteApp());
+    const originalFetch = globalThis.fetch;
+
+    Reflect.set(globalThis as object, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as Record<string, unknown> : {};
+      return new Response(JSON.stringify(envelope({
+        summary: `quoted:${String(body.query ?? "")}`,
+        provider_status: "ok",
+      })), { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    try {
+      const recorded = await harness.record(cassettePath, (currentHarness) =>
+        currentHarness.dry_run("quote_lookup", { input_params: { query: "sony" } }),
+      );
+      expect(recorded.output?.summary).toBe("quoted:sony");
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+    }
+
+    Reflect.set(globalThis as object, "fetch", async () => {
+      throw new Error("Replay should not hit fetch");
+    });
+
+    try {
+      const replayed = await harness.replay(cassettePath, (currentHarness) =>
+        currentHarness.dry_run("quote_lookup", { input_params: { query: "sony" } }),
+      );
+      expect(replayed.output?.summary).toBe("quoted:sony");
+    } finally {
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+    }
+  });
+});

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -1000,3 +1000,50 @@ class AppTestHarness:
             connected_accounts={},  # intentionally empty
             **kwargs,
         )
+
+    def record(
+        self,
+        cassette_path: str,
+        *,
+        ignore_body_fields: list[str] | None = None,
+    ) -> "_HarnessRecorderScope":
+        from siglume_api_sdk.testing import Recorder, RecordMode
+
+        return _HarnessRecorderScope(
+            self,
+            Recorder(
+                cassette_path,
+                mode=RecordMode.RECORD,
+                ignore_body_fields=ignore_body_fields,
+            ),
+        )
+
+    def replay(
+        self,
+        cassette_path: str,
+        *,
+        ignore_body_fields: list[str] | None = None,
+    ) -> "_HarnessRecorderScope":
+        from siglume_api_sdk.testing import Recorder, RecordMode
+
+        return _HarnessRecorderScope(
+            self,
+            Recorder(
+                cassette_path,
+                mode=RecordMode.REPLAY,
+                ignore_body_fields=ignore_body_fields,
+            ),
+        )
+
+
+class _HarnessRecorderScope:
+    def __init__(self, harness: AppTestHarness, recorder: Any) -> None:
+        self.harness = harness
+        self.recorder = recorder
+
+    def __enter__(self) -> AppTestHarness:
+        self.recorder.__enter__()
+        return self.harness
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.recorder.__exit__(exc_type, exc, tb)

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -90,6 +90,7 @@ from .exporters import (  # noqa: E402, F401
     to_openai_function,
     to_openai_responses_tool,
 )
+from .testing import Recorder, RecordMode  # noqa: E402, F401
 from .tool_manual_assist import (  # noqa: E402, F401
     AnthropicProvider,
     LLMProvider,
@@ -135,6 +136,8 @@ __all__ = sorted(
             "AnthropicProvider",
             "LLMProvider",
             "OpenAIProvider",
+            "RecordMode",
+            "Recorder",
             "diff_manifest",
             "diff_tool_manual",
             "to_anthropic_tool",

--- a/siglume_api_sdk/testing/__init__.py
+++ b/siglume_api_sdk/testing/__init__.py
@@ -1,0 +1,6 @@
+"""Testing helpers for deterministic SDK integration tests."""
+from __future__ import annotations
+
+from .recorder import Recorder, RecordMode
+
+__all__ = ["Recorder", "RecordMode"]

--- a/siglume_api_sdk/testing/recorder.py
+++ b/siglume_api_sdk/testing/recorder.py
@@ -1,0 +1,368 @@
+"""Lightweight VCR-like recorder for Siglume SDK tests."""
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import httpx
+
+CASSETTE_VERSION = 1
+_SECRET_KEY_RE = re.compile(r"(api[_-]?key|secret|private[_-]?key|access[_-]?token|refresh[_-]?token)", re.IGNORECASE)
+_PRIVKEY_RE = re.compile(r"0x[a-f0-9]{64}")
+_TOKEN_RE = re.compile(r"(pypi|ghp|gho|ghu|ghs)-[A-Za-z0-9]+")
+_BOUNDARY_RE = re.compile(r'boundary="?([^";]+)"?', re.IGNORECASE)
+HeaderValue = str | list[str]
+
+
+class RecordMode(str, Enum):
+    RECORD = "record"
+    REPLAY = "replay"
+    AUTO = "auto"
+
+
+def _append_header(result: dict[str, HeaderValue], key: str, value: str) -> None:
+    existing = result.get(key)
+    if existing is None:
+        result[key] = value
+    elif isinstance(existing, list):
+        existing.append(value)
+    else:
+        result[key] = [existing, value]
+
+
+def _normalize_headers(headers: Mapping[str, Any] | httpx.Headers | None) -> dict[str, HeaderValue]:
+    if headers is None:
+        return {}
+    result: dict[str, HeaderValue] = {}
+    if isinstance(headers, httpx.Headers):
+        items = headers.multi_items()
+    else:
+        items = headers.items()
+    for key, value in items:
+        normalized_key = str(key).lower()
+        if isinstance(value, list):
+            for entry in value:
+                _append_header(result, normalized_key, str(entry))
+        else:
+            _append_header(result, normalized_key, str(value))
+    return result
+
+
+def _redact_string(value: str) -> str:
+    value = _PRIVKEY_RE.sub("<REDACTED_PRIVKEY>", value)
+    value = _TOKEN_RE.sub("<REDACTED_TOKEN>", value)
+    return value
+
+
+def _redact_header_value(key: str, value: str) -> str:
+    if key == "content-type" and "multipart/form-data" in value.lower():
+        return _normalize_multipart_content_type(value)
+    if key == "authorization" and value.lower().startswith("bearer "):
+        return "Bearer <REDACTED>"
+    if key in {"cookie", "set-cookie"} or _SECRET_KEY_RE.search(key):
+        redacted = _redact_string(value)
+        return redacted if redacted != value else "<REDACTED>"
+    return _redact_string(value)
+
+
+def _redact_headers(headers: Mapping[str, Any] | httpx.Headers | None) -> dict[str, HeaderValue]:
+    normalized = _normalize_headers(headers)
+    result: dict[str, HeaderValue] = {}
+    for key, value in normalized.items():
+        if isinstance(value, list):
+            result[key] = [_redact_header_value(key, item) for item in value]
+        else:
+            result[key] = _redact_header_value(key, value)
+    return result
+
+
+def _redact_url(url: str) -> str:
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+    redacted_query: list[tuple[str, str]] = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if _SECRET_KEY_RE.search(key):
+            next_value = _redact_string(value)
+            redacted_query.append((key, next_value if next_value != value else "<REDACTED>"))
+        else:
+            redacted_query.append((key, _redact_string(value)))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(redacted_query), parts.fragment))
+
+
+def _redact_body(value: Any, *, key_name: str | None = None) -> Any:
+    if key_name and _SECRET_KEY_RE.search(key_name):
+        if isinstance(value, str):
+            redacted = _redact_string(value)
+            return redacted if redacted != value else "<REDACTED>"
+        return "<REDACTED>"
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): _redact_body(child_value, key_name=str(child_key))
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_body(item) for item in value]
+    if isinstance(value, str):
+        return _redact_string(value)
+    return value
+
+
+def _normalize_multipart_bytes(content: bytes, content_type: str | None) -> bytes:
+    if not content_type:
+        return content
+    match = _BOUNDARY_RE.search(content_type)
+    if not match:
+        return content
+    boundary = match.group(1).encode("utf-8")
+    return content.replace(boundary, b"<BOUNDARY>")
+
+
+def _normalize_multipart_content_type(content_type: str | None) -> str:
+    if not content_type:
+        return "multipart/form-data; boundary=<BOUNDARY>"
+    return _BOUNDARY_RE.sub("boundary=<BOUNDARY>", content_type)
+
+
+def _parse_body_bytes(content: bytes | str | None, *, content_type: str | None = None) -> Any:
+    if content in (None, b"", ""):
+        return None
+    if content_type and "multipart/form-data" in content_type.lower():
+        raw_bytes = content if isinstance(content, bytes) else content.encode("utf-8")
+        return {
+            "content_type": _normalize_multipart_content_type(content_type),
+            "encoding": "base64",
+            "base64": base64.b64encode(_normalize_multipart_bytes(raw_bytes, content_type)).decode("ascii"),
+        }
+    if isinstance(content, bytes):
+        text = content.decode("utf-8", errors="replace")
+    else:
+        text = content
+    try:
+        return json.loads(text)
+    except ValueError:
+        return text
+
+
+def _serialize_request_body(request: httpx.Request) -> Any:
+    try:
+        body = request.content
+    except Exception:
+        try:
+            body = request.read()
+        except Exception:
+            return None
+    return _parse_body_bytes(body, content_type=request.headers.get("content-type"))
+
+
+def _serialize_response_body(response: httpx.Response) -> Any:
+    try:
+        body = response.content
+    except Exception:
+        return None
+    return _parse_body_bytes(body)
+
+
+def _normalize_body_for_match(body: Any, ignore_body_fields: set[str]) -> Any:
+    if isinstance(body, Mapping):
+        return {
+            key: _normalize_body_for_match(body[key], set())
+            for key in sorted(body)
+            if key not in ignore_body_fields
+        }
+    if isinstance(body, list):
+        return [_normalize_body_for_match(item, set()) for item in body]
+    return body
+
+
+def _request_signature(request_payload: Mapping[str, Any], ignore_body_fields: set[str]) -> str:
+    normalized = {
+        "method": str(request_payload.get("method") or "").upper(),
+        "url": str(request_payload.get("url") or ""),
+        "body": _normalize_body_for_match(request_payload.get("body"), ignore_body_fields),
+    }
+    return json.dumps(normalized, ensure_ascii=False, separators=(",", ":"))
+
+
+def _response_from_cassette(response_payload: Mapping[str, Any], request: httpx.Request) -> httpx.Response:
+    headers: list[tuple[str, str]] = []
+    for key, value in _normalize_headers(response_payload.get("headers")).items():
+        if isinstance(value, list):
+            headers.extend((str(key), str(item)) for item in value)
+        else:
+            headers.append((str(key), str(value)))
+    body = response_payload.get("body")
+    if isinstance(body, str):
+        content = body.encode("utf-8")
+    elif body is None:
+        content = b""
+    else:
+        content = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        if not any(key.lower() == "content-type" for key, _ in headers):
+            headers.append(("content-type", "application/json"))
+    return httpx.Response(
+        int(response_payload.get("status") or 200),
+        headers=headers,
+        content=content,
+        request=request,
+    )
+
+
+class Recorder:
+    """Record and replay HTTP interactions as JSON cassettes."""
+
+    def __init__(
+        self,
+        cassette_path: str | Path,
+        *,
+        mode: RecordMode = RecordMode.AUTO,
+        ignore_body_fields: list[str] | None = None,
+    ) -> None:
+        self.cassette_path = Path(cassette_path)
+        self.mode = mode
+        self.ignore_body_fields = set(ignore_body_fields or [])
+        self._effective_mode = mode
+        self._interactions: list[dict[str, Any]] = []
+        self._cursor = 0
+        self._original_client_request: Callable[..., httpx.Response] | None = None
+        self._original_module_request: Callable[..., httpx.Response] | None = None
+
+    def __enter__(self) -> "Recorder":
+        self._effective_mode = self._resolve_mode()
+        self._interactions = self._load_cassette() if self._effective_mode == RecordMode.REPLAY else []
+        self._cursor = 0
+        self._patch_httpx()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._restore_httpx()
+        if exc_type is None and self._effective_mode == RecordMode.RECORD:
+            self._write_cassette()
+
+    def wrap(self, client: Any) -> Any:
+        return client
+
+    def _resolve_mode(self) -> RecordMode:
+        if self.mode == RecordMode.AUTO:
+            return RecordMode.REPLAY if self.cassette_path.exists() else RecordMode.RECORD
+        return self.mode
+
+    def _load_cassette(self) -> list[dict[str, Any]]:
+        if not self.cassette_path.exists():
+            raise AssertionError(f"Cassette not found for replay: {self.cassette_path}")
+        payload = json.loads(self.cassette_path.read_text(encoding="utf-8"))
+        if payload.get("version") != CASSETTE_VERSION:
+            raise AssertionError(f"Unsupported cassette version in {self.cassette_path}")
+        interactions = payload.get("interactions")
+        if not isinstance(interactions, list):
+            raise AssertionError(f"Invalid cassette interactions in {self.cassette_path}")
+        return [dict(item) for item in interactions if isinstance(item, Mapping)]
+
+    def _write_cassette(self) -> None:
+        self.cassette_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"version": CASSETTE_VERSION, "interactions": self._interactions}
+        self.cassette_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def _patch_httpx(self) -> None:
+        self._original_client_request = httpx.Client.request
+        self._original_module_request = httpx.request
+        recorder = self
+        original_client_request = self._original_client_request
+        original_module_request = self._original_module_request
+
+        def client_request_wrapper(client_self: httpx.Client, method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
+            request = client_self.build_request(
+                method,
+                url,
+                content=kwargs.get("content"),
+                data=kwargs.get("data"),
+                files=kwargs.get("files"),
+                json=kwargs.get("json"),
+                params=kwargs.get("params"),
+                headers=kwargs.get("headers"),
+                cookies=kwargs.get("cookies"),
+            )
+            if recorder._effective_mode == RecordMode.REPLAY:
+                return recorder._replay_request(request)
+            started = time.perf_counter()
+            response = original_client_request(client_self, method, url, *args, **kwargs)
+            duration_ms = int(round((time.perf_counter() - started) * 1000))
+            recorder._record_interaction(request, response, duration_ms)
+            return response
+
+        def module_request_wrapper(method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
+            with httpx.Client() as temp_client:
+                request = temp_client.build_request(
+                    method,
+                    url,
+                    content=kwargs.get("content"),
+                    data=kwargs.get("data"),
+                    files=kwargs.get("files"),
+                    json=kwargs.get("json"),
+                    params=kwargs.get("params"),
+                    headers=kwargs.get("headers"),
+                    cookies=kwargs.get("cookies"),
+                )
+            if recorder._effective_mode == RecordMode.REPLAY:
+                return recorder._replay_request(request)
+            started = time.perf_counter()
+            response = original_module_request(method, url, *args, **kwargs)
+            duration_ms = int(round((time.perf_counter() - started) * 1000))
+            recorder._record_interaction(request, response, duration_ms)
+            return response
+
+        httpx.Client.request = client_request_wrapper
+        httpx.request = module_request_wrapper
+
+    def _restore_httpx(self) -> None:
+        if self._original_client_request is not None:
+            httpx.Client.request = self._original_client_request
+        if self._original_module_request is not None:
+            httpx.request = self._original_module_request
+
+    def _record_interaction(self, request: httpx.Request, response: httpx.Response, duration_ms: int) -> None:
+        self._interactions.append(
+            {
+                "request": {
+                    "method": request.method,
+                    "url": _redact_url(str(request.url)),
+                    "headers": _redact_headers(request.headers),
+                    "body": _redact_body(_serialize_request_body(request)),
+                },
+                "response": {
+                    "status": response.status_code,
+                    "headers": _redact_headers(response.headers),
+                    "body": _redact_body(_serialize_response_body(response)),
+                    "duration_ms": duration_ms,
+                },
+            }
+        )
+
+    def _replay_request(self, request: httpx.Request) -> httpx.Response:
+        if self._cursor >= len(self._interactions):
+            raise AssertionError(
+                f"Replay attempted unexpected HTTP call {request.method} {request.url} after cassette was exhausted."
+            )
+        expected = self._interactions[self._cursor]
+        actual_request = {
+            "method": request.method,
+            "url": _redact_url(str(request.url)),
+            "body": _redact_body(_serialize_request_body(request)),
+        }
+        if _request_signature(expected["request"], self.ignore_body_fields) != _request_signature(actual_request, self.ignore_body_fields):
+            raise AssertionError(
+                "Replay request mismatch.\n"
+                f"Expected: {_request_signature(expected['request'], self.ignore_body_fields)}\n"
+                f"Actual:   {_request_signature(actual_request, self.ignore_body_fields)}"
+            )
+        self._cursor += 1
+        return _response_from_cassette(expected["response"], request)

--- a/tests/cassettes/auto_register_flow.json
+++ b/tests/cassettes/auto_register_flow.json
@@ -1,0 +1,165 @@
+{
+  "version": 1,
+  "interactions": [
+    {
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.test/v1/market/capabilities/auto-register",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer <REDACTED>",
+          "content-length": "448",
+          "content-type": "application/json",
+          "user-agent": "siglume-api-sdk/fixture"
+        },
+        "body": {
+          "capability_key": "price-compare-helper",
+          "i18n": {
+            "job_to_be_done_en": "Compare retailer prices for a product and return the best current offer.",
+            "job_to_be_done_ja": "Compare retailer prices for a product and return the best current offer.",
+            "short_description_en": "Search multiple retailers and summarize the best current price.",
+            "short_description_ja": "Search multiple retailers and summarize the best current price."
+          },
+          "name": "Price Compare Helper",
+          "price_model": "free",
+          "price_value_minor": 0,
+          "source_code": "# shared registration stub"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "auto_manifest": {
+              "capability_key": "price-compare-helper"
+            },
+            "confidence": {
+              "overall": 0.94
+            },
+            "listing_id": "lst_123",
+            "review_url": "/owner/publish?listing=lst_123",
+            "status": "draft"
+          },
+          "error": null,
+          "meta": {
+            "request_id": "req_test",
+            "trace_id": "trc_test"
+          }
+        },
+        "duration_ms": 7
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.test/v1/market/capabilities/lst_123/confirm-auto-register",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer <REDACTED>",
+          "content-length": "1166",
+          "content-type": "application/json",
+          "user-agent": "siglume-api-sdk/fixture"
+        },
+        "body": {
+          "approved": true,
+          "overrides": {
+            "job_to_be_done": "Compare retailer prices for a product and return the best current offer.",
+            "name": "Price Compare Helper",
+            "tool_manual": {
+              "do_not_use_when": [
+                "the request is to complete checkout or place an order instead of comparing offers"
+              ],
+              "dry_run_supported": true,
+              "error_hints": [
+                "If no offers are found, ask for a clearer product name or model number."
+              ],
+              "input_schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "query": {
+                    "description": "Product name, model number, or search phrase.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "type": "object"
+              },
+              "job_to_be_done": "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+              "output_schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "offers": {
+                    "description": "Ranked retailer offers.",
+                    "items": {
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "summary": {
+                    "description": "One-line overview of the best available deal.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "summary",
+                  "offers"
+                ],
+                "type": "object"
+              },
+              "permission_class": "read_only",
+              "requires_connected_accounts": [],
+              "result_hints": [
+                "Lead with the best offer and then summarize notable trade-offs."
+              ],
+              "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+              "tool_name": "price_compare_helper",
+              "trigger_conditions": [
+                "owner asks to compare prices for a product before deciding where to buy",
+                "agent needs retailer offer data to support a shopping recommendation",
+                "request is to find the cheapest or best-value option for a product query"
+              ],
+              "usage_hints": [
+                "Use this tool after the owner has named a product and wants evidence-backed price comparison."
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "data": {
+            "listing_id": "lst_123",
+            "quality": {
+              "grade": "B",
+              "improvement_suggestions": [
+                "Add one more retailer-specific trigger example."
+              ],
+              "issues": [],
+              "overall_score": 84
+            },
+            "release": {
+              "release_id": "rel_123",
+              "release_status": "pending_review"
+            },
+            "status": "pending_review"
+          },
+          "error": null,
+          "meta": {
+            "request_id": "req_confirm",
+            "trace_id": "trc_confirm"
+          }
+        },
+        "duration_ms": 9
+      }
+    }
+  ]
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,6 +22,7 @@ from siglume_api_sdk import (  # noqa: E402
     ToolManual,
     ToolManualPermissionClass,
 )
+from siglume_api_sdk.testing import Recorder, RecordMode  # noqa: E402
 
 
 def envelope(data, *, trace_id: str = "trc_test", request_id: str = "req_test") -> dict[str, object]:
@@ -96,10 +97,11 @@ def build_client(handler) -> SiglumeClient:
     )
 
 
-def test_auto_register_and_confirm_registration_return_typed_objects() -> None:
+def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: Path) -> None:
     manifest = build_manifest()
     tool_manual = build_tool_manual()
     requests: list[tuple[str, str, dict[str, object]]] = []
+    cassette_path = tmp_path / "auto_register_recorded.json"
 
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content.decode("utf-8")) if request.content else {}
@@ -145,9 +147,18 @@ def test_auto_register_and_confirm_registration_return_typed_objects() -> None:
 
         raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
-    with build_client(handler) as client:
-        receipt = client.auto_register(manifest, tool_manual)
-        confirmation = client.confirm_registration(receipt.listing_id)
+    with Recorder(cassette_path, mode=RecordMode.RECORD) as recorder:
+        with recorder.wrap(build_client(handler)) as client:
+            receipt = client.auto_register(manifest, tool_manual)
+            confirmation = client.confirm_registration(receipt.listing_id)
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY) as recorder:
+        with recorder.wrap(build_client(unexpected_handler)) as client:
+            replay_receipt = client.auto_register(manifest, tool_manual)
+            replay_confirmation = client.confirm_registration(replay_receipt.listing_id)
 
     assert receipt.listing_id == "lst_123"
     assert receipt.trace_id == "trc_test"
@@ -158,6 +169,8 @@ def test_auto_register_and_confirm_registration_return_typed_objects() -> None:
     assert confirmation.trace_id == "trc_confirm"
     assert requests[0][1] == "/v1/market/capabilities/auto-register"
     assert requests[1][1] == "/v1/market/capabilities/lst_123/confirm-auto-register"
+    assert replay_receipt.listing_id == receipt.listing_id
+    assert replay_confirmation.quality.grade == confirmation.quality.grade
 
 
 def test_cursor_pages_follow_next_cursor_for_listings_and_usage() -> None:

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    ApprovalMode,
+    ExecutionContext,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    SiglumeClient,
+    ToolManual,
+    ToolManualPermissionClass,
+)
+from siglume_api_sdk.testing import Recorder, RecordMode  # noqa: E402
+
+
+def envelope(data, *, trace_id: str = "trc_test", request_id: str = "req_test") -> dict[str, object]:
+    return {
+        "data": data,
+        "meta": {"request_id": request_id, "trace_id": trace_id},
+        "error": None,
+    }
+
+
+def build_manifest() -> AppManifest:
+    return AppManifest(
+        capability_key="price-compare-helper",
+        name="Price Compare Helper",
+        job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+        category=AppCategory.COMMERCE,
+        permission_class=PermissionClass.READ_ONLY,
+        approval_mode=ApprovalMode.AUTO,
+        dry_run_supported=True,
+        required_connected_accounts=[],
+        price_model=PriceModel.FREE,
+        jurisdiction="US",
+        short_description="Search multiple retailers and summarize the best current price.",
+        example_prompts=["Compare prices for Sony WH-1000XM5."],
+    )
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="price_compare_helper",
+        job_to_be_done="Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+        summary_for_model="Looks up current retailer offers and returns a structured comparison with the best deal first.",
+        trigger_conditions=[
+            "owner asks to compare prices for a product before deciding where to buy",
+            "agent needs retailer offer data to support a shopping recommendation",
+            "request is to find the cheapest or best-value option for a product query",
+        ],
+        do_not_use_when=[
+            "the request is to complete checkout or place an order instead of comparing offers",
+        ],
+        permission_class=ToolManualPermissionClass.READ_ONLY,
+        dry_run_supported=True,
+        requires_connected_accounts=[],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Product name, model number, or search phrase."},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line overview of the best available deal."},
+                "offers": {"type": "array", "items": {"type": "object"}, "description": "Ranked retailer offers."},
+            },
+            "required": ["summary", "offers"],
+            "additionalProperties": False,
+        },
+        usage_hints=["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
+        result_hints=["Lead with the best offer and then summarize notable trade-offs."],
+        error_hints=["If no offers are found, ask for a clearer product name or model number."],
+    )
+
+
+def build_client(handler) -> SiglumeClient:
+    return SiglumeClient(
+        api_key="sig_test_key",
+        base_url="https://api.example.test/v1",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def test_python_recorder_replays_committed_shared_cassette() -> None:
+    cassette_path = ROOT / "tests" / "cassettes" / "auto_register_flow.json"
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY) as recorder:
+        with recorder.wrap(build_client(unexpected_handler)) as client:
+            receipt = client.auto_register(build_manifest(), build_tool_manual(), source_code="# shared registration stub")
+            confirmation = client.confirm_registration(receipt.listing_id)
+
+    assert receipt.listing_id == "lst_123"
+    assert confirmation.status == "pending_review"
+    assert confirmation.quality.grade == "B"
+    assert confirmation.trace_id == "trc_confirm"
+
+
+def test_python_recorder_redacts_sensitive_values(tmp_path: Path) -> None:
+    cassette_path = tmp_path / "redacted.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "refresh_token": "pypi-SECRET123",
+                    "wallet_secret": "0x" + ("a" * 64),
+                    "ok": True,
+                }
+            ),
+            headers={"Authorization": "Bearer downstream-secret"},
+        )
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        with httpx.Client(
+            base_url="https://api.example.test",
+            transport=httpx.MockTransport(handler),
+            headers={
+                "Authorization": "Bearer sig_super_secret",
+                "Cookie": "session=ghp-COOKIESECRET",
+                "X-API-Key": "sig_header_secret",
+            },
+        ) as client:
+            response = client.post(
+                "/secrets?api_key=query-secret&access_token=ghp-QUERYSECRET",
+                json={
+                    "api_key": "sig_private",
+                    "nested": {"private_key": "0x" + ("b" * 64)},
+                    "access_token": "ghp-EXAMPLESECRET",
+                },
+            )
+            assert response.status_code == 200
+
+    cassette_text = cassette_path.read_text(encoding="utf-8")
+    assert "sig_super_secret" not in cassette_text
+    assert "sig_private" not in cassette_text
+    assert "sig_header_secret" not in cassette_text
+    assert "query-secret" not in cassette_text
+    assert "ghp-QUERYSECRET" not in cassette_text
+    assert "ghp-COOKIESECRET" not in cassette_text
+    assert "ghp-EXAMPLESECRET" not in cassette_text
+    assert "<REDACTED>" in cassette_text
+    assert "<REDACTED_PRIVKEY>" in cassette_text
+    assert "<REDACTED_TOKEN>" in cassette_text
+    assert "Bearer <REDACTED>" in cassette_text
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY):
+        with httpx.Client(
+            base_url="https://api.example.test",
+            transport=httpx.MockTransport(unexpected_handler),
+            headers={
+                "Authorization": "Bearer sig_super_secret",
+                "Cookie": "session=ghp-COOKIESECRET",
+                "X-API-Key": "sig_header_secret",
+            },
+        ) as client:
+            replayed = client.post(
+                "/secrets?api_key=query-secret&access_token=ghp-QUERYSECRET",
+                json={
+                    "api_key": "sig_private",
+                    "nested": {"private_key": "0x" + ("b" * 64)},
+                    "access_token": "ghp-EXAMPLESECRET",
+                },
+            )
+            assert replayed.status_code == 200
+
+
+def test_python_recorder_ignore_body_fields_allows_replay_drift(tmp_path: Path) -> None:
+    cassette_path = tmp_path / "ignore-fields.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"ok": True, "echo": json.loads(request.content.decode("utf-8"))}))
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD, ignore_body_fields=["request_id", "timestamp"]):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(handler)) as client:
+            recorded = client.post(
+                "/events",
+                json={"query": "headphones", "request_id": "req_record", "timestamp": "2026-04-19T00:00:00Z"},
+            )
+            assert recorded.status_code == 200
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY, ignore_body_fields=["request_id", "timestamp"]):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(unexpected_handler)) as client:
+            replayed = client.post(
+                "/events",
+                json={"query": "headphones", "request_id": "req_replay", "timestamp": "2026-04-19T01:00:00Z"},
+            )
+            assert replayed.json()["data"]["ok"] is True
+
+
+def test_python_recorder_auto_mode_prefers_replay_for_existing_cassette() -> None:
+    cassette_path = ROOT / "tests" / "cassettes" / "auto_register_flow.json"
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Auto mode should replay instead of hitting transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.AUTO) as recorder:
+        with recorder.wrap(build_client(unexpected_handler)) as client:
+            receipt = client.auto_register(build_manifest(), build_tool_manual(), source_code="# shared registration stub")
+
+    assert receipt.listing_id == "lst_123"
+
+
+class HttpxQuoteApp(AppAdapter):
+    def __init__(self, transport: httpx.BaseTransport) -> None:
+        self.transport = transport
+
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="httpx-quote",
+            name="HTTPX Quote",
+            job_to_be_done="Quote a price from an upstream HTTP service.",
+            category=AppCategory.COMMERCE,
+            permission_class=PermissionClass.READ_ONLY,
+            approval_mode=ApprovalMode.AUTO,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="Calls an upstream quote API.",
+            example_prompts=["Quote this item."],
+        )
+
+    async def execute(self, ctx: ExecutionContext):
+        with httpx.Client(
+            base_url="https://api.example.test",
+            transport=self.transport,
+            headers={"Authorization": "Bearer harness-secret"},
+        ) as client:
+            response = client.post(
+                "/quote",
+                json={
+                    "query": str(ctx.input_params.get("query") or "headphones"),
+                    "timestamp": "2026-04-19T00:00:00Z",
+                },
+            )
+        data = response.json()["data"]
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output=data,
+        )
+
+
+def test_app_test_harness_record_and_replay_httpx_calls(tmp_path: Path) -> None:
+    from siglume_api_sdk import AppTestHarness
+
+    cassette_path = tmp_path / "harness.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json=envelope({"summary": f"quoted:{payload['query']}", "provider_status": "ok"}),
+        )
+
+    harness = AppTestHarness(HttpxQuoteApp(httpx.MockTransport(handler)))
+
+    with harness.record(str(cassette_path)) as recorded_harness:
+        recorded = asyncio.run(recorded_harness.dry_run("quote_lookup", input_params={"query": "sony"}))
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    replay_harness = AppTestHarness(HttpxQuoteApp(httpx.MockTransport(unexpected_handler)))
+    with replay_harness.replay(str(cassette_path)) as replayed_harness:
+        replayed = asyncio.run(replayed_harness.dry_run("quote_lookup", input_params={"query": "sony"}))
+
+    assert recorded.output["summary"] == "quoted:sony"
+    assert replayed.output == recorded.output
+
+
+def test_python_recorder_raises_on_request_mismatch(tmp_path: Path) -> None:
+    cassette_path = tmp_path / "mismatch.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"ok": True}))
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(handler)) as client:
+            client.post("/events", json={"query": "camera"})
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(AssertionError, match="Replay request mismatch"):
+                client.post("/events", json={"query": "laptop"})
+
+
+def test_python_recorder_preserves_repeated_response_headers(tmp_path: Path) -> None:
+    cassette_path = tmp_path / "repeat-headers.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=envelope({"ok": True}),
+            headers=[("Set-Cookie", "a=1"), ("Set-Cookie", "b=2")],
+        )
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(handler)) as client:
+            recorded = client.get("/cookies")
+            assert recorded.headers.get_list("set-cookie") == ["a=1", "b=2"]
+
+    cassette = json.loads(cassette_path.read_text(encoding="utf-8"))
+    assert cassette["interactions"][0]["response"]["headers"]["set-cookie"] == ["<REDACTED>", "<REDACTED>"]
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(unexpected_handler)) as client:
+            replayed = client.get("/cookies")
+            assert replayed.headers.get_list("set-cookie") == ["<REDACTED>", "<REDACTED>"]
+
+
+def test_python_recorder_replays_multipart_uploads(tmp_path: Path) -> None:
+    cassette_path = tmp_path / "multipart.json"
+    file_bytes = b"\xff\x00\xfe\x10binary"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"ok": True}))
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(handler)) as client:
+            recorded = client.post(
+                "/upload",
+                data={"note": "hello"},
+                files={"file": ("hello.bin", file_bytes, "application/octet-stream")},
+            )
+            assert recorded.status_code == 200
+
+    cassette_text = cassette_path.read_text(encoding="utf-8")
+    assert '"encoding": "base64"' in cassette_text
+    assert "boundary=<BOUNDARY>" in cassette_text
+
+    def unexpected_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Replay should not hit transport: {request.method} {request.url}")
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(unexpected_handler)) as client:
+            replayed = client.post(
+                "/upload",
+                data={"note": "hello"},
+                files={"file": ("hello.bin", file_bytes, "application/octet-stream")},
+            )
+            assert replayed.json()["data"]["ok"] is True
+
+    with Recorder(cassette_path, mode=RecordMode.REPLAY):
+        with httpx.Client(base_url="https://api.example.test", transport=httpx.MockTransport(unexpected_handler)) as client:
+            with pytest.raises(AssertionError, match="Replay request mismatch"):
+                client.post(
+                    "/upload",
+                    data={"note": "hello"},
+                    files={"file": ("hello.bin", b"\x00\x01different", "application/octet-stream")},
+                )


### PR DESCRIPTION
## Summary
- add a Python and TypeScript recording harness with shared JSON cassette format and RecordMode support
- add AppTestHarness.record(...) / .replay(...) helpers and recorder-aware client wrapping
- commit a shared 	ests/cassettes/auto_register_flow.json fixture and cover record/replay, redaction, duplicate headers/query params, and multipart uploads in both runtimes

## Test plan
- [x] py -3.11 -m ruff check .
- [x] py -3.11 -m pytest -> 108 passed
- [x] py -3.11 scripts/contract_sync.py -> passed
- [x] py -3.11 -m compileall siglume_api_sdk.py siglume_api_sdk examples tests scripts\\contract_sync.py
- [x] 
pm run lint
- [x] 
pm test -> 126 passed, coverage gate green
- [x] 
pm run build
- [x] reviewer agent -> no critical / warning

## Notes
- cassettes normalize multipart boundaries, redact secret-bearing headers/query params/bodies, and preserve repeated header values as arrays
- duration_ms remains wall-clock derived and is the only reviewer info note left