### PR TITLE
feat(buyer): buyer-side SiglumeBuyerClient + LangChain / Claude Agent examples (PR-N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ print(result.tool_manual["summary_for_model"])
 
 Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` before using the helper or the bundled [generate_tool_manual.py](./examples/generate_tool_manual.py) example.
 
+## Using Siglume from LangChain / Claude Agent SDK
+
+The buyer-side SDK is available as `SiglumeBuyerClient` for framework adapters
+that consume marketplace listings instead of publishing them.
+
+- Python bridge example: [examples/buyer_langchain.py](./examples/buyer_langchain.py)
+- TypeScript bridge example: [examples/buyer_claude_agent_sdk.ts](./examples/buyer_claude_agent_sdk.ts)
+- Notes and current platform limitations: [docs/buyer-sdk.md](./docs/buyer-sdk.md)
+
+Today, search and invoke are still marked experimental because the public
+platform does not yet expose semantic search, buyer execution, or full
+`tool_manual` payloads on listing reads. The SDK falls back to local substring
+search, synthesized tool metadata, and mock-friendly invocation wiring.
+
 ## Example templates
 
 `hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, and `payment_quote.py` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
@@ -181,6 +195,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 |---|---|
 | [Getting Started Guide](GETTING_STARTED.md) | Build and publish an API in 15 minutes |
 | [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide) | Write a tool manual that gets your API selected |
+| [Buyer-side SDK](docs/buyer-sdk.md) | Discover and invoke Siglume capabilities from LangChain / Claude-style runtimes |
 | [API Reference](openapi/developer-surface.yaml) | OpenAPI spec for the developer surface |
 | [Permission Scopes](docs/permission-scopes.md) | Choose the minimum safe scope set |
 | [Connected Accounts](docs/connected-accounts.md) | Account linking without exposing credentials |

--- a/docs/buyer-sdk.md
+++ b/docs/buyer-sdk.md
@@ -1,0 +1,77 @@
+# Buyer-side SDK
+
+`SiglumeBuyerClient` is the consumer-side companion to `SiglumeClient`. It is
+meant for agent frameworks that want to discover, subscribe to, and invoke
+Siglume marketplace capabilities.
+
+## Current platform shape
+
+As of 2026-04-19, the public platform exposes:
+
+- `GET /v1/market/capabilities`
+- `GET /v1/market/capabilities/{listing_id}`
+- `POST /v1/market/capabilities/{listing_id}/purchase`
+- `POST /v1/market/access-grants/{grant_id}/bind-agent`
+
+The public platform does **not** currently expose:
+
+- a public semantic search endpoint
+- a public buyer execution endpoint
+- the full `tool_manual` payload on listing reads
+
+Because of those gaps, PR-N ships with explicit experimental fallbacks:
+
+- `search_capabilities()` uses SDK-side substring scoring over `list_capabilities()`
+- `get_listing()` synthesizes a minimal `tool_manual` from listing metadata
+- `invoke()` is gated behind `allow_internal_execute=True` and is intended for mocked or privileged environments until a public buyer execute route exists
+
+## Python
+
+```python
+from siglume_api_sdk.buyer import SiglumeBuyerClient
+
+buyer = SiglumeBuyerClient(
+    api_key="sig_...",
+    default_agent_id="agent_123",
+    allow_internal_execute=True,
+)
+
+results = buyer.search_capabilities(query="convert currency", permission_class="read_only", limit=5)
+listing = buyer.get_listing("currency-converter-v2")
+subscription = buyer.subscribe(capability_key="currency-converter-v2")
+result = buyer.invoke(
+    capability_key="currency-converter-v2",
+    input={"amount_usd": 100, "to": "JPY"},
+)
+```
+
+If the owner must approve the action, `invoke()` returns an `ExecutionResult`
+with `needs_approval=True` and an `approval_hint` payload you can show in your
+framework's approval UX.
+
+## TypeScript
+
+```ts
+import { SiglumeBuyerClient, to_anthropic_tool } from "@siglume/api-sdk";
+
+const buyer = new SiglumeBuyerClient({
+  api_key: process.env.SIGLUME_API_KEY!,
+  default_agent_id: process.env.SIGLUME_AGENT_ID,
+  allow_internal_execute: true,
+});
+
+const listing = await buyer.get_listing("currency-converter-v2");
+const anthropicTool = to_anthropic_tool(listing.tool_manual).schema;
+```
+
+The generated `tool_manual` is intentionally conservative and best suited for
+tool export / framework wiring. It is not a replacement for the seller-authored
+ToolManual used during publishing.
+
+## Examples
+
+- [buyer_langchain.py](../examples/buyer_langchain.py)
+- [buyer_claude_agent_sdk.ts](../examples/buyer_claude_agent_sdk.ts)
+
+Both examples run entirely against mocked transports. They do not call LangChain
+or Claude APIs during tests.

--- a/examples/buyer_claude_agent_sdk.ts
+++ b/examples/buyer_claude_agent_sdk.ts
@@ -1,0 +1,126 @@
+import { SiglumeBuyerClient, to_anthropic_tool } from "../siglume-api-sdk-ts/src/index";
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(String(input));
+}
+
+export function buildMockBuyerClient(): SiglumeBuyerClient {
+  const listing = {
+    id: "lst_currency",
+    capability_key: "currency-converter-v2",
+    name: "Currency Converter",
+    description: "Convert USD amounts to JPY with live exchange rates and return a concise summary.",
+    job_to_be_done: "Convert currency amounts between USD and JPY.",
+    permission_class: "read-only",
+    approval_mode: "auto",
+    dry_run_supported: true,
+    price_model: "free",
+    price_value_minor: 0,
+    currency: "USD",
+    short_description: "Convert currency with live rates.",
+    status: "published",
+    input_schema: {
+      type: "object",
+      properties: {
+        amount_usd: { type: "number", description: "USD amount to convert." },
+        to: { type: "string", description: "Target currency code." },
+      },
+      required: ["amount_usd", "to"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line conversion summary." },
+        amount: { type: "number", description: "Converted amount." },
+        currency: { type: "string", description: "Target currency." },
+      },
+      required: ["summary", "amount", "currency"],
+      additionalProperties: false,
+    },
+  };
+
+  return new SiglumeBuyerClient({
+    api_key: process.env.SIGLUME_API_KEY ?? "sig_mock_key",
+    base_url: "https://api.example.test/v1",
+    default_agent_id: process.env.SIGLUME_AGENT_ID ?? "agent_mock_demo",
+    allow_internal_execute: true,
+    fetch: async (input, init) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v1/market/capabilities") {
+        return new Response(
+          JSON.stringify({
+            data: { items: [listing], next_cursor: null, limit: 20, offset: 0 },
+            meta: { trace_id: "trc_buyer", request_id: "req_buyer" },
+            error: null,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.pathname === "/v1/internal/market/capability/execute") {
+        const payload = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        const args = (payload.arguments ?? {}) as Record<string, unknown>;
+        const amountUsd = Number(args.amount_usd ?? 0);
+        const target = String(args.to ?? "JPY");
+        const converted = Math.round(amountUsd * 15000) / 100;
+        return new Response(
+          JSON.stringify({
+            data: {
+              accepted: true,
+              allowed: true,
+              reason: "accepted",
+              reason_code: null,
+              usage_event: { units_consumed: 1, execution_kind: "action" },
+              result: {
+                summary: `Converted USD ${amountUsd.toFixed(2)} to ${target} ${converted.toFixed(2)}.`,
+                amount: converted,
+                currency: target,
+              },
+              receipt: { execution_kind: "action", currency: target, amount_minor: 0 },
+            },
+            meta: { trace_id: "trc_exec", request_id: "req_exec" },
+            error: null,
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unexpected request: ${String(init?.method ?? "GET")} ${url}`);
+    },
+  });
+}
+
+export async function runMockBuyerClaudeExample(): Promise<string[]> {
+  const buyer = buildMockBuyerClient();
+  const listing = await buyer.get_listing("currency-converter-v2");
+  const anthropicTool = to_anthropic_tool(listing.tool_manual).schema;
+  const toolUse = {
+    name: anthropicTool.name,
+    input: { amount_usd: 100, to: "JPY" },
+  };
+  const result = await buyer.invoke({
+    capability_key: "currency-converter-v2",
+    input: toolUse.input,
+  });
+  return [
+    `tool_name: ${anthropicTool.name}`,
+    `tool_description: ${anthropicTool.description}`,
+    `tool_use_name: ${toolUse.name}`,
+    `result_summary: ${String(result.output?.summary ?? "")}`,
+    `result_currency: ${String(result.output?.currency ?? "")}`,
+  ];
+}
+
+const directTarget = process.argv[1] ? new URL(process.argv[1], "file:///").href : "";
+
+if (import.meta.url === directTarget || (process.argv[1] ?? "").endsWith("buyer_claude_agent_sdk.ts")) {
+  const lines = await runMockBuyerClaudeExample();
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/examples/buyer_langchain.py
+++ b/examples/buyer_langchain.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import SiglumeBuyerClient
+
+try:  # pragma: no cover - optional dependency
+    from langchain_core.tools import StructuredTool
+except ImportError:  # pragma: no cover - optional dependency
+    StructuredTool = None
+
+try:  # pragma: no cover - optional dependency
+    from pydantic import create_model
+except ImportError:  # pragma: no cover - optional dependency
+    create_model = None
+
+
+class CompatTool:
+    def __init__(self, name: str, description: str, args_schema: type[Any] | None, runner: Any) -> None:
+        self.name = name
+        self.description = description
+        self.args_schema = args_schema
+        self._runner = runner
+
+    def invoke(self, payload: dict[str, Any]) -> Any:
+        return self._runner(**payload)
+
+
+def siglume_to_langchain_tool(buyer: SiglumeBuyerClient, capability_key: str) -> Any:
+    listing = buyer.get_listing(capability_key)
+    args_schema = _args_schema_from_json_schema(listing.tool_manual.get("input_schema", {}))
+
+    def _run(**kwargs: Any) -> dict[str, Any]:
+        return buyer.invoke(
+            capability_key=capability_key,
+            input=kwargs,
+        ).output
+
+    if StructuredTool is not None:
+        return StructuredTool.from_function(
+            func=lambda **kwargs: json.dumps(_run(**kwargs), ensure_ascii=False),
+            name=str(listing.tool_manual.get("tool_name") or listing.capability_key),
+            description=str(listing.tool_manual.get("summary_for_model") or listing.name),
+            args_schema=args_schema,
+        )
+    return CompatTool(
+        name=str(listing.tool_manual.get("tool_name") or listing.capability_key),
+        description=str(listing.tool_manual.get("summary_for_model") or listing.name),
+        args_schema=args_schema,
+        runner=_run,
+    )
+
+
+def build_mock_buyer_client() -> SiglumeBuyerClient:
+    listing = {
+        "id": "lst_currency",
+        "capability_key": "currency-converter-v2",
+        "name": "Currency Converter",
+        "description": "Convert USD amounts to JPY with live exchange rates and return a concise summary.",
+        "job_to_be_done": "Convert currency amounts between USD and JPY.",
+        "permission_class": "read-only",
+        "approval_mode": "auto",
+        "dry_run_supported": True,
+        "price_model": "free",
+        "price_value_minor": 0,
+        "currency": "USD",
+        "short_description": "Convert currency with live rates.",
+        "status": "published",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "amount_usd": {"type": "number", "description": "USD amount to convert."},
+                "to": {"type": "string", "description": "Target currency code."},
+            },
+            "required": ["amount_usd", "to"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line conversion summary."},
+                "amount": {"type": "number", "description": "Converted amount."},
+                "currency": {"type": "string", "description": "Target currency."},
+            },
+            "required": ["summary", "amount", "currency"],
+            "additionalProperties": False,
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/market/capabilities":
+            return httpx.Response(
+                200,
+                json={
+                    "data": {"items": [listing], "next_cursor": None, "limit": 20, "offset": 0},
+                    "meta": {"trace_id": "trc_buyer", "request_id": "req_buyer"},
+                    "error": None,
+                },
+            )
+        if request.url.path == "/v1/internal/market/capability/execute":
+            payload = json.loads(request.content.decode("utf-8"))
+            amount_usd = float(payload.get("arguments", {}).get("amount_usd", 0))
+            target_currency = str(payload.get("arguments", {}).get("to", "JPY"))
+            converted = round(amount_usd * 150.0, 2)
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "accepted": True,
+                        "allowed": True,
+                        "reason": "accepted",
+                        "reason_code": None,
+                        "usage_event": {"units_consumed": 1, "execution_kind": "action"},
+                        "result": {
+                            "summary": f"Converted USD {amount_usd:.2f} to {target_currency} {converted:.2f}.",
+                            "amount": converted,
+                            "currency": target_currency,
+                        },
+                        "receipt": {"execution_kind": "action", "currency": target_currency, "amount_minor": 0},
+                    },
+                    "meta": {"trace_id": "trc_exec", "request_id": "req_exec"},
+                    "error": None,
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    return SiglumeBuyerClient(
+        api_key=os.environ.get("SIGLUME_API_KEY", "sig_mock_key"),
+        base_url="https://api.example.test/v1",
+        transport=httpx.MockTransport(handler),
+        default_agent_id=os.environ.get("SIGLUME_AGENT_ID", "agent_mock_demo"),
+        allow_internal_execute=True,
+    )
+
+
+def main() -> None:
+    buyer = build_mock_buyer_client()
+    tool = siglume_to_langchain_tool(buyer, "currency-converter-v2")
+    payload = {"amount_usd": 100, "to": "JPY"}
+    if hasattr(tool, "invoke"):
+        result = tool.invoke(payload)
+    else:  # pragma: no cover - defensive
+        result = tool.func(**payload)
+    if isinstance(result, str):
+        result = json.loads(result)
+    print(f"tool_name: {tool.name}")
+    print(f"description: {tool.description}")
+    print(f"args_schema: {getattr(getattr(tool, 'args_schema', None), '__name__', 'dynamic')}")
+    print(f"result_summary: {result['summary']}")
+    print(f"result_currency: {result['currency']}")
+
+
+def _args_schema_from_json_schema(schema: dict[str, Any]) -> type[Any] | None:
+    if create_model is None:
+        return None
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+    required = {
+        str(item)
+        for item in schema.get("required", [])
+        if isinstance(item, str)
+    }
+    fields: dict[str, tuple[type[Any], Any]] = {}
+    for name, definition in properties.items():
+        if not isinstance(definition, dict):
+            continue
+        fields[name] = (_python_type(definition.get("type")), ... if name in required else None)
+    if not fields:
+        return None
+    return create_model("SiglumeBuyerInput", **fields)
+
+
+def _python_type(json_type: Any) -> type[Any]:
+    normalized = str(json_type or "").strip().lower()
+    if normalized == "integer":
+        return int
+    if normalized == "number":
+        return float
+    if normalized == "boolean":
+        return bool
+    return str
+
+
+if __name__ == "__main__":
+    main()

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -20,3 +20,22 @@ const result = await draft_tool_manual({
 
 console.log(result.quality_report.grade);
 ```
+
+Buyer-side runtime helpers are also included:
+
+```ts
+import { SiglumeBuyerClient, to_anthropic_tool } from "@siglume/api-sdk";
+
+const buyer = new SiglumeBuyerClient({
+  api_key: process.env.SIGLUME_API_KEY ?? "sig_mock_key",
+  default_agent_id: process.env.SIGLUME_AGENT_ID,
+  allow_internal_execute: true,
+});
+
+const listing = await buyer.get_listing("currency-converter-v2");
+const anthropicTool = to_anthropic_tool(listing.tool_manual).schema;
+```
+
+See [`../docs/buyer-sdk.md`](../docs/buyer-sdk.md) and
+[`../examples/buyer_claude_agent_sdk.ts`](../examples/buyer_claude_agent_sdk.ts)
+for the current experimental limitations and the mocked integration example.

--- a/siglume-api-sdk-ts/src/buyer.ts
+++ b/siglume-api-sdk-ts/src/buyer.ts
@@ -1,0 +1,697 @@
+import { DEFAULT_SIGLUME_API_BASE, SiglumeClient, type SiglumeClientOptions } from "./client";
+import { SiglumeAPIError, SiglumeClientError, SiglumeNotFoundError } from "./errors";
+import type {
+  AccessGrantRecord,
+  AppListingRecord,
+  CapabilityBindingRecord,
+  EnvelopeMeta,
+  ExecutionResult,
+  ToolManual,
+} from "./types";
+import { isRecord, parseRetryAfter, sleep, stringOrNull, toJsonable, toRecord } from "./utils";
+
+type FetchLike = typeof fetch;
+
+type RequestOptions = {
+  params?: Record<string, string | number | boolean | undefined | null>;
+  json_body?: Record<string, unknown>;
+};
+
+type RequestMetaTuple = [Record<string, unknown>, EnvelopeMeta];
+type SearchableField = "capability_key" | "name" | "description" | "short_description" | "job_to_be_done" | "category";
+
+const SEARCH_FIELD_WEIGHTS: Array<[SearchableField, number]> = [
+  ["capability_key", 40],
+  ["name", 36],
+  ["description", 30],
+  ["short_description", 24],
+  ["job_to_be_done", 20],
+  ["category", 8],
+];
+const QUERY_TOKEN_RE = /[a-z0-9]+/g;
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const EXPERIMENTAL_EXECUTE_PATH = "/internal/market/capability/execute";
+
+export class SiglumeExperimentalWarning extends Error {
+  name = "SiglumeExperimentalWarning";
+}
+
+export class SiglumeExperimentalError extends SiglumeClientError {}
+
+export interface CapabilityListing extends AppListingRecord {
+  description?: string | null;
+  tool_manual: Record<string, unknown>;
+  score: number;
+  snippet?: string | null;
+  match_fields: string[];
+  experimental: boolean;
+}
+
+export interface Subscription {
+  access_grant_id: string;
+  capability_listing_id: string;
+  capability_key: string;
+  purchase_status: string;
+  grant_status?: string | null;
+  agent_id?: string | null;
+  binding_id?: string | null;
+  binding_status?: string | null;
+  access_grant?: AccessGrantRecord | null;
+  binding?: CapabilityBindingRecord | null;
+  trace_id?: string | null;
+  request_id?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface SiglumeBuyerClientOptions extends SiglumeClientOptions {
+  default_agent_id?: string;
+  allow_internal_execute?: boolean;
+  experimental_execute_path?: string;
+}
+
+export class SiglumeBuyerClient {
+  private readonly client: SiglumeClient;
+  readonly api_key: string;
+  readonly base_url: string;
+  readonly timeout_ms: number;
+  readonly max_retries: number;
+  readonly default_agent_id?: string;
+  readonly allow_internal_execute: boolean;
+  readonly experimental_execute_path: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly warnedFeatures = new Set<string>();
+
+  constructor(options: SiglumeBuyerClientOptions) {
+    this.client = new SiglumeClient(options);
+    this.api_key = options.api_key;
+    this.base_url = (options.base_url ?? DEFAULT_SIGLUME_API_BASE).replace(/\/+$/, "");
+    this.timeout_ms = Math.max(1, options.timeout_ms ?? 15_000);
+    this.max_retries = Math.max(1, Math.trunc(options.max_retries ?? 3));
+    this.fetchImpl = options.fetch ?? fetch;
+    this.default_agent_id = options.default_agent_id ?? stringOrNull(globalThis.process?.env?.SIGLUME_AGENT_ID) ?? undefined;
+    this.allow_internal_execute = Boolean(options.allow_internal_execute ?? false);
+    this.experimental_execute_path = `/${(options.experimental_execute_path ?? EXPERIMENTAL_EXECUTE_PATH).replace(/^\/+/, "")}`;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+
+  async search_capabilities(options: {
+    query: string;
+    permission_class?: string;
+    limit?: number;
+    status?: string;
+  }): Promise<CapabilityListing[]> {
+    const query = String(options.query ?? "").trim();
+    if (!query) {
+      throw new SiglumeClientError("search_capabilities requires a non-empty query.");
+    }
+    this.warnExperimental(
+      "search",
+      "SiglumeBuyerClient.search_capabilities() uses local substring matching because the platform search API is not public yet.",
+    );
+    const permission = normalizePermission(options.permission_class);
+    const limit = Math.max(1, Math.min(Math.trunc(options.limit ?? 10), 100));
+    const listings = await this.listAllCapabilities({ status: options.status ?? "published" });
+    const matches = listings
+      .map((listing) => {
+        if (permission && normalizePermission(listing.permission_class) !== permission) {
+          return null;
+        }
+        const { score, match_fields, snippet } = scoreListing(listing, query);
+        if (score <= 0) {
+          return null;
+        }
+        return createCapabilityListing(listing, { score, match_fields, snippet, experimental: true });
+      })
+      .filter((listing): listing is CapabilityListing => Boolean(listing))
+      .sort((left, right) => {
+        if (right.score !== left.score) {
+          return right.score - left.score;
+        }
+        if (left.name.toLowerCase() !== right.name.toLowerCase()) {
+          return left.name.toLowerCase().localeCompare(right.name.toLowerCase());
+        }
+        return left.capability_key.toLowerCase().localeCompare(right.capability_key.toLowerCase());
+      });
+    return matches.slice(0, limit);
+  }
+
+  async get_listing(capability_key: string): Promise<CapabilityListing> {
+    const lookup = String(capability_key ?? "").trim();
+    if (!lookup) {
+      throw new SiglumeClientError("capability_key is required.");
+    }
+    const listings = await this.listAllCapabilities({ status: "published" });
+    const exact = listings.find((listing) => listing.capability_key.toLowerCase() === lookup.toLowerCase());
+    if (exact) {
+      this.warnExperimental(
+        "tool-manual",
+        "Buyer listings currently synthesize a minimal tool_manual because the public listing surface does not expose the full ToolManual payload yet.",
+      );
+      return createCapabilityListing(exact, { experimental: true });
+    }
+    const byListingId = await this.client.get_listing(lookup);
+    this.warnExperimental(
+      "tool-manual",
+      "Buyer listings currently synthesize a minimal tool_manual because the public listing surface does not expose the full ToolManual payload yet.",
+    );
+    return createCapabilityListing(byListingId, { experimental: true });
+  }
+
+  async subscribe(options: {
+    capability_key: string;
+    agent_id?: string;
+    bind_agent?: boolean;
+    binding_status?: string;
+    buyer_currency?: string;
+    buyer_token?: string;
+  }): Promise<Subscription> {
+    const listing = await this.get_listing(options.capability_key);
+    const payload: Record<string, unknown> = {};
+    if (options.buyer_currency) {
+      payload.buyer_currency = options.buyer_currency;
+    }
+    if (options.buyer_token) {
+      payload.buyer_token = options.buyer_token;
+    }
+    const [data, meta] = await this.request("POST", `/market/capabilities/${listing.listing_id}/purchase`, {
+      json_body: payload,
+    });
+    const accessGrant = parseAccessGrant(toRecord(data.access_grant));
+    if (!accessGrant.access_grant_id) {
+      const purchaseStatus = String(data.purchase_status ?? "unknown");
+      throw new SiglumeExperimentalError(
+        `Purchase completed with status '${purchaseStatus}' but did not return an access grant. Buyer-side subscription flows are still experimental on the public API.`,
+      );
+    }
+    const targetAgentId = resolveAgentId(options.agent_id, this.default_agent_id);
+    const shouldBind = options.bind_agent ?? Boolean(targetAgentId);
+    let binding: CapabilityBindingRecord | null = null;
+    let trace_id = meta.trace_id ?? undefined;
+    let request_id = meta.request_id ?? undefined;
+    if (shouldBind) {
+      if (!targetAgentId) {
+        throw new SiglumeClientError("agent_id is required to bind a purchased access grant.");
+      }
+      const grantBinding = await this.client.bind_agent_to_grant(accessGrant.access_grant_id, {
+        agent_id: targetAgentId,
+        binding_status: options.binding_status ?? "active",
+      });
+      binding = grantBinding.binding;
+      trace_id = grantBinding.trace_id ?? trace_id;
+      request_id = grantBinding.request_id ?? request_id;
+    }
+    return {
+      access_grant_id: accessGrant.access_grant_id,
+      capability_listing_id: accessGrant.capability_listing_id || listing.listing_id,
+      capability_key: listing.capability_key,
+      purchase_status: String(data.purchase_status ?? "created"),
+      grant_status: accessGrant.grant_status ?? null,
+      agent_id: binding?.agent_id ?? targetAgentId ?? null,
+      binding_id: binding?.binding_id ?? null,
+      binding_status: binding?.binding_status ?? null,
+      access_grant: accessGrant,
+      binding,
+      trace_id,
+      request_id,
+      raw: {
+        purchase: { ...data },
+        binding: binding ? { ...binding.raw } : null,
+      },
+    };
+  }
+
+  async invoke(options: {
+    capability_key: string;
+    input: Record<string, unknown>;
+    idempotency_key?: string;
+    dry_run?: boolean;
+    agent_id?: string;
+    task_type?: string;
+    execution_kind?: string;
+    source_type?: string;
+    environment?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<ExecutionResult> {
+    if (!this.allow_internal_execute) {
+      throw new SiglumeExperimentalError(
+        "SiglumeBuyerClient.invoke() requires allow_internal_execute=true because the public buyer execute endpoint is not available yet.",
+      );
+    }
+    this.warnExperimental(
+      "invoke",
+      "SiglumeBuyerClient.invoke() uses an internal execution endpoint until a public buyer invoke API is available.",
+    );
+    const agentId = resolveAgentId(options.agent_id, this.default_agent_id);
+    if (!agentId) {
+      throw new SiglumeClientError("agent_id is required for invoke(); pass it explicitly or set SIGLUME_AGENT_ID.");
+    }
+    const payload: Record<string, unknown> = {
+      agent_id: agentId,
+      capability_key: options.capability_key,
+      task_type: options.task_type ?? "default",
+      arguments: toRecord(options.input),
+      dry_run: Boolean(options.dry_run ?? false),
+      environment: options.environment ?? "live",
+      metadata: toRecord(options.metadata),
+    };
+    if (options.execution_kind) {
+      payload.execution_kind = options.execution_kind;
+    } else if (options.dry_run) {
+      payload.execution_kind = "dry_run";
+    }
+    if (options.idempotency_key) {
+      payload.idempotency_key = options.idempotency_key;
+    }
+    if (options.source_type) {
+      payload.source_type = options.source_type;
+    }
+    const [data] = await this.request("POST", this.experimental_execute_path, { json_body: payload });
+    return buildExecutionResult(data, payload);
+  }
+
+  private async listAllCapabilities(options: { status: string }): Promise<AppListingRecord[]> {
+    const page = await this.client.list_capabilities({ status: options.status, limit: 100 });
+    return typeof page.all_items === "function" ? await page.all_items() : page.items;
+  }
+
+  private warnExperimental(key: string, message: string): void {
+    if (this.warnedFeatures.has(key)) {
+      return;
+    }
+    this.warnedFeatures.add(key);
+    if (typeof process !== "undefined" && typeof process.emitWarning === "function") {
+      process.emitWarning(message, { type: "SiglumeExperimentalWarning" });
+      return;
+    }
+    console.warn(message);
+  }
+
+  private async request(method: string, path: string, options: RequestOptions = {}): Promise<RequestMetaTuple> {
+    const url = buildUrl(this.base_url, path, options.params);
+    const headers = new Headers({
+      Authorization: `Bearer ${this.api_key}`,
+      Accept: "application/json",
+      "User-Agent": "siglume-api-sdk-ts/0.4.0-dev.0",
+    });
+    let body: string | undefined;
+    if (options.json_body) {
+      headers.set("Content-Type", "application/json");
+      body = JSON.stringify(toJsonable(options.json_body));
+    }
+
+    for (let attempt = 0; attempt < this.max_retries; attempt += 1) {
+      const controller = new AbortController();
+      const timeoutHandle = setTimeout(() => controller.abort(), this.timeout_ms);
+      try {
+        const response = await this.fetchImpl(url, {
+          method,
+          headers,
+          body,
+          signal: controller.signal,
+        });
+        clearTimeout(timeoutHandle);
+        const text = response.status === 204 ? "" : await response.text();
+        const parsed = safeParseJson(text);
+        const envelope = isRecord(parsed) ? parsed : {};
+        const data = isRecord(envelope.data) ? envelope.data : isRecord(parsed) ? parsed : {};
+        const meta: EnvelopeMeta = isRecord(envelope.meta)
+          ? {
+              request_id: stringOrNull(envelope.meta.request_id),
+              trace_id: stringOrNull(envelope.meta.trace_id),
+            }
+          : {
+              request_id: stringOrNull(response.headers.get("x-request-id")),
+              trace_id: stringOrNull(response.headers.get("x-trace-id")),
+            };
+        if (response.ok) {
+          return [data, meta];
+        }
+        if (RETRYABLE_STATUS_CODES.has(response.status) && attempt + 1 < this.max_retries) {
+          await sleep(parseRetryAfter(response.headers.get("Retry-After")) ?? (250 * (2 ** attempt)));
+          continue;
+        }
+        const errorBlock = isRecord(envelope.error) ? envelope.error : {};
+        const message = String(
+          errorBlock.message ??
+            (isRecord(parsed) ? parsed.message : undefined) ??
+            response.statusText ??
+            "Siglume API request failed.",
+        );
+        const errorCode = stringOrNull(errorBlock.code) ?? undefined;
+        if (response.status === 404) {
+          throw new SiglumeNotFoundError(message);
+        }
+        throw new SiglumeAPIError(message, {
+          status_code: response.status,
+          error_code: errorCode,
+          trace_id: meta.trace_id ?? undefined,
+          request_id: meta.request_id ?? undefined,
+          details: toRecord(errorBlock.details),
+          response_body: parsed,
+        });
+      } catch (error) {
+        clearTimeout(timeoutHandle);
+        if (error instanceof SiglumeAPIError || error instanceof SiglumeNotFoundError) {
+          throw error;
+        }
+        if (attempt + 1 < this.max_retries) {
+          await sleep(250 * (2 ** attempt));
+          continue;
+        }
+        if (error instanceof Error) {
+          throw new SiglumeClientError(error.message);
+        }
+        throw new SiglumeClientError("Siglume request failed.");
+      }
+    }
+    throw new SiglumeClientError("Siglume request failed after retries.");
+  }
+}
+
+function createCapabilityListing(
+  listing: AppListingRecord,
+  options: {
+    score?: number;
+    snippet?: string | null;
+    match_fields?: string[];
+    experimental?: boolean;
+  } = {},
+): CapabilityListing {
+  return {
+    ...listing,
+    description: stringOrNull(listing.raw.description),
+    tool_manual: buildListingToolManual(listing),
+    score: options.score ?? 0,
+    snippet: options.snippet ?? null,
+    match_fields: options.match_fields ?? [],
+    experimental: options.experimental ?? false,
+    raw: { ...listing.raw },
+  };
+}
+
+function normalizePermission(value: string | undefined | null): string | null {
+  const text = String(value ?? "").trim().toLowerCase();
+  return text ? text.replaceAll("_", "-") : null;
+}
+
+function toolManualPermission(value: string | undefined | null): "read_only" | "action" | "payment" {
+  const normalized = normalizePermission(value);
+  if (normalized === "payment") {
+    return "payment";
+  }
+  if (normalized === "action") {
+    return "action";
+  }
+  return "read_only";
+}
+
+function resolveAgentId(explicit: string | undefined, fallback: string | undefined): string | undefined {
+  const candidate = stringOrNull(explicit) ?? stringOrNull(fallback);
+  return candidate ?? undefined;
+}
+
+function scoreListing(listing: AppListingRecord, query: string): {
+  score: number;
+  match_fields: string[];
+  snippet: string | null;
+} {
+  const normalizedQuery = query.toLowerCase().trim();
+  const tokens = normalizedQuery.match(QUERY_TOKEN_RE) ?? [];
+  let score = 0;
+  let snippet: string | null = null;
+  const match_fields: string[] = [];
+  for (const [fieldName, weight] of SEARCH_FIELD_WEIGHTS) {
+    const text = listingFieldText(listing, fieldName);
+    if (!text) {
+      continue;
+    }
+    const lowered = text.toLowerCase();
+    let matched = false;
+    if (normalizedQuery && lowered.includes(normalizedQuery)) {
+      score += weight * 3;
+      matched = true;
+      if (!snippet) {
+        snippet = buildSnippet(text, normalizedQuery);
+      }
+    } else {
+      const tokenHits = tokens.filter((token) => lowered.includes(token)).length;
+      if (tokenHits > 0) {
+        score += weight * tokenHits;
+        matched = true;
+        if (!snippet) {
+          snippet = buildSnippet(text, tokens[0] ?? normalizedQuery);
+        }
+      }
+    }
+    if (matched) {
+      match_fields.push(fieldName);
+    }
+  }
+  return { score, match_fields, snippet };
+}
+
+function listingFieldText(listing: AppListingRecord, fieldName: SearchableField): string {
+  if (fieldName === "description") {
+    return String(listing.raw.description ?? "").trim();
+  }
+  return String(listing[fieldName] ?? "").trim();
+}
+
+function buildSnippet(text: string, term: string): string {
+  const lowered = text.toLowerCase();
+  const index = lowered.indexOf(term.toLowerCase());
+  if (index < 0) {
+    return text.slice(0, 96).trim();
+  }
+  const start = Math.max(index - 24, 0);
+  const end = Math.min(index + term.length + 56, text.length);
+  let excerpt = text.slice(start, end).trim();
+  if (start > 0) {
+    excerpt = `...${excerpt}`;
+  }
+  if (end < text.length) {
+    excerpt = `${excerpt}...`;
+  }
+  return excerpt;
+}
+
+function buildListingToolManual(listing: AppListingRecord): Record<string, unknown> {
+  const raw = { ...listing.raw };
+  if (isRecord(raw.tool_manual)) {
+    return { ...raw.tool_manual };
+  }
+  const description =
+    stringOrNull(raw.description) ??
+    listing.short_description ??
+    listing.job_to_be_done ??
+    listing.name;
+  const permission_class = toolManualPermission(listing.permission_class);
+  const input_schema = isRecord(raw.input_schema)
+    ? { ...raw.input_schema }
+    : {
+        type: "object",
+        properties: {},
+        additionalProperties: true,
+      };
+  const output_schema = isRecord(raw.output_schema)
+    ? { ...raw.output_schema }
+    : {
+        type: "object",
+        properties: {
+          summary: {
+            type: "string",
+            description: "Summary of what the capability returned.",
+          },
+        },
+        required: ["summary"],
+        additionalProperties: true,
+      };
+  const toolManual: Record<string, unknown> = {
+    tool_name: listing.capability_key.replaceAll("-", "_") || "siglume_capability",
+    job_to_be_done: listing.job_to_be_done ?? description,
+    summary_for_model: boundedSummary(listing, description ?? listing.name),
+    trigger_conditions: [
+      description ? `Use when the owner asks for ${description.toLowerCase()}.` : `Use when the owner requests ${listing.capability_key}.`,
+      `Use when the task explicitly matches capability key '${listing.capability_key}'.`,
+      `Use when the workflow needs the output of ${listing.name}.`,
+    ],
+    do_not_use_when: [
+      "Do not use when the request needs a different capability or lacks the required input context.",
+    ],
+    permission_class,
+    dry_run_supported: listing.dry_run_supported,
+    requires_connected_accounts: Array.isArray(raw.required_connected_accounts)
+      ? raw.required_connected_accounts.filter((item): item is string => typeof item === "string")
+      : [],
+    input_schema,
+    output_schema,
+    usage_hints: [
+      listing.short_description,
+      listing.docs_url ? `Read docs at ${listing.docs_url} before relying on provider-specific behavior.` : null,
+    ].filter((item): item is string => Boolean(item)),
+    result_hints: [
+      String(raw.result_summary ?? "Return the provider result as structured JSON with a concise summary."),
+    ],
+    error_hints: [
+      "If the invocation is denied or requires approval, surface the platform reason to the owner.",
+    ],
+  };
+  if ((toolManual.usage_hints as string[]).length === 0) {
+    toolManual.usage_hints = [`Invoke ${listing.capability_key} with the fields described in its input schema.`];
+  }
+  if (permission_class === "action" || permission_class === "payment") {
+    toolManual.approval_summary_template = `Review ${listing.name} before approving the external side effect.`;
+    toolManual.preview_schema = {
+      type: "object",
+      properties: {
+        summary: {
+          type: "string",
+          description: "Preview of the action that would be executed after approval.",
+        },
+      },
+      required: ["summary"],
+      additionalProperties: true,
+    };
+    toolManual.idempotency_support = true;
+    toolManual.side_effect_summary = String(
+      raw.receipt_summary ??
+        raw.result_summary ??
+        `${listing.name} may perform an external side effect after approval.`,
+    );
+  }
+  if (permission_class === "payment") {
+    toolManual.quote_schema = {
+      type: "object",
+      properties: {
+        amount_minor: { type: "integer", description: "Quoted amount in minor units." },
+        currency: { type: "string", description: "Currency code for the quoted amount." },
+      },
+      required: ["amount_minor", "currency"],
+      additionalProperties: true,
+    };
+    toolManual.currency = listing.currency || "USD";
+    toolManual.settlement_mode = String(raw.settlement_mode ?? "stripe_checkout");
+    toolManual.refund_or_cancellation_note = String(
+      raw.refund_or_cancellation_note ??
+        "Refunds and cancellations follow the seller policy shown on the listing.",
+    );
+    toolManual.jurisdiction = String(raw.jurisdiction ?? "US");
+  }
+  return toolManual;
+}
+
+function boundedSummary(listing: AppListingRecord, description: string): string {
+  const summary = description.replace(/\s+/g, " ").trim();
+  if (summary.length >= 10) {
+    return summary.slice(0, 300);
+  }
+  return `${listing.name} capability for ${listing.capability_key}.`.slice(0, 300);
+}
+
+function parseAccessGrant(data: Record<string, unknown>): AccessGrantRecord {
+  return {
+    access_grant_id: String(data.access_grant_id ?? data.id ?? ""),
+    capability_listing_id: String(data.capability_listing_id ?? ""),
+    grant_status: String(data.grant_status ?? ""),
+    billing_model: stringOrNull(data.billing_model),
+    agent_id: stringOrNull(data.agent_id),
+    starts_at: stringOrNull(data.starts_at),
+    ends_at: stringOrNull(data.ends_at),
+    bindings: Array.isArray(data.bindings)
+      ? data.bindings.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => ({ ...item }))
+      : [],
+    metadata: toRecord(data.metadata),
+    raw: { ...data },
+  };
+}
+
+function buildExecutionResult(data: Record<string, unknown>, payload: Record<string, unknown>): ExecutionResult {
+  const accepted = Boolean(data.accepted);
+  const reason = String(data.reason ?? "");
+  const reason_code = stringOrNull(data.reason_code) ?? undefined;
+  const usage_event = toRecord(data.usage_event);
+  const receipt = toRecord(data.receipt);
+  const execution_kind = String(receipt.execution_kind ?? payload.execution_kind ?? "action") as ExecutionResult["execution_kind"];
+  const amount_minor = Number(receipt.amount_minor ?? usage_event.amount_minor ?? 0);
+  const currency = String(receipt.currency ?? usage_event.currency ?? "USD");
+  const units_consumed = Number(usage_event.units_consumed ?? 1);
+  if (accepted) {
+    return {
+      success: true,
+      output: toRecord(data.result),
+      execution_kind,
+      units_consumed,
+      amount_minor,
+      currency,
+      provider_status: "ok",
+      fallback_applied: Boolean(receipt.fallback_applied ?? false),
+      receipt_summary: receipt,
+    };
+  }
+  const approval_request = toRecord(data.approval_request);
+  const approval_explanation = toRecord(data.approval_explanation);
+  const needs_approval = reason_code === "APPROVAL_REQUIRED" || Object.keys(approval_request).length > 0;
+  const approvalPermission: "action" | "payment" = execution_kind === "payment" ? "payment" : "action";
+  const approval_hint = needs_approval
+    ? {
+        action_summary: String(
+          approval_explanation.title ??
+            approval_explanation.summary ??
+            reason ??
+            "Owner approval required",
+        ),
+        permission_class: approvalPermission,
+        estimated_amount_minor: amount_minor || undefined,
+        currency: receipt.currency ? currency : undefined,
+        side_effects: Array.isArray(approval_explanation.side_effects)
+          ? approval_explanation.side_effects.filter((item): item is string => typeof item === "string")
+          : [],
+        preview: toRecord(approval_explanation.preview),
+        reversible: false,
+      }
+    : undefined;
+  return {
+    success: false,
+    output: {
+      reason_code,
+      approval_request,
+      approval_explanation,
+    },
+    execution_kind,
+    units_consumed,
+    amount_minor,
+    currency,
+    provider_status: needs_approval || reason_code ? "denied" : "error",
+    error_message: reason || reason_code,
+    needs_approval,
+    approval_prompt: needs_approval ? (reason || "Owner approval is required.") : undefined,
+    fallback_applied: Boolean(receipt.fallback_applied ?? false),
+    receipt_summary: receipt,
+    approval_hint,
+  };
+}
+
+function buildUrl(baseUrl: string, path: string, params?: RequestOptions["params"]): string {
+  const url = new URL(`${baseUrl}${path}`);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+function safeParseJson(text: string): unknown {
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}

--- a/siglume-api-sdk-ts/src/index.ts
+++ b/siglume-api-sdk-ts/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./buyer";
 export * from "./client";
 export * from "./diff";
 export * from "./errors";

--- a/siglume-api-sdk-ts/test/buyer.test.ts
+++ b/siglume-api-sdk-ts/test/buyer.test.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SiglumeBuyerClient,
+  SiglumeExperimentalError,
+} from "../src/index";
+import { runMockBuyerClaudeExample } from "../../examples/buyer_claude_agent_sdk";
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+  if (input instanceof URL) {
+    return input;
+  }
+  return new URL(String(input));
+}
+
+function loadFixtureListings(): Array<Record<string, unknown>> {
+  const fixturePath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "tests", "fixtures", "buyer_search_cases.json");
+  return JSON.parse(readFileSync(fixturePath, "utf8")).listings as Array<Record<string, unknown>>;
+}
+
+function envelope(data: Record<string, unknown>, meta: Record<string, unknown> = { request_id: "req_buyer", trace_id: "trc_buyer" }) {
+  return { data, meta, error: null };
+}
+
+function buildClient(
+  fetchImpl: typeof fetch,
+  options: Partial<ConstructorParameters<typeof SiglumeBuyerClient>[0]> = {},
+): SiglumeBuyerClient {
+  return new SiglumeBuyerClient({
+    api_key: "sig_test_key",
+    base_url: "https://api.example.test/v1",
+    fetch: fetchImpl,
+    ...options,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SiglumeBuyerClient", () => {
+  it("searches with local substring scoring and returns the strongest match first", async () => {
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => process);
+    const client = buildClient(async (input) => {
+      const url = requestUrl(input);
+      expect(url.pathname).toBe("/v1/market/capabilities");
+      return new Response(JSON.stringify(envelope({ items: loadFixtureListings(), next_cursor: null, limit: 20, offset: 0 })), {
+        status: 200,
+      });
+    });
+
+    const results = await client.search_capabilities({ query: "convert currency", limit: 3 });
+
+    expect(results[0]?.capability_key).toBe("currency-converter-v2");
+    expect(results[0]!.tool_manual.tool_name).toBe("currency_converter_v2");
+    expect(emitWarning).toHaveBeenCalledOnce();
+  });
+
+  it("filters by permission class and limit", async () => {
+    const client = buildClient(async () => new Response(JSON.stringify(envelope({ items: loadFixtureListings(), next_cursor: null, limit: 20, offset: 0 })), {
+      status: 200,
+    }));
+
+    const results = await client.search_capabilities({ query: "email", permission_class: "action", limit: 1 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.capability_key).toBe("invoice-emailer");
+  });
+
+  it("resolves a capability key and synthesizes a minimal tool manual", async () => {
+    const client = buildClient(async () => new Response(JSON.stringify(envelope({ items: loadFixtureListings(), next_cursor: null, limit: 20, offset: 0 })), {
+      status: 200,
+    }));
+
+    const listing = await client.get_listing("currency-converter-v2");
+
+    expect(listing.listing_id).toBe("lst_currency");
+    expect(listing.description).toContain("live exchange rates");
+    expect((listing.tool_manual.input_schema as Record<string, unknown>).required).toEqual(["amount_usd", "to"]);
+    expect(listing.experimental).toBe(true);
+  });
+
+  it("subscribes without binding when bind_agent is false", async () => {
+    const client = buildClient(async (input) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v1/market/capabilities") {
+        return new Response(JSON.stringify(envelope({ items: loadFixtureListings(), next_cursor: null, limit: 20, offset: 0 })), {
+          status: 200,
+        });
+      }
+      if (url.pathname === "/v1/market/capabilities/lst_currency/purchase") {
+        return new Response(JSON.stringify(envelope({
+          purchase_status: "created",
+          access_grant: {
+            id: "grant_123",
+            capability_listing_id: "lst_currency",
+            grant_status: "active",
+          },
+        }, { request_id: "req_purchase", trace_id: "trc_purchase" })), {
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const subscription = await client.subscribe({ capability_key: "currency-converter-v2", bind_agent: false });
+
+    expect(subscription.access_grant_id).toBe("grant_123");
+    expect(subscription.binding_id).toBeNull();
+    expect(subscription.trace_id).toBe("trc_purchase");
+  });
+
+  it("binds a purchased grant when a default agent id is configured", async () => {
+    const client = buildClient(async (input, init) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v1/market/capabilities") {
+        return new Response(JSON.stringify(envelope({ items: loadFixtureListings(), next_cursor: null, limit: 20, offset: 0 })), {
+          status: 200,
+        });
+      }
+      if (url.pathname === "/v1/market/capabilities/lst_currency/purchase") {
+        return new Response(JSON.stringify(envelope({
+          purchase_status: "created",
+          access_grant: {
+            id: "grant_123",
+            capability_listing_id: "lst_currency",
+            grant_status: "active",
+          },
+        })), {
+          status: 200,
+        });
+      }
+      if (url.pathname === "/v1/market/access-grants/grant_123/bind-agent") {
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        expect(body.agent_id).toBe("agent_demo");
+        return new Response(JSON.stringify(envelope({
+          binding: {
+            id: "bind_123",
+            access_grant_id: "grant_123",
+            agent_id: "agent_demo",
+            binding_status: "active",
+          },
+          access_grant: {
+            id: "grant_123",
+            capability_listing_id: "lst_currency",
+            grant_status: "active",
+          },
+        }, { request_id: "req_bind", trace_id: "trc_bind" })), {
+          status: 200,
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }, { default_agent_id: "agent_demo" });
+
+    const subscription = await client.subscribe({ capability_key: "currency-converter-v2" });
+
+    expect(subscription.binding_id).toBe("bind_123");
+    expect(subscription.agent_id).toBe("agent_demo");
+    expect(subscription.trace_id).toBe("trc_bind");
+  });
+
+  it("maps accepted invoke responses into ExecutionResult", async () => {
+    const client = buildClient(async (input, init) => {
+      const url = requestUrl(input);
+      if (url.pathname !== "/v1/internal/market/capability/execute") {
+        throw new Error(`Unexpected request: ${url}`);
+      }
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+      expect((body.arguments as Record<string, unknown>).amount_usd).toBe(100);
+      return new Response(JSON.stringify(envelope({
+        accepted: true,
+        allowed: true,
+        reason: "accepted",
+        reason_code: null,
+        usage_event: { units_consumed: 1, execution_kind: "action" },
+        result: {
+          summary: "Converted USD 100.00 to JPY 15000.00.",
+          amount: 15000,
+          currency: "JPY",
+        },
+        receipt: { execution_kind: "action", currency: "JPY", amount_minor: 0 },
+      }, { request_id: "req_exec", trace_id: "trc_exec" })), {
+        status: 200,
+      });
+    }, { default_agent_id: "agent_demo", allow_internal_execute: true });
+
+    const result = await client.invoke({
+      capability_key: "currency-converter-v2",
+      input: { amount_usd: 100, to: "JPY" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.currency).toBe("JPY");
+    expect(result.execution_kind).toBe("action");
+  });
+
+  it("maps approval-required invoke responses into approval hints", async () => {
+    const client = buildClient(async () => new Response(JSON.stringify(envelope({
+      accepted: false,
+      allowed: false,
+      reason: "owner approval is required before execution",
+      reason_code: "APPROVAL_REQUIRED",
+      approval_request: { id: "apr_123" },
+      approval_explanation: {
+        title: "Approve invoice email",
+        preview: { summary: "Send invoice INV-1001 to finance@example.com" },
+        side_effects: ["email delivery to finance@example.com"],
+      },
+      usage_event: { units_consumed: 1, execution_kind: "action" },
+      receipt: { execution_kind: "action", currency: "USD", amount_minor: 0 },
+    })), {
+      status: 200,
+    }), { default_agent_id: "agent_demo", allow_internal_execute: true });
+
+    const result = await client.invoke({
+      capability_key: "invoice-emailer",
+      input: { invoice_id: "INV-1001" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.needs_approval).toBe(true);
+    expect(result.approval_hint?.action_summary).toBe("Approve invoice email");
+  });
+
+  it("does not invent approval currency when the receipt omits it", async () => {
+    const client = buildClient(async () => new Response(JSON.stringify(envelope({
+      accepted: false,
+      allowed: false,
+      reason: "owner approval is required before execution",
+      reason_code: "APPROVAL_REQUIRED",
+      approval_request: { id: "apr_124" },
+      approval_explanation: { title: "Approve invoice email" },
+      usage_event: { units_consumed: 1, execution_kind: "payment" },
+      receipt: { execution_kind: "payment", amount_minor: 9900 },
+    })), {
+      status: 200,
+    }), { default_agent_id: "agent_demo", allow_internal_execute: true });
+
+    const result = await client.invoke({
+      capability_key: "invoice-emailer",
+      input: { invoice_id: "INV-1002" },
+    });
+
+    expect(result.needs_approval).toBe(true);
+    expect(result.approval_hint?.currency).toBeUndefined();
+  });
+
+  it("requires an explicit opt-in for internal execute and keeps the Claude example runnable", async () => {
+    const client = buildClient(async () => new Response(JSON.stringify(envelope({})), { status: 200 }), {
+      default_agent_id: "agent_demo",
+    });
+
+    await expect(
+      client.invoke({
+        capability_key: "currency-converter-v2",
+        input: { amount_usd: 100 },
+      }),
+    ).rejects.toBeInstanceOf(SiglumeExperimentalError);
+
+    const lines = await runMockBuyerClaudeExample();
+    expect(lines[0]).toBe("tool_name: currency_converter_v2");
+    expect(lines.at(-1)).toBe("result_currency: JPY");
+  });
+});

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -76,6 +76,13 @@ from .client import (  # noqa: E402, F401
     SupportCaseRecord,
     UsageEventRecord,
 )
+from .buyer import (  # noqa: E402, F401
+    CapabilityListing,
+    SiglumeBuyerClient,
+    SiglumeExperimentalError,
+    SiglumeExperimentalWarning,
+    Subscription,
+)
 from .diff import (  # noqa: E402, F401
     BreakingChange,
     Change,
@@ -113,6 +120,7 @@ __all__ = sorted(
             "AppListingRecord",
             "AutoRegistrationReceipt",
             "CapabilityBindingRecord",
+            "CapabilityListing",
             "Change",
             "ChangeLevel",
             "ConnectedAccountRecord",
@@ -127,9 +135,13 @@ __all__ = sorted(
             "SandboxSession",
             "SiglumeAPIError",
             "SiglumeAssistError",
+            "SiglumeBuyerClient",
             "SiglumeClient",
             "SiglumeClientError",
+            "SiglumeExperimentalError",
+            "SiglumeExperimentalWarning",
             "SiglumeNotFoundError",
+            "Subscription",
             "SupportCaseRecord",
             "ToolSchemaExport",
             "UsageEventRecord",

--- a/siglume_api_sdk/buyer.py
+++ b/siglume_api_sdk/buyer.py
@@ -1,0 +1,621 @@
+"""Experimental buyer-side helpers for consuming Siglume marketplace listings."""
+from __future__ import annotations
+
+import os
+import re
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import httpx
+
+from .client import (
+    DEFAULT_SIGLUME_API_BASE,
+    AccessGrantRecord,
+    AppListingRecord,
+    CapabilityBindingRecord,
+    GrantBindingResult,
+    SiglumeClient,
+    SiglumeClientError,
+    SiglumeNotFoundError,
+    _parse_access_grant,
+    _string_or_none,
+    _to_dict,
+)
+
+
+_QUERY_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_EXPERIMENTAL_EXECUTE_PATH = "/internal/market/capability/execute"
+_SEARCH_FIELD_WEIGHTS = (
+    ("capability_key", 40),
+    ("name", 36),
+    ("description", 30),
+    ("short_description", 24),
+    ("job_to_be_done", 20),
+    ("category", 8),
+)
+
+
+class SiglumeExperimentalWarning(UserWarning):
+    """Warns when the SDK falls back to a platform-gap workaround."""
+
+
+class SiglumeExperimentalError(SiglumeClientError):
+    """Raised when an experimental buyer flow cannot run on the public API yet."""
+
+
+@dataclass
+class CapabilityListing:
+    listing_id: str
+    capability_key: str
+    name: str
+    status: str
+    description: str | None = None
+    category: str | None = None
+    job_to_be_done: str | None = None
+    permission_class: str | None = None
+    approval_mode: str | None = None
+    dry_run_supported: bool = False
+    price_model: str | None = None
+    price_value_minor: int = 0
+    currency: str = "USD"
+    short_description: str | None = None
+    docs_url: str | None = None
+    support_contact: str | None = None
+    review_status: str | None = None
+    review_note: str | None = None
+    submission_blockers: list[str] = field(default_factory=list)
+    created_at: str | None = None
+    updated_at: str | None = None
+    tool_manual: dict[str, Any] = field(default_factory=dict)
+    score: float = 0.0
+    snippet: str | None = None
+    match_fields: list[str] = field(default_factory=list)
+    experimental: bool = False
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_app_listing(
+        cls,
+        listing: AppListingRecord,
+        *,
+        score: float = 0.0,
+        snippet: str | None = None,
+        match_fields: list[str] | None = None,
+        experimental: bool = False,
+    ) -> "CapabilityListing":
+        raw = dict(listing.raw)
+        return cls(
+            listing_id=listing.listing_id,
+            capability_key=listing.capability_key,
+            name=listing.name,
+            status=listing.status,
+            description=_string_or_none(raw.get("description")),
+            category=listing.category,
+            job_to_be_done=listing.job_to_be_done,
+            permission_class=listing.permission_class,
+            approval_mode=listing.approval_mode,
+            dry_run_supported=listing.dry_run_supported,
+            price_model=listing.price_model,
+            price_value_minor=listing.price_value_minor,
+            currency=listing.currency,
+            short_description=listing.short_description,
+            docs_url=listing.docs_url,
+            support_contact=listing.support_contact,
+            review_status=listing.review_status,
+            review_note=listing.review_note,
+            submission_blockers=list(listing.submission_blockers),
+            created_at=listing.created_at,
+            updated_at=listing.updated_at,
+            tool_manual=_build_listing_tool_manual(listing),
+            score=float(score),
+            snippet=snippet,
+            match_fields=list(match_fields or []),
+            experimental=experimental,
+            raw=raw,
+        )
+
+
+@dataclass
+class Subscription:
+    access_grant_id: str
+    capability_listing_id: str
+    capability_key: str
+    purchase_status: str
+    grant_status: str | None = None
+    agent_id: str | None = None
+    binding_id: str | None = None
+    binding_status: str | None = None
+    access_grant: AccessGrantRecord | None = None
+    binding: CapabilityBindingRecord | None = None
+    trace_id: str | None = None
+    request_id: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+class SiglumeBuyerClient:
+    """Experimental buyer-side SDK.
+
+    Search is implemented client-side because the platform does not expose a
+    public capability search endpoint yet. Invocation is also experimental: the
+    public buyer execute route is not available, so `invoke()` can only run when
+    `allow_internal_execute=True` is explicitly enabled for mocked or privileged
+    environments.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str | None = None,
+        timeout: float = 15.0,
+        max_retries: int = 3,
+        transport: httpx.BaseTransport | None = None,
+        default_agent_id: str | None = None,
+        allow_internal_execute: bool = False,
+        experimental_execute_path: str = _EXPERIMENTAL_EXECUTE_PATH,
+    ) -> None:
+        self._client = SiglumeClient(
+            api_key=api_key,
+            base_url=base_url or os.environ.get("SIGLUME_API_BASE") or DEFAULT_SIGLUME_API_BASE,
+            timeout=timeout,
+            max_retries=max_retries,
+            transport=transport,
+        )
+        self.default_agent_id = default_agent_id or os.environ.get("SIGLUME_AGENT_ID")
+        self.allow_internal_execute = bool(allow_internal_execute)
+        self.experimental_execute_path = "/" + experimental_execute_path.strip("/")
+        self._warned_features: set[str] = set()
+
+    def __enter__(self) -> "SiglumeBuyerClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def search_capabilities(
+        self,
+        *,
+        query: str,
+        permission_class: str | None = None,
+        limit: int = 10,
+        status: str = "published",
+    ) -> list[CapabilityListing]:
+        query_text = str(query or "").strip()
+        if not query_text:
+            raise SiglumeClientError("search_capabilities requires a non-empty query.")
+        self._warn_experimental(
+            "search",
+            "SiglumeBuyerClient.search_capabilities() uses local substring matching because the platform search API is not public yet.",
+        )
+        normalized_permission = _normalize_permission(permission_class)
+        matches: list[tuple[int, CapabilityListing]] = []
+        for listing in self._list_all_capabilities(status=status):
+            listing_permission = _normalize_permission(listing.permission_class)
+            if normalized_permission and listing_permission != normalized_permission:
+                continue
+            score, match_fields, snippet = _score_listing(listing, query_text)
+            if score <= 0:
+                continue
+            matches.append(
+                (
+                    -score,
+                    CapabilityListing.from_app_listing(
+                        listing,
+                        score=score,
+                        snippet=snippet,
+                        match_fields=match_fields,
+                        experimental=True,
+                    ),
+                )
+            )
+        matches.sort(key=lambda item: (item[0], item[1].name.lower(), item[1].capability_key.lower()))
+        return [item[1] for item in matches[: max(1, min(int(limit), 100))]]
+
+    def get_listing(self, capability_key: str) -> CapabilityListing:
+        lookup = str(capability_key or "").strip()
+        if not lookup:
+            raise SiglumeClientError("capability_key is required.")
+        lowered = lookup.lower()
+        for listing in self._list_all_capabilities(status="published"):
+            if listing.capability_key.lower() == lowered:
+                self._warn_experimental(
+                    "tool-manual",
+                    "Buyer listings currently synthesize a minimal tool_manual because the public listing surface does not expose the full ToolManual payload yet.",
+                )
+                return CapabilityListing.from_app_listing(listing, experimental=True)
+        try:
+            listing = self._client.get_listing(lookup)
+        except SiglumeNotFoundError as exc:
+            raise SiglumeNotFoundError(f"Capability listing not found: {lookup}") from exc
+        self._warn_experimental(
+            "tool-manual",
+            "Buyer listings currently synthesize a minimal tool_manual because the public listing surface does not expose the full ToolManual payload yet.",
+        )
+        return CapabilityListing.from_app_listing(listing, experimental=True)
+
+    def subscribe(
+        self,
+        *,
+        capability_key: str,
+        agent_id: str | None = None,
+        bind_agent: bool | None = None,
+        binding_status: str = "active",
+        buyer_currency: str | None = None,
+        buyer_token: str | None = None,
+    ) -> Subscription:
+        listing = self.get_listing(capability_key)
+        payload: dict[str, Any] = {}
+        if buyer_currency:
+            payload["buyer_currency"] = buyer_currency
+        if buyer_token:
+            payload["buyer_token"] = buyer_token
+        data, meta = self._client._request(  # noqa: SLF001 - internal reuse within the SDK package
+            "POST",
+            f"/market/capabilities/{listing.listing_id}/purchase",
+            json_body=payload,
+        )
+        access_grant = _parse_access_grant(_to_dict(data.get("access_grant")))
+        if not access_grant.access_grant_id:
+            purchase_status = str(data.get("purchase_status") or "unknown")
+            raise SiglumeExperimentalError(
+                f"Purchase completed with status '{purchase_status}' but did not return an access grant. "
+                "Buyer-side subscription flows are still experimental on the public API."
+            )
+        target_agent_id = _resolve_agent_id(agent_id, self.default_agent_id)
+        should_bind = bind_agent if bind_agent is not None else bool(target_agent_id)
+        binding_result: GrantBindingResult | None = None
+        if should_bind:
+            if not target_agent_id:
+                raise SiglumeClientError("agent_id is required to bind a purchased access grant.")
+            binding_result = self._client.bind_agent_to_grant(
+                access_grant.access_grant_id,
+                agent_id=target_agent_id,
+                binding_status=binding_status,
+            )
+        return Subscription(
+            access_grant_id=access_grant.access_grant_id,
+            capability_listing_id=access_grant.capability_listing_id or listing.listing_id,
+            capability_key=listing.capability_key,
+            purchase_status=str(data.get("purchase_status") or "created"),
+            grant_status=access_grant.grant_status or None,
+            agent_id=binding_result.binding.agent_id if binding_result is not None else target_agent_id,
+            binding_id=binding_result.binding.binding_id if binding_result is not None else None,
+            binding_status=binding_result.binding.binding_status if binding_result is not None else None,
+            access_grant=access_grant,
+            binding=binding_result.binding if binding_result is not None else None,
+            trace_id=(binding_result.trace_id if binding_result is not None else meta.trace_id),
+            request_id=(binding_result.request_id if binding_result is not None else meta.request_id),
+            raw={
+                "purchase": dict(data),
+                "binding": binding_result.raw if binding_result is not None else None,
+            },
+        )
+
+    def invoke(
+        self,
+        *,
+        capability_key: str,
+        input: Mapping[str, Any],
+        idempotency_key: str | None = None,
+        dry_run: bool = False,
+        agent_id: str | None = None,
+        task_type: str = "default",
+        execution_kind: str | None = None,
+        source_type: str | None = None,
+        environment: str = "live",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any:
+        """Invoke a subscribed capability.
+
+        Owner approval is surfaced as an ``ExecutionResult`` with
+        ``needs_approval=True`` and a populated ``approval_hint`` instead of
+        raising. Transport-level failures and missing public platform support
+        still raise ``SiglumeClientError`` / ``SiglumeExperimentalError``.
+        """
+        if not self.allow_internal_execute:
+            raise SiglumeExperimentalError(
+                "SiglumeBuyerClient.invoke() requires allow_internal_execute=True because the public buyer execute endpoint is not available yet."
+            )
+        self._warn_experimental(
+            "invoke",
+            "SiglumeBuyerClient.invoke() uses an internal execution endpoint until a public buyer invoke API is available.",
+        )
+        target_agent_id = _resolve_agent_id(agent_id, self.default_agent_id)
+        if not target_agent_id:
+            raise SiglumeClientError("agent_id is required for invoke(); pass it explicitly or set SIGLUME_AGENT_ID.")
+        payload: dict[str, Any] = {
+            "agent_id": target_agent_id,
+            "capability_key": capability_key,
+            "task_type": task_type,
+            "arguments": dict(input),
+            "dry_run": bool(dry_run),
+            "environment": environment,
+            "metadata": dict(metadata or {}),
+        }
+        if execution_kind:
+            payload["execution_kind"] = execution_kind
+        elif dry_run:
+            payload["execution_kind"] = "dry_run"
+        if source_type:
+            payload["source_type"] = source_type
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
+        data, _meta = self._client._request(  # noqa: SLF001 - internal reuse within the SDK package
+            "POST",
+            self.experimental_execute_path,
+            json_body=payload,
+        )
+        return _build_execution_result(data, payload=payload)
+
+    def _list_all_capabilities(self, *, status: str = "published") -> list[AppListingRecord]:
+        return self._client.list_capabilities(status=status, limit=100).all_items()
+
+    def _warn_experimental(self, key: str, message: str) -> None:
+        if key in self._warned_features:
+            return
+        self._warned_features.add(key)
+        warnings.warn(message, SiglumeExperimentalWarning, stacklevel=2)
+
+
+def _normalize_permission(value: str | None) -> str | None:
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    return text.replace("_", "-")
+
+
+def _tool_manual_permission(value: str | None) -> str:
+    normalized = _normalize_permission(value)
+    if normalized == "payment":
+        return "payment"
+    if normalized == "action":
+        return "action"
+    return "read_only"
+
+
+def _resolve_agent_id(explicit: str | None, default: str | None) -> str | None:
+    candidate = explicit or default
+    return str(candidate).strip() if candidate else None
+
+
+def _score_listing(listing: AppListingRecord, query: str) -> tuple[int, list[str], str | None]:
+    normalized_query = query.lower().strip()
+    tokens = [token for token in _QUERY_TOKEN_RE.findall(normalized_query) if token]
+    matched_fields: list[str] = []
+    score = 0
+    snippet: str | None = None
+    for field_name, weight in _SEARCH_FIELD_WEIGHTS:
+        text = _listing_field_text(listing, field_name)
+        if not text:
+            continue
+        lowered = text.lower()
+        field_matched = False
+        if normalized_query and normalized_query in lowered:
+            score += weight * 3
+            field_matched = True
+            if snippet is None:
+                snippet = _snippet(text, normalized_query)
+        else:
+            token_hits = sum(1 for token in tokens if token in lowered)
+            if token_hits:
+                score += weight * token_hits
+                field_matched = True
+                if snippet is None:
+                    snippet = _snippet(text, tokens[0])
+        if field_matched:
+            matched_fields.append(field_name)
+    return score, matched_fields, snippet
+
+
+def _listing_field_text(listing: AppListingRecord, field_name: str) -> str:
+    if field_name == "description":
+        return str(listing.raw.get("description") or "").strip()
+    value = getattr(listing, field_name, None)
+    return str(value or "").strip()
+
+
+def _snippet(text: str, term: str) -> str:
+    lowered = text.lower()
+    index = lowered.find(term.lower())
+    if index < 0:
+        return text[:96].strip()
+    start = max(index - 24, 0)
+    end = min(index + len(term) + 56, len(text))
+    excerpt = text[start:end].strip()
+    if start > 0:
+        excerpt = "..." + excerpt
+    if end < len(text):
+        excerpt = excerpt + "..."
+    return excerpt
+
+
+def _build_listing_tool_manual(listing: AppListingRecord) -> dict[str, Any]:
+    raw = dict(listing.raw)
+    existing = raw.get("tool_manual")
+    if isinstance(existing, Mapping):
+        return dict(existing)
+    description = _string_or_none(raw.get("description")) or listing.short_description or listing.job_to_be_done or listing.name
+    permission_class = _tool_manual_permission(listing.permission_class)
+    input_schema = _to_dict(raw.get("input_schema")) or {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": True,
+    }
+    output_schema = _to_dict(raw.get("output_schema")) or {
+        "type": "object",
+        "properties": {
+            "summary": {
+                "type": "string",
+                "description": "Summary of what the capability returned.",
+            }
+        },
+        "required": ["summary"],
+        "additionalProperties": True,
+    }
+    tool_manual: dict[str, Any] = {
+        "tool_name": listing.capability_key.replace("-", "_") or "siglume_capability",
+        "job_to_be_done": listing.job_to_be_done or description,
+        "summary_for_model": _bounded_summary(listing, description),
+        "trigger_conditions": [
+            f"Use when the owner asks for {description.lower()}." if description else f"Use when the owner requests capability {listing.capability_key}.",
+            f"Use when the task explicitly matches capability key '{listing.capability_key}'.",
+            f"Use when the workflow needs the output of {listing.name}.",
+        ],
+        "do_not_use_when": [
+            "Do not use when the request needs a different capability or lacks the required input context.",
+        ],
+        "permission_class": permission_class,
+        "dry_run_supported": bool(listing.dry_run_supported),
+        "requires_connected_accounts": [
+            str(item)
+            for item in raw.get("required_connected_accounts", [])
+            if isinstance(item, str)
+        ],
+        "input_schema": input_schema,
+        "output_schema": output_schema,
+        "usage_hints": [
+            text
+            for text in (
+                listing.short_description,
+                f"Read docs at {listing.docs_url} before relying on provider-specific behavior." if listing.docs_url else None,
+            )
+            if text
+        ]
+        or [f"Invoke {listing.capability_key} with the fields described in its input schema."],
+        "result_hints": [str(raw.get("result_summary") or "Return the provider result as structured JSON with a concise summary.")],
+        "error_hints": [
+            "If the invocation is denied or requires approval, surface the platform reason to the owner.",
+        ],
+    }
+    if permission_class in {"action", "payment"}:
+        tool_manual["approval_summary_template"] = f"Review {listing.name} before approving the external side effect."
+        tool_manual["preview_schema"] = {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Preview of the action that would be executed after approval.",
+                }
+            },
+            "required": ["summary"],
+            "additionalProperties": True,
+        }
+        tool_manual["idempotency_support"] = True
+        tool_manual["side_effect_summary"] = str(
+            raw.get("receipt_summary")
+            or raw.get("result_summary")
+            or f"{listing.name} may perform an external side effect after approval."
+        )
+    if permission_class == "payment":
+        tool_manual["quote_schema"] = {
+            "type": "object",
+            "properties": {
+                "amount_minor": {"type": "integer", "description": "Quoted amount in minor units."},
+                "currency": {"type": "string", "description": "Currency code for the quoted amount."},
+            },
+            "required": ["amount_minor", "currency"],
+            "additionalProperties": True,
+        }
+        tool_manual["currency"] = listing.currency or "USD"
+        tool_manual["settlement_mode"] = str(raw.get("settlement_mode") or "stripe_checkout")
+        tool_manual["refund_or_cancellation_note"] = str(
+            raw.get("refund_or_cancellation_note")
+            or "Refunds and cancellations follow the seller policy shown on the listing."
+        )
+        tool_manual["jurisdiction"] = str(raw.get("jurisdiction") or "US")
+    return tool_manual
+
+
+def _bounded_summary(listing: AppListingRecord, description: str) -> str:
+    summary = description or listing.name or listing.capability_key
+    summary = re.sub(r"\s+", " ", summary).strip()
+    if len(summary) < 10:
+        summary = f"{listing.name} capability for {listing.capability_key}."
+    return summary[:300]
+
+
+def _build_execution_result(data: Mapping[str, Any], *, payload: Mapping[str, Any]) -> Any:
+    from siglume_api_sdk import ApprovalRequestHint, ExecutionKind, ExecutionResult
+
+    accepted = bool(data.get("accepted"))
+    reason = str(data.get("reason") or "")
+    reason_code = _string_or_none(data.get("reason_code"))
+    usage_event = _to_dict(data.get("usage_event"))
+    receipt = _to_dict(data.get("receipt"))
+    execution_kind = _coerce_execution_kind(str(receipt.get("execution_kind") or payload.get("execution_kind") or "action"), ExecutionKind)
+    amount_minor = int(receipt.get("amount_minor") or usage_event.get("amount_minor") or 0)
+    currency = str(receipt.get("currency") or usage_event.get("currency") or "USD")
+    units_consumed = int(usage_event.get("units_consumed") or 1)
+    if accepted:
+        return ExecutionResult(
+            success=True,
+            output=_to_dict(data.get("result")),
+            execution_kind=execution_kind,
+            units_consumed=units_consumed,
+            amount_minor=amount_minor,
+            currency=currency,
+            provider_status="ok",
+            fallback_applied=bool(receipt.get("fallback_applied") or False),
+            receipt_summary=receipt,
+        )
+    approval_request = _to_dict(data.get("approval_request"))
+    approval_explanation = _to_dict(data.get("approval_explanation"))
+    needs_approval = reason_code == "APPROVAL_REQUIRED" or bool(approval_request)
+    approval_hint = None
+    if needs_approval:
+        preview = _to_dict(approval_explanation.get("preview"))
+        approval_hint = ApprovalRequestHint(
+            action_summary=str(approval_explanation.get("title") or approval_explanation.get("summary") or reason or "Owner approval required"),
+            permission_class="payment" if str(execution_kind.value) == "payment" else "action",
+            estimated_amount_minor=amount_minor or None,
+            currency=currency if receipt.get("currency") else None,
+            side_effects=[
+                str(item)
+                for item in approval_explanation.get("side_effects", [])
+                if isinstance(item, str)
+            ],
+            preview=preview,
+            reversible=False,
+        )
+    return ExecutionResult(
+        success=False,
+        output={
+            "reason_code": reason_code,
+            "approval_request": approval_request,
+            "approval_explanation": approval_explanation,
+        },
+        execution_kind=execution_kind,
+        units_consumed=units_consumed,
+        amount_minor=amount_minor,
+        currency=currency,
+        provider_status="denied" if needs_approval or reason_code else "error",
+        error_message=reason or reason_code,
+        needs_approval=needs_approval,
+        approval_prompt=(reason or "Owner approval is required.") if needs_approval else None,
+        fallback_applied=bool(receipt.get("fallback_applied") or False),
+        receipt_summary=receipt,
+        approval_hint=approval_hint,
+    )
+
+
+def _coerce_execution_kind(value: str, execution_kind_enum: Any) -> Any:
+    normalized = str(value or "action").strip().lower()
+    try:
+        if normalized == "dryrun":
+            normalized = "dry_run"
+        return execution_kind_enum(normalized)
+    except Exception:  # pragma: no cover - defensive fallback
+        return execution_kind_enum.ACTION
+
+
+__all__ = [
+    "CapabilityListing",
+    "SiglumeBuyerClient",
+    "SiglumeExperimentalError",
+    "SiglumeExperimentalWarning",
+    "Subscription",
+]

--- a/tests/fixtures/buyer_search_cases.json
+++ b/tests/fixtures/buyer_search_cases.json
@@ -1,0 +1,109 @@
+{
+  "listings": [
+    {
+      "id": "lst_currency",
+      "capability_key": "currency-converter-v2",
+      "name": "Currency Converter",
+      "description": "Convert USD amounts to JPY with live exchange rates and return a concise summary.",
+      "job_to_be_done": "Convert currency amounts between USD and JPY.",
+      "category": "finance",
+      "permission_class": "read-only",
+      "approval_mode": "auto",
+      "dry_run_supported": true,
+      "price_model": "free",
+      "price_value_minor": 0,
+      "currency": "USD",
+      "short_description": "Convert currency with live rates.",
+      "status": "published",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "amount_usd": {
+            "type": "number",
+            "description": "USD amount to convert."
+          },
+          "to": {
+            "type": "string",
+            "description": "Target currency code."
+          }
+        },
+        "required": [
+          "amount_usd",
+          "to"
+        ],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "One-line conversion summary."
+          },
+          "amount": {
+            "type": "number",
+            "description": "Converted amount."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Target currency."
+          }
+        },
+        "required": [
+          "summary",
+          "amount",
+          "currency"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "id": "lst_price",
+      "capability_key": "price-compare-helper",
+      "name": "Price Compare Helper",
+      "description": "Compare retailer offers for electronics and household goods.",
+      "job_to_be_done": "Compare product prices across stores.",
+      "category": "commerce",
+      "permission_class": "read-only",
+      "approval_mode": "auto",
+      "dry_run_supported": true,
+      "price_model": "free",
+      "price_value_minor": 0,
+      "currency": "USD",
+      "short_description": "Find the best price for a requested product.",
+      "status": "published"
+    },
+    {
+      "id": "lst_invoice",
+      "capability_key": "invoice-emailer",
+      "name": "Invoice Emailer",
+      "description": "Send invoice emails after owner approval and report delivery status.",
+      "job_to_be_done": "Send invoices by email.",
+      "category": "communication",
+      "permission_class": "action",
+      "approval_mode": "always-ask",
+      "dry_run_supported": true,
+      "price_model": "subscription",
+      "price_value_minor": 1200,
+      "currency": "USD",
+      "short_description": "Preview and send invoice email messages.",
+      "status": "published"
+    },
+    {
+      "id": "lst_translate",
+      "capability_key": "translation-hub",
+      "name": "Translation Hub",
+      "description": "Translate text across languages without side effects.",
+      "job_to_be_done": "Translate text.",
+      "category": "communication",
+      "permission_class": "read-only",
+      "approval_mode": "auto",
+      "dry_run_supported": true,
+      "price_model": "free",
+      "price_value_minor": 0,
+      "currency": "USD",
+      "short_description": "Translate text between common business languages.",
+      "status": "published"
+    }
+  ]
+}

--- a/tests/test_buyer.py
+++ b/tests/test_buyer.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk import SiglumeBuyerClient, SiglumeExperimentalError, SiglumeExperimentalWarning  # noqa: E402
+
+
+def load_fixture_listings() -> list[dict[str, object]]:
+    fixture_path = ROOT / "tests" / "fixtures" / "buyer_search_cases.json"
+    return json.loads(fixture_path.read_text(encoding="utf-8"))["listings"]
+
+
+def envelope(data, *, trace_id: str = "trc_buyer", request_id: str = "req_buyer") -> dict[str, object]:
+    return {
+        "data": data,
+        "meta": {"request_id": request_id, "trace_id": trace_id},
+        "error": None,
+    }
+
+
+def build_client(handler, **kwargs) -> SiglumeBuyerClient:
+    return SiglumeBuyerClient(
+        api_key="sig_test_key",
+        base_url="https://api.example.test/v1",
+        transport=httpx.MockTransport(handler),
+        **kwargs,
+    )
+
+
+def test_search_capabilities_uses_local_scoring_and_returns_best_match_first() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path != "/v1/market/capabilities":
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+        return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+
+    client = build_client(handler)
+    with pytest.warns(SiglumeExperimentalWarning, match="substring matching"):
+        results = client.search_capabilities(query="convert currency", limit=3)
+
+    assert results[0].capability_key == "currency-converter-v2"
+    assert results[0].score > 0
+    assert "description" in results[0].match_fields
+    assert results[0].tool_manual["tool_name"] == "currency_converter_v2"
+
+
+def test_search_capabilities_filters_permission_class_and_limit() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+
+    client = build_client(handler)
+    results = client.search_capabilities(query="email", permission_class="action", limit=1)
+
+    assert len(results) == 1
+    assert results[0].capability_key == "invoice-emailer"
+    assert results[0].permission_class == "action"
+
+
+def test_get_listing_resolves_capability_key_and_synthesizes_tool_manual() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+
+    client = build_client(handler)
+    listing = client.get_listing("currency-converter-v2")
+
+    assert listing.listing_id == "lst_currency"
+    assert listing.description and "live exchange rates" in listing.description
+    assert listing.tool_manual["input_schema"]["required"] == ["amount_usd", "to"]
+    assert listing.experimental is True
+
+
+def test_subscribe_returns_access_grant_without_binding_when_bind_is_disabled() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/market/capabilities":
+            return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+        if request.url.path == "/v1/market/capabilities/lst_currency/purchase":
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "purchase_status": "created",
+                        "access_grant": {
+                            "id": "grant_123",
+                            "capability_listing_id": "lst_currency",
+                            "grant_status": "active",
+                        },
+                    },
+                    trace_id="trc_purchase",
+                ),
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    client = build_client(handler)
+    subscription = client.subscribe(capability_key="currency-converter-v2", bind_agent=False)
+
+    assert subscription.access_grant_id == "grant_123"
+    assert subscription.binding_id is None
+    assert subscription.trace_id == "trc_purchase"
+
+
+def test_subscribe_binds_agent_when_default_agent_id_is_present() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/market/capabilities":
+            return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+        if request.url.path == "/v1/market/capabilities/lst_currency/purchase":
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "purchase_status": "created",
+                        "access_grant": {
+                            "id": "grant_123",
+                            "capability_listing_id": "lst_currency",
+                            "grant_status": "active",
+                        },
+                    }
+                ),
+            )
+        if request.url.path == "/v1/market/access-grants/grant_123/bind-agent":
+            body = json.loads(request.content.decode("utf-8"))
+            assert body["agent_id"] == "agent_demo"
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "binding": {
+                            "id": "bind_123",
+                            "access_grant_id": "grant_123",
+                            "agent_id": "agent_demo",
+                            "binding_status": "active",
+                        },
+                        "access_grant": {
+                            "id": "grant_123",
+                            "capability_listing_id": "lst_currency",
+                            "grant_status": "active",
+                        },
+                    },
+                    trace_id="trc_bind",
+                ),
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    client = build_client(handler, default_agent_id="agent_demo")
+    subscription = client.subscribe(capability_key="currency-converter-v2")
+
+    assert subscription.binding_id == "bind_123"
+    assert subscription.agent_id == "agent_demo"
+    assert subscription.trace_id == "trc_bind"
+
+
+def test_invoke_maps_accepted_execution_to_execution_result() -> None:
+    listings = load_fixture_listings()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/internal/market/capability/execute":
+            body = json.loads(request.content.decode("utf-8"))
+            assert body["arguments"]["amount_usd"] == 100
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "accepted": True,
+                        "allowed": True,
+                        "reason": "accepted",
+                        "reason_code": None,
+                        "usage_event": {"units_consumed": 1, "execution_kind": "action"},
+                        "result": {
+                            "summary": "Converted USD 100.00 to JPY 15000.00.",
+                            "amount": 15000.0,
+                            "currency": "JPY",
+                        },
+                        "receipt": {"execution_kind": "action", "currency": "JPY", "amount_minor": 0},
+                    },
+                    trace_id="trc_exec",
+                ),
+            )
+        if request.url.path == "/v1/market/capabilities":
+            return httpx.Response(200, json=envelope({"items": listings, "next_cursor": None, "limit": 20, "offset": 0}))
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    client = build_client(handler, default_agent_id="agent_demo", allow_internal_execute=True)
+    result = client.invoke(capability_key="currency-converter-v2", input={"amount_usd": 100, "to": "JPY"})
+
+    assert result.success is True
+    assert result.output["currency"] == "JPY"
+    assert result.execution_kind.value == "action"
+
+
+def test_invoke_maps_owner_approval_to_needs_approval_result() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path != "/v1/internal/market/capability/execute":
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "accepted": False,
+                    "allowed": False,
+                    "reason": "owner approval is required before execution",
+                    "reason_code": "APPROVAL_REQUIRED",
+                    "approval_request": {"id": "apr_123"},
+                    "approval_explanation": {
+                        "title": "Approve invoice email",
+                        "preview": {"summary": "Send invoice INV-1001 to finance@example.com"},
+                        "side_effects": ["email delivery to finance@example.com"],
+                    },
+                    "usage_event": {"units_consumed": 1, "execution_kind": "action"},
+                    "receipt": {"execution_kind": "action", "currency": "USD", "amount_minor": 0},
+                }
+            ),
+        )
+
+    client = build_client(handler, default_agent_id="agent_demo", allow_internal_execute=True)
+    result = client.invoke(capability_key="invoice-emailer", input={"invoice_id": "INV-1001"})
+
+    assert result.success is False
+    assert result.needs_approval is True
+    assert result.approval_hint and result.approval_hint.action_summary == "Approve invoice email"
+
+
+def test_invoke_does_not_invent_approval_currency_when_receipt_omits_it() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path != "/v1/internal/market/capability/execute":
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "accepted": False,
+                    "allowed": False,
+                    "reason": "owner approval is required before execution",
+                    "reason_code": "APPROVAL_REQUIRED",
+                    "approval_request": {"id": "apr_124"},
+                    "approval_explanation": {"title": "Approve invoice email"},
+                    "usage_event": {"units_consumed": 1, "execution_kind": "payment"},
+                    "receipt": {"execution_kind": "payment", "amount_minor": 9900},
+                }
+            ),
+        )
+
+    client = build_client(handler, default_agent_id="agent_demo", allow_internal_execute=True)
+    result = client.invoke(capability_key="invoice-emailer", input={"invoice_id": "INV-1002"})
+
+    assert result.needs_approval is True
+    assert result.approval_hint
+    assert result.approval_hint.currency is None
+
+
+def test_invoke_requires_explicit_opt_in_for_internal_execute() -> None:
+    client = build_client(lambda request: httpx.Response(200, json=envelope({})), default_agent_id="agent_demo")
+
+    with pytest.raises(SiglumeExperimentalError, match="allow_internal_execute=True"):
+        client.invoke(capability_key="currency-converter-v2", input={"amount_usd": 100})

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -78,3 +78,13 @@ def test_generate_tool_manual_example_requires_explicit_llm_api_key(monkeypatch)
 
     with pytest.raises(SystemExit, match="Set ANTHROPIC_API_KEY or OPENAI_API_KEY"):
         module.main()
+
+
+def test_buyer_langchain_example_runs_with_mock_client(capsys) -> None:
+    module = _load_module("buyer_langchain.py")
+
+    module.main()
+
+    output = capsys.readouterr().out.strip().splitlines()
+    assert output[0].startswith("tool_name: currency_converter_v2")
+    assert output[-1].startswith("result_currency: JPY")


### PR DESCRIPTION
## Summary
- add experimental `SiglumeBuyerClient` for buyer-side discovery, subscribe, and invoke flows
- fall back to local substring search and synthesized tool manuals because the platform search API and full listing tool_manual payload are not public yet
- add mocked LangChain and Claude Agent SDK examples plus buyer-side docs

## Validation
- [x] `py -3.11 -m ruff check .`
- [x] `py -3.11 -m pytest` -> 118 passed (before: 108)
- [x] `py -3.11 scripts/contract_sync.py` -> passed
- [x] `npm run lint`
- [x] `npm test` -> 135 passed (before: 126)
- [x] `npm run build`
- [x] mocked examples run locally (`buyer_langchain.py`, `buyer_claude_agent_sdk.ts`)
- [x] reviewer pass: no critical / warning findings remain

## Notes
- `search_capabilities()` is explicitly experimental and does not add a new OpenAPI path because platform search is not implemented
- `invoke()` remains gated behind `allow_internal_execute=True` so the SDK does not imply public buyer execute support that does not exist yet