### PR TITLE
feat(examples): crm_sync / news_digest / wallet_balance (PR-O)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-19
+
+First full multi-runtime SDK release. v0.4.0 adds offline ToolManual scoring,
+the shipping TypeScript runtime, LLM-assisted ToolManual drafting, manifest/tool
+manual diffing, provider schema exporters, deterministic recording harnesses,
+experimental buyer-side helpers, and the final example set needed for a
+workflow-complete public SDK.
+
+### Added
+
+- `score_tool_manual_offline()` parity scorer plus `siglume score --offline`.
+- Full TypeScript runtime package `@siglume/api-sdk` with AppAdapter,
+  AppTestHarness, client, buyer, diff, exporter, recorder, and CLI coverage.
+- LLM-assisted ToolManual helpers:
+  `draft_tool_manual()`, `fill_tool_manual_gaps()`,
+  `AnthropicProvider`, and `OpenAIProvider`.
+- Pure diff utilities:
+  `diff_manifest()` / `diff_tool_manual()` and `siglume diff`.
+- Tool schema exporters for Anthropic, OpenAI Chat Completions, OpenAI
+  Responses, and MCP descriptors.
+- Shared JSON cassette recorder for Python and TypeScript tests.
+- Experimental buyer-side SDK:
+  `SiglumeBuyerClient`, LangChain bridge example, and Claude-style example.
+- Remaining publish-ready examples:
+  `crm_sync.py`, `news_digest.py`, `wallet_balance.py`,
+  plus matching TypeScript examples under `examples-ts/`.
+
+### Fixed
+
+- Preview-quality endpoint malformed-JSON handling now returns a 4xx
+  `INVALID_PAYLOAD` envelope instead of surfacing a 500.
+- TypeScript `SiglumeClientShape` now includes
+  `preview_quality_score(tool_manual)`.
+- Offline grader now flags non-string items in usage/result/error hint lists
+  instead of silently letting malformed manuals keep publishable grades.
+
+### Compatibility
+
+- Public v0.3.x APIs remain available; v0.4.0 is additive for existing Python
+  users.
+- TypeScript package version moves from the prerelease line to the first stable
+  `0.4.0` cut.
+- No change to the USD-only rule, required `jurisdiction`, or the manifest vs.
+  tool-manual permission-class naming split.
+
 ## [0.3.1] - 2026-04-19
 
 Patch release for two Codex auto-review P2 fixes across the v0.3 surface.

--- a/RELEASE_NOTES_v0.4.0.md
+++ b/RELEASE_NOTES_v0.4.0.md
@@ -1,0 +1,65 @@
+# v0.4.0 - offline grader, TypeScript runtime, and workflow-complete examples
+
+**2026-04-19**
+
+v0.4.0 is the first Siglume SDK release where both Python and TypeScript users
+can build, test, diff, score, export, and mock replay a capability end-to-end
+without leaving the public SDK surface.
+
+## Highlights
+
+- **Offline ToolManual grading**: `score_tool_manual_offline()` mirrors the
+  publish-time quality bar locally, and `siglume score --offline` works without
+  a network round-trip.
+- **TypeScript runtime is now first-class**: `@siglume/api-sdk` ships
+  AppAdapter, AppTestHarness, SiglumeClient, buyer helpers, diff/exporters,
+  recorder support, and the `siglume` CLI in ESM + CJS form.
+- **LLM-assisted ToolManual drafting**: use `draft_tool_manual()` or
+  `fill_tool_manual_gaps()` with `AnthropicProvider` or `OpenAIProvider`,
+  backed by offline scoring + retry.
+- **Safe review tooling**: `siglume diff` classifies breaking vs. warning vs.
+  info changes for manifests and tool manuals.
+- **Schema exporters**: turn one ToolManual into Anthropic, OpenAI, or MCP tool
+  descriptors with explicit lossy-field reporting.
+- **Deterministic recording harness**: shared Python/TypeScript cassettes let
+  tests replay HTTP flows without live network access.
+- **Buyer-side SDK**: experimental `SiglumeBuyerClient` makes it easier to plug
+  Siglume marketplace capabilities into LangChain-style and Claude-style agent
+  runtimes.
+- **Example set completed for v0.4**: `crm_sync`, `news_digest`, and
+  `wallet_balance` join the earlier examples, with TypeScript counterparts in
+  `examples-ts/`.
+
+## Included PRs
+
+- PR-C2: offline ToolManual grader parity
+- PR-D: LLM assist for ToolManual draft + gap fill
+- PR-E: full TypeScript runtime package
+- PR-J: manifest / ToolManual diff tool
+- PR-K: Anthropic / OpenAI / MCP schema exporters
+- PR-L: deterministic recording harness
+- PR-N: experimental buyer-side SDK
+- PR-O: final example set + release prep
+
+## Patch fixes folded into this release
+
+- Preview-quality malformed JSON now maps to a 4xx `INVALID_PAYLOAD` envelope
+  instead of a 500.
+- TypeScript `SiglumeClientShape` includes `preview_quality_score(tool_manual)`.
+- Offline grader now penalizes non-string items in hint arrays.
+
+## Compatibility
+
+This release is additive for Python users on the v0.3 line.
+
+- No change to the USD-only publishing rule.
+- `AppManifest.jurisdiction` remains required.
+- `ToolManual.permission_class` still uses underscore values.
+- `AppManifest.permission_class` still uses hyphen values.
+
+## Suggested upgrade
+
+```bash
+pip install --upgrade siglume-api-sdk==0.4.0
+npm install @siglume/api-sdk@0.4.0
+```

--- a/examples-ts/crm_sync.ts
+++ b/examples-ts/crm_sync.ts
@@ -1,0 +1,192 @@
+/*
+API: CRM lead upsert for revenue and sales operations workflows.
+Intended user: operators or agent builders who need to create or refresh leads.
+Connected account: hubspot.
+*/
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  StubProvider,
+  ToolManualPermissionClass,
+  score_tool_manual_offline,
+  validate_tool_manual,
+} from "../siglume-api-sdk-ts/src/index";
+import type { ExecutionContext, ExecutionResult, ToolManual } from "../siglume-api-sdk-ts/src/index";
+
+export class CrmSyncApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "crm-sync",
+      name: "CRM Sync",
+      job_to_be_done: "Create or update CRM lead records after the owner approves the write.",
+      category: AppCategory.CRM,
+      permission_class: PermissionClass.ACTION,
+      approval_mode: ApprovalMode.ALWAYS_ASK,
+      dry_run_supported: true,
+      required_connected_accounts: ["hubspot"],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Preview and upsert HubSpot lead records with explicit approval.",
+      example_prompts: ["Sync this inbound contact into HubSpot as a lead."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const external_id = String(ctx.input_params?.external_id ?? "lead-ext-1001");
+    const full_name = String(ctx.input_params?.full_name ?? "Avery Stone");
+    const email = String(ctx.input_params?.email ?? "avery.stone@example.com");
+    const company = String(ctx.input_params?.company ?? "Northwind Labs");
+    const notes = String(ctx.input_params?.notes ?? "Qualified inbound lead from pricing page.");
+    const lead_id = `hubspot_${external_id.replaceAll("-", "_")}`;
+    const preview = {
+      summary: `Would sync lead ${full_name} (${email}) to HubSpot.`,
+      external_id,
+      full_name,
+      email,
+      company,
+    };
+    if (ctx.execution_kind === "dry_run") {
+      return {
+        success: true,
+        execution_kind: ctx.execution_kind,
+        output: preview,
+        needs_approval: true,
+        approval_prompt: `Sync CRM lead ${external_id} for ${email} into HubSpot.`,
+      };
+    }
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: {
+        summary: `Synced HubSpot lead ${full_name}.`,
+        lead_id,
+        external_id,
+        provider: "hubspot",
+        notes,
+      },
+      receipt_summary: {
+        action: "crm_lead_upserted",
+        lead_id,
+        external_id,
+        provider: "hubspot",
+      },
+      artifacts: [
+        {
+          artifact_type: "crm_lead",
+          external_id: lead_id,
+          title: full_name,
+          summary: `CRM lead record for ${email}`,
+        },
+      ],
+      side_effects: [
+        {
+          action: "crm_lead_upserted",
+          provider: "hubspot",
+          external_id: lead_id,
+          reversible: true,
+          reversal_hint: "Archive the lead record in HubSpot if it was created in error.",
+          metadata: { external_id, company },
+        },
+      ],
+    };
+  }
+
+  supported_task_types() {
+    return ["sync_crm_lead", "create_crm_lead"];
+  }
+}
+
+export function buildStubs() {
+  return { hubspot: new StubProvider("hubspot") };
+}
+
+export function buildToolManual(): ToolManual {
+  return {
+    tool_name: "crm_sync",
+    job_to_be_done: "Create or update a CRM lead record in HubSpot after the owner reviews the lead preview.",
+    summary_for_model: "Previews a HubSpot lead upsert and then writes the lead only after explicit owner approval.",
+    trigger_conditions: [
+      "owner asks to create or update a CRM lead after collecting contact information",
+      "agent needs to push a qualified inbound lead into HubSpot with an external_id for dedupe",
+      "request is to sync contact details into CRM rather than only summarize the lead",
+    ],
+    do_not_use_when: [
+      "the owner only wants a draft message or notes without writing any CRM record",
+      "the contact has not consented to being stored in the CRM system",
+    ],
+    permission_class: ToolManualPermissionClass.ACTION,
+    dry_run_supported: true,
+    requires_connected_accounts: ["hubspot"],
+    input_schema: {
+      type: "object",
+      properties: {
+        external_id: { type: "string", description: "Stable dedupe key for the lead." },
+        full_name: { type: "string", description: "Lead full name." },
+        email: { type: "string", description: "Lead email address." },
+        company: { type: "string", description: "Company name.", default: "" },
+        notes: { type: "string", description: "Qualification notes.", default: "" },
+      },
+      required: ["external_id", "full_name", "email"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line outcome summary." },
+        lead_id: { type: "string", description: "HubSpot lead identifier." },
+        external_id: { type: "string", description: "Caller-provided dedupe key." },
+        provider: { type: "string", description: "CRM provider that received the write." },
+      },
+      required: ["summary", "lead_id", "external_id", "provider"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use dry_run first so the owner can verify the contact details before the CRM write happens."],
+    result_hints: ["Show both the HubSpot lead_id and external_id so follow-up automations can reuse the same record."],
+    error_hints: ["If contact details are incomplete, ask for the missing email or full_name before retrying."],
+    approval_summary_template: "Sync CRM lead {external_id} for {email}.",
+    preview_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Preview of the CRM write." },
+        external_id: { type: "string", description: "Lead dedupe key." },
+        full_name: { type: "string", description: "Lead full name." },
+        email: { type: "string", description: "Lead email address." },
+      },
+      required: ["summary", "external_id", "full_name", "email"],
+      additionalProperties: false,
+    },
+    idempotency_support: true,
+    side_effect_summary: "Creates or updates a lead record in HubSpot using the provided external_id as the dedupe key.",
+    jurisdiction: "US",
+    legal_notes: "Only sync personal data that the approving owner is authorized to store in HubSpot.",
+  };
+}
+
+export async function runCrmSyncExample(): Promise<string[]> {
+  const harness = new AppTestHarness(new CrmSyncApp(), buildStubs());
+  const [ok, issues] = validate_tool_manual(buildToolManual());
+  const report = score_tool_manual_offline(buildToolManual());
+  const dryRun = await harness.dry_run("sync_crm_lead");
+  const action = await harness.execute_action("sync_crm_lead");
+  return [
+    `tool_manual_valid: ${String(ok)} ${issues.length}`,
+    `quality_grade: ${report.grade} ${report.overall_score}`,
+    `manifest_issues: ${(await harness.validate_manifest()).length}`,
+    `dry_run: ${String(dryRun.success)}`,
+    `action: ${String(action.success)}`,
+    `receipt_issues: ${harness.validate_receipt(action).length}`,
+  ];
+}
+
+const directTarget = process.argv[1] ? new URL(process.argv[1], "file:///").href : "";
+
+if (import.meta.url === directTarget || (process.argv[1] ?? "").endsWith("crm_sync.ts")) {
+  const lines = await runCrmSyncExample();
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/examples-ts/news_digest.ts
+++ b/examples-ts/news_digest.ts
@@ -1,0 +1,156 @@
+/*
+API: read-only topic digest over public news feeds.
+Intended user: researchers, assistants, or monitoring agents.
+Connected account: none.
+*/
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  ToolManualPermissionClass,
+  score_tool_manual_offline,
+  validate_tool_manual,
+} from "../siglume-api-sdk-ts/src/index";
+import type { ExecutionContext, ExecutionResult, ToolManual } from "../siglume-api-sdk-ts/src/index";
+
+export class NewsDigestApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "news-digest",
+      name: "News Digest",
+      job_to_be_done: "Summarize recent public news articles for a topic without any external side effects.",
+      category: AppCategory.MONITORING,
+      permission_class: PermissionClass.READ_ONLY,
+      approval_mode: ApprovalMode.AUTO,
+      dry_run_supported: true,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Collect and summarize public news articles for a requested topic.",
+      example_prompts: ["Give me a 3-day digest of news about AI agents."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const topic = String(ctx.input_params?.topic ?? "AI agents");
+    const lookback_days = Number(ctx.input_params?.lookback_days ?? 3);
+    const articles = [
+      {
+        title: `${topic}: enterprise adoption accelerates`,
+        source: "Example Wire",
+        published_at: "2026-04-18",
+        url: "https://news.example.test/enterprise-adoption",
+      },
+      {
+        title: `${topic}: new tooling reduces agent evaluation time`,
+        source: "Signal Post",
+        published_at: "2026-04-17",
+        url: "https://news.example.test/eval-speedup",
+      },
+      {
+        title: `${topic}: builders focus on safer approval flows`,
+        source: "Daily Runtime",
+        published_at: "2026-04-16",
+        url: "https://news.example.test/approval-flows",
+      },
+    ];
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: {
+        summary: `Found ${articles.length} notable ${topic} stories from the last ${lookback_days} days.`,
+        articles,
+        topic,
+      },
+    };
+  }
+
+  supported_task_types() {
+    return ["news_digest", "monitor_topic"];
+  }
+}
+
+export function buildToolManual(): ToolManual {
+  return {
+    tool_name: "news_digest",
+    job_to_be_done: "Collect recent public news coverage for a topic and return a concise digest with article links.",
+    summary_for_model: "Searches recent public news coverage for a topic and returns a structured digest with article metadata and a concise summary.",
+    trigger_conditions: [
+      "owner asks for a recent digest of public news on a specific topic",
+      "agent needs fresh article coverage before summarizing market or product movement",
+      "request is to monitor or brief recent headlines without contacting any private account",
+    ],
+    do_not_use_when: [
+      "the request is to publish, email, or otherwise write back to an external system",
+      "the owner needs private or paywalled sources that are not part of the configured public feed",
+    ],
+    permission_class: ToolManualPermissionClass.READ_ONLY,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        topic: { type: "string", description: "Topic to monitor in public news coverage." },
+        lookback_days: {
+          type: "integer",
+          description: "How many days of recent news to scan.",
+          default: 3,
+        },
+      },
+      required: ["topic"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line digest summary." },
+        articles: {
+          type: "array",
+          description: "Recent articles returned for the requested topic.",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              source: { type: "string" },
+              published_at: { type: "string" },
+              url: { type: "string" },
+            },
+            required: ["title", "source", "published_at", "url"],
+            additionalProperties: false,
+          },
+        },
+        topic: { type: "string", description: "Topic that was queried." },
+      },
+      required: ["summary", "articles", "topic"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool when the owner wants a recent public-news briefing before making a decision."],
+    result_hints: ["Lead with the digest summary, then cite the most relevant article titles and sources."],
+    error_hints: ["If the topic is too broad, ask for a narrower company, product, or sector focus."],
+  };
+}
+
+export async function runNewsDigestExample(): Promise<string[]> {
+  const harness = new AppTestHarness(new NewsDigestApp());
+  const [ok, issues] = validate_tool_manual(buildToolManual());
+  const report = score_tool_manual_offline(buildToolManual());
+  const dryRun = await harness.dry_run("news_digest", { input_params: { topic: "AI agents", lookback_days: 3 } });
+  return [
+    `tool_manual_valid: ${String(ok)} ${issues.length}`,
+    `quality_grade: ${report.grade} ${report.overall_score}`,
+    `manifest_issues: ${(await harness.validate_manifest()).length}`,
+    `dry_run: ${String(dryRun.success)}`,
+  ];
+}
+
+const directTarget = process.argv[1] ? new URL(process.argv[1], "file:///").href : "";
+
+if (import.meta.url === directTarget || (process.argv[1] ?? "").endsWith("news_digest.ts")) {
+  const lines = await runNewsDigestExample();
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/examples-ts/wallet_balance.ts
+++ b/examples-ts/wallet_balance.ts
@@ -1,0 +1,153 @@
+/*
+API: wallet balance lookup across Ethereum or Polygon.
+Intended user: treasury or portfolio monitoring agents.
+Connected account: metamask.
+*/
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  StubProvider,
+  ToolManualPermissionClass,
+  score_tool_manual_offline,
+  validate_tool_manual,
+} from "../siglume-api-sdk-ts/src/index";
+import type { ExecutionContext, ExecutionResult, ToolManual } from "../siglume-api-sdk-ts/src/index";
+
+const ETHEREUM_DEFAULT: [string, number, number] = ["ETH", 1.2345, 3200.0];
+const CHAIN_DEFAULTS: Record<string, [string, number, number]> = {
+  ethereum: ETHEREUM_DEFAULT,
+  polygon: ["MATIC", 542.1, 0.75],
+};
+
+const TOKEN_PRICES: Record<string, number> = {
+  ETH: 3200.0,
+  MATIC: 0.75,
+  USDC: 1.0,
+};
+
+export class WalletBalanceApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "wallet-balance",
+      name: "Wallet Balance",
+      job_to_be_done: "Read the owner's connected wallet balance on Ethereum or Polygon without moving funds.",
+      category: AppCategory.FINANCE,
+      permission_class: PermissionClass.READ_ONLY,
+      approval_mode: ApprovalMode.AUTO,
+      dry_run_supported: true,
+      required_connected_accounts: ["metamask"],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Read native-token or ERC-20 balances from a connected MetaMask wallet.",
+      example_prompts: ["Check my Polygon wallet balance."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const chain = String(ctx.input_params?.chain ?? "ethereum").toLowerCase();
+    const chainDefaults = CHAIN_DEFAULTS[chain] ?? ETHEREUM_DEFAULT;
+    const [defaultSymbol, defaultBalance, defaultPrice] = chainDefaults;
+    const token_symbol = String(ctx.input_params?.token_symbol ?? defaultSymbol).toUpperCase();
+    const balance = token_symbol === defaultSymbol ? defaultBalance : token_symbol === "USDC" ? 250.0 : 18.75;
+    const usd_equivalent = Math.round(balance * (TOKEN_PRICES[token_symbol] ?? defaultPrice) * 100) / 100;
+    const provider = ctx.connected_accounts?.metamask?.provider_key ?? "metamask";
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: {
+        summary: `${chain[0]?.toUpperCase() ?? ""}${chain.slice(1)} wallet holds ${balance.toFixed(4)} ${token_symbol} (~USD ${usd_equivalent.toFixed(2)}).`,
+        chain,
+        token_symbol,
+        balance,
+        usd_equivalent,
+        provider,
+      },
+    };
+  }
+
+  supported_task_types() {
+    return ["wallet_balance", "check_wallet_balance"];
+  }
+}
+
+export function buildStubs() {
+  return { metamask: new StubProvider("metamask") };
+}
+
+export function buildToolManual(): ToolManual {
+  return {
+    tool_name: "wallet_balance",
+    job_to_be_done: "Read the owner's connected MetaMask wallet balance on Ethereum or Polygon without creating any blockchain side effects.",
+    summary_for_model: "Returns native-token or ERC-20 wallet balances plus a USD equivalent for a connected MetaMask wallet on Ethereum or Polygon.",
+    trigger_conditions: [
+      "owner asks to check a wallet balance on Ethereum or Polygon",
+      "agent needs a read-only on-chain balance snapshot before planning a payment or treasury action",
+      "request is to inspect holdings rather than transfer funds or approve a transaction",
+    ],
+    do_not_use_when: [
+      "the request is to sign, send, swap, or bridge assets",
+      "the owner has not connected a MetaMask wallet for the target chain",
+    ],
+    permission_class: ToolManualPermissionClass.READ_ONLY,
+    dry_run_supported: true,
+    requires_connected_accounts: ["metamask"],
+    input_schema: {
+      type: "object",
+      properties: {
+        chain: {
+          type: "string",
+          description: "Target chain to inspect.",
+          enum: ["ethereum", "polygon"],
+        },
+        token_symbol: {
+          type: "string",
+          description: "Optional token symbol; omit to read the native asset.",
+          default: "native",
+        },
+      },
+      required: ["chain"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line balance summary." },
+        chain: { type: "string", description: "Chain that was queried." },
+        token_symbol: { type: "string", description: "Token that was priced." },
+        balance: { type: "number", description: "Token balance on the requested chain." },
+        usd_equivalent: { type: "number", description: "Approximate USD equivalent." },
+      },
+      required: ["summary", "chain", "token_symbol", "balance", "usd_equivalent"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use this tool before payment planning when the owner needs a read-only wallet balance snapshot."],
+    result_hints: ["State the chain, token, and USD equivalent in the first sentence so the owner can sanity-check the result quickly."],
+    error_hints: ["If the owner has not connected MetaMask for the requested chain, ask them to connect the wallet before retrying."],
+  };
+}
+
+export async function runWalletBalanceExample(): Promise<string[]> {
+  const harness = new AppTestHarness(new WalletBalanceApp(), buildStubs());
+  const [ok, issues] = validate_tool_manual(buildToolManual());
+  const report = score_tool_manual_offline(buildToolManual());
+  const dryRun = await harness.dry_run("wallet_balance", { input_params: { chain: "polygon" } });
+  return [
+    `tool_manual_valid: ${String(ok)} ${issues.length}`,
+    `quality_grade: ${report.grade} ${report.overall_score}`,
+    `manifest_issues: ${(await harness.validate_manifest()).length}`,
+    `dry_run: ${String(dryRun.success)}`,
+  ];
+}
+
+const directTarget = process.argv[1] ? new URL(process.argv[1], "file:///").href : "";
+
+if (import.meta.url === directTarget || (process.argv[1] ?? "").endsWith("wallet_balance.ts")) {
+  const lines = await runWalletBalanceExample();
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/examples/crm_sync.py
+++ b/examples/crm_sync.py
@@ -1,0 +1,197 @@
+"""Example: sync a CRM lead record with preview + approval.
+
+API: CRM lead upsert for revenue and sales operations workflows.
+Intended user: operators or agent builders who need to create or refresh leads.
+Connected account: hubspot.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    ExecutionArtifact,
+    ExecutionContext,
+    ExecutionKind,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    SideEffectRecord,
+    StubProvider,
+    ToolManual,
+    ToolManualPermissionClass,
+    score_tool_manual_offline,
+    validate_tool_manual,
+)
+
+
+class CrmSyncApp(AppAdapter):
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="crm-sync",
+            name="CRM Sync",
+            job_to_be_done="Create or update CRM lead records after the owner approves the write.",
+            category=AppCategory.CRM,
+            permission_class=PermissionClass.ACTION,
+            approval_mode=ApprovalMode.ALWAYS_ASK,
+            dry_run_supported=True,
+            required_connected_accounts=["hubspot"],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="Preview and upsert HubSpot lead records with explicit approval.",
+            example_prompts=["Sync this inbound contact into HubSpot as a lead."],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+        external_id = str(ctx.input_params.get("external_id") or "lead-ext-1001")
+        full_name = str(ctx.input_params.get("full_name") or "Avery Stone")
+        email = str(ctx.input_params.get("email") or "avery.stone@example.com")
+        company = str(ctx.input_params.get("company") or "Northwind Labs")
+        notes = str(ctx.input_params.get("notes") or "Qualified inbound lead from pricing page.")
+        lead_id = f"hubspot_{external_id.replace('-', '_')}"
+        preview = {
+            "summary": f"Would sync lead {full_name} ({email}) to HubSpot.",
+            "external_id": external_id,
+            "full_name": full_name,
+            "email": email,
+            "company": company,
+        }
+        if ctx.execution_kind == ExecutionKind.DRY_RUN:
+            return ExecutionResult(
+                success=True,
+                execution_kind=ctx.execution_kind,
+                output=preview,
+                needs_approval=True,
+                approval_prompt=f"Sync CRM lead {external_id} for {email} into HubSpot.",
+            )
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": f"Synced HubSpot lead {full_name}.",
+                "lead_id": lead_id,
+                "external_id": external_id,
+                "provider": "hubspot",
+                "notes": notes,
+            },
+            receipt_summary={
+                "action": "crm_lead_upserted",
+                "lead_id": lead_id,
+                "external_id": external_id,
+                "provider": "hubspot",
+            },
+            artifacts=[
+                ExecutionArtifact(
+                    artifact_type="crm_lead",
+                    external_id=lead_id,
+                    title=full_name,
+                    summary=f"CRM lead record for {email}",
+                )
+            ],
+            side_effects=[
+                SideEffectRecord(
+                    action="crm_lead_upserted",
+                    provider="hubspot",
+                    external_id=lead_id,
+                    reversible=True,
+                    reversal_hint="Archive the lead record in HubSpot if it was created in error.",
+                    metadata={"external_id": external_id, "company": company},
+                )
+            ],
+        )
+
+    def supported_task_types(self) -> list[str]:
+        return ["sync_crm_lead", "create_crm_lead"]
+
+
+def build_stubs() -> dict[str, StubProvider]:
+    return {"hubspot": StubProvider("hubspot")}
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="crm_sync",
+        job_to_be_done="Create or update a CRM lead record in HubSpot after the owner reviews the lead preview.",
+        summary_for_model="Previews a HubSpot lead upsert and then writes the lead only after explicit owner approval.",
+        trigger_conditions=[
+            "owner asks to create or update a CRM lead after collecting contact information",
+            "agent needs to push a qualified inbound lead into HubSpot with an external_id for dedupe",
+            "request is to sync contact details into CRM rather than only summarize the lead",
+        ],
+        do_not_use_when=[
+            "the owner only wants a draft message or notes without writing any CRM record",
+            "the contact has not consented to being stored in the CRM system",
+        ],
+        permission_class=ToolManualPermissionClass.ACTION,
+        dry_run_supported=True,
+        requires_connected_accounts=["hubspot"],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "external_id": {"type": "string", "description": "Stable dedupe key for the lead."},
+                "full_name": {"type": "string", "description": "Lead full name."},
+                "email": {"type": "string", "description": "Lead email address."},
+                "company": {"type": "string", "description": "Company name.", "default": ""},
+                "notes": {"type": "string", "description": "Qualification notes.", "default": ""},
+            },
+            "required": ["external_id", "full_name", "email"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line outcome summary."},
+                "lead_id": {"type": "string", "description": "HubSpot lead identifier."},
+                "external_id": {"type": "string", "description": "Caller-provided dedupe key."},
+                "provider": {"type": "string", "description": "CRM provider that received the write."},
+            },
+            "required": ["summary", "lead_id", "external_id", "provider"],
+            "additionalProperties": False,
+        },
+        usage_hints=["Use dry_run first so the owner can verify the contact details before the CRM write happens."],
+        result_hints=["Show both the HubSpot lead_id and external_id so follow-up automations can reuse the same record."],
+        error_hints=["If contact details are incomplete, ask for the missing email or full_name before retrying."],
+        approval_summary_template="Sync CRM lead {external_id} for {email}.",
+        preview_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Preview of the CRM write."},
+                "external_id": {"type": "string", "description": "Lead dedupe key."},
+                "full_name": {"type": "string", "description": "Lead full name."},
+                "email": {"type": "string", "description": "Lead email address."},
+            },
+            "required": ["summary", "external_id", "full_name", "email"],
+            "additionalProperties": False,
+        },
+        idempotency_support=True,
+        side_effect_summary="Creates or updates a lead record in HubSpot using the provided external_id as the dedupe key.",
+        jurisdiction="US",
+        legal_notes="Only sync personal data that the approving owner is authorized to store in HubSpot.",
+    )
+
+
+async def main() -> None:
+    harness = AppTestHarness(CrmSyncApp(), stubs=build_stubs())
+    ok, issues = validate_tool_manual(build_tool_manual())
+    report = score_tool_manual_offline(build_tool_manual())
+    dry_run = await harness.dry_run(task_type="sync_crm_lead")
+    action = await harness.execute_action(task_type="sync_crm_lead")
+    print("tool_manual_valid:", ok, len(issues))
+    print("quality_grade:", report.grade, report.overall_score)
+    print("manifest_issues:", harness.validate_manifest())
+    print("dry_run:", dry_run.success)
+    print("action:", action.success)
+    print("receipt_issues:", len(harness.validate_receipt(action)))
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/news_digest.py
+++ b/examples/news_digest.py
@@ -1,0 +1,159 @@
+"""Example: aggregate recent news into a topic digest.
+
+API: read-only topic digest over public news feeds.
+Intended user: researchers, assistants, or monitoring agents.
+Connected account: none.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    ExecutionContext,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    ToolManual,
+    ToolManualPermissionClass,
+    score_tool_manual_offline,
+    validate_tool_manual,
+)
+
+
+class NewsDigestApp(AppAdapter):
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="news-digest",
+            name="News Digest",
+            job_to_be_done="Summarize recent public news articles for a topic without any external side effects.",
+            category=AppCategory.MONITORING,
+            permission_class=PermissionClass.READ_ONLY,
+            approval_mode=ApprovalMode.AUTO,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="Collect and summarize public news articles for a requested topic.",
+            example_prompts=["Give me a 3-day digest of news about AI agents."],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+        topic = str(ctx.input_params.get("topic") or "AI agents")
+        lookback_days = int(ctx.input_params.get("lookback_days") or 3)
+        articles = [
+            {
+                "title": f"{topic}: enterprise adoption accelerates",
+                "source": "Example Wire",
+                "published_at": "2026-04-18",
+                "url": "https://news.example.test/enterprise-adoption",
+            },
+            {
+                "title": f"{topic}: new tooling reduces agent evaluation time",
+                "source": "Signal Post",
+                "published_at": "2026-04-17",
+                "url": "https://news.example.test/eval-speedup",
+            },
+            {
+                "title": f"{topic}: builders focus on safer approval flows",
+                "source": "Daily Runtime",
+                "published_at": "2026-04-16",
+                "url": "https://news.example.test/approval-flows",
+            },
+        ]
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": f"Found {len(articles)} notable {topic} stories from the last {lookback_days} days.",
+                "articles": articles,
+                "topic": topic,
+            },
+        )
+
+    def supported_task_types(self) -> list[str]:
+        return ["news_digest", "monitor_topic"]
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="news_digest",
+        job_to_be_done="Collect recent public news coverage for a topic and return a concise digest with article links.",
+        summary_for_model="Searches recent public news coverage for a topic and returns a structured digest with article metadata and a concise summary.",
+        trigger_conditions=[
+            "owner asks for a recent digest of public news on a specific topic",
+            "agent needs fresh article coverage before summarizing market or product movement",
+            "request is to monitor or brief recent headlines without contacting any private account",
+        ],
+        do_not_use_when=[
+            "the request is to publish, email, or otherwise write back to an external system",
+            "the owner needs private or paywalled sources that are not part of the configured public feed",
+        ],
+        permission_class=ToolManualPermissionClass.READ_ONLY,
+        dry_run_supported=True,
+        requires_connected_accounts=[],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "topic": {"type": "string", "description": "Topic to monitor in public news coverage."},
+                "lookback_days": {
+                    "type": "integer",
+                    "description": "How many days of recent news to scan.",
+                    "default": 3,
+                },
+            },
+            "required": ["topic"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line digest summary."},
+                "articles": {
+                    "type": "array",
+                    "description": "Recent articles returned for the requested topic.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "source": {"type": "string"},
+                            "published_at": {"type": "string"},
+                            "url": {"type": "string"},
+                        },
+                        "required": ["title", "source", "published_at", "url"],
+                        "additionalProperties": False,
+                    },
+                },
+                "topic": {"type": "string", "description": "Topic that was queried."},
+            },
+            "required": ["summary", "articles", "topic"],
+            "additionalProperties": False,
+        },
+        usage_hints=["Use this tool when the owner wants a recent public-news briefing before making a decision."],
+        result_hints=["Lead with the digest summary, then cite the most relevant article titles and sources."],
+        error_hints=["If the topic is too broad, ask for a narrower company, product, or sector focus."],
+    )
+
+
+async def main() -> None:
+    harness = AppTestHarness(NewsDigestApp())
+    ok, issues = validate_tool_manual(build_tool_manual())
+    report = score_tool_manual_offline(build_tool_manual())
+    dry_run = await harness.dry_run(task_type="news_digest")
+    print("tool_manual_valid:", ok, len(issues))
+    print("quality_grade:", report.grade, report.overall_score)
+    print("manifest_issues:", harness.validate_manifest())
+    print("dry_run:", dry_run.success)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/wallet_balance.py
+++ b/examples/wallet_balance.py
@@ -1,0 +1,164 @@
+"""Example: read wallet balances through a connected wallet account.
+
+API: wallet balance lookup across Ethereum or Polygon.
+Intended user: treasury or portfolio monitoring agents.
+Connected account: metamask.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    ExecutionContext,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    StubProvider,
+    ToolManual,
+    ToolManualPermissionClass,
+    score_tool_manual_offline,
+    validate_tool_manual,
+)
+
+
+CHAIN_DEFAULTS: dict[str, tuple[str, float, float]] = {
+    "ethereum": ("ETH", 1.2345, 3200.0),
+    "polygon": ("MATIC", 542.1, 0.75),
+}
+
+TOKEN_PRICES: dict[str, float] = {
+    "ETH": 3200.0,
+    "MATIC": 0.75,
+    "USDC": 1.0,
+}
+
+
+class WalletBalanceApp(AppAdapter):
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="wallet-balance",
+            name="Wallet Balance",
+            job_to_be_done="Read the owner's connected wallet balance on Ethereum or Polygon without moving funds.",
+            category=AppCategory.FINANCE,
+            permission_class=PermissionClass.READ_ONLY,
+            approval_mode=ApprovalMode.AUTO,
+            dry_run_supported=True,
+            required_connected_accounts=["metamask"],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="Read native-token or ERC-20 balances from a connected MetaMask wallet.",
+            example_prompts=["Check my Polygon wallet balance."],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+        chain = str(ctx.input_params.get("chain") or "ethereum").lower()
+        default_symbol, default_balance, default_price = CHAIN_DEFAULTS.get(chain, CHAIN_DEFAULTS["ethereum"])
+        token_symbol = str(ctx.input_params.get("token_symbol") or default_symbol).upper()
+        if token_symbol == default_symbol:
+            balance = default_balance
+            usd_price = default_price
+        else:
+            balance = 250.0 if token_symbol == "USDC" else 18.75
+            usd_price = TOKEN_PRICES.get(token_symbol, 1.25)
+        usd_equivalent = round(balance * usd_price, 2)
+        provider_key = (
+            ctx.connected_accounts.get("metamask").provider_key
+            if ctx.connected_accounts.get("metamask")
+            else "metamask"
+        )
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": f"{chain.title()} wallet holds {balance:.4f} {token_symbol} (~USD {usd_equivalent:.2f}).",
+                "chain": chain,
+                "token_symbol": token_symbol,
+                "balance": balance,
+                "usd_equivalent": usd_equivalent,
+                "provider": provider_key,
+            },
+        )
+
+    def supported_task_types(self) -> list[str]:
+        return ["wallet_balance", "check_wallet_balance"]
+
+
+def build_stubs() -> dict[str, StubProvider]:
+    return {"metamask": StubProvider("metamask")}
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="wallet_balance",
+        job_to_be_done="Read the owner's connected MetaMask wallet balance on Ethereum or Polygon without creating any blockchain side effects.",
+        summary_for_model="Returns native-token or ERC-20 wallet balances plus a USD equivalent for a connected MetaMask wallet on Ethereum or Polygon.",
+        trigger_conditions=[
+            "owner asks to check a wallet balance on Ethereum or Polygon",
+            "agent needs a read-only on-chain balance snapshot before planning a payment or treasury action",
+            "request is to inspect holdings rather than transfer funds or approve a transaction",
+        ],
+        do_not_use_when=[
+            "the request is to sign, send, swap, or bridge assets",
+            "the owner has not connected a MetaMask wallet for the target chain",
+        ],
+        permission_class=ToolManualPermissionClass.READ_ONLY,
+        dry_run_supported=True,
+        requires_connected_accounts=["metamask"],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "chain": {
+                    "type": "string",
+                    "description": "Target chain to inspect.",
+                    "enum": ["ethereum", "polygon"],
+                },
+                "token_symbol": {
+                    "type": "string",
+                    "description": "Optional token symbol; omit to read the native asset.",
+                    "default": "native",
+                },
+            },
+            "required": ["chain"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line balance summary."},
+                "chain": {"type": "string", "description": "Chain that was queried."},
+                "token_symbol": {"type": "string", "description": "Token that was priced."},
+                "balance": {"type": "number", "description": "Token balance on the requested chain."},
+                "usd_equivalent": {"type": "number", "description": "Approximate USD equivalent."},
+            },
+            "required": ["summary", "chain", "token_symbol", "balance", "usd_equivalent"],
+            "additionalProperties": False,
+        },
+        usage_hints=["Use this tool before payment planning when the owner needs a read-only wallet balance snapshot."],
+        result_hints=["State the chain, token, and USD equivalent in the first sentence so the owner can sanity-check the result quickly."],
+        error_hints=["If the owner has not connected MetaMask for the requested chain, ask them to connect the wallet before retrying."],
+    )
+
+
+async def main() -> None:
+    harness = AppTestHarness(WalletBalanceApp(), stubs=build_stubs())
+    ok, issues = validate_tool_manual(build_tool_manual())
+    report = score_tool_manual_offline(build_tool_manual())
+    dry_run = await harness.dry_run(task_type="wallet_balance", input_params={"chain": "polygon"})
+    print("tool_manual_valid:", ok, len(issues))
+    print("quality_grade:", report.grade, report.overall_score)
+    print("manifest_issues:", harness.validate_manifest())
+    print("dry_run:", dry_run.success)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.3.1"
+version = "0.4.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.4.0-dev.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.4.0-dev.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.4.0-dev.0",
+  "version": "0.4.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "type": "module",

--- a/siglume-api-sdk-ts/test/examples.test.ts
+++ b/siglume-api-sdk-ts/test/examples.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AppTestHarness,
+  PermissionClass,
+  score_tool_manual_offline,
+  validate_tool_manual,
+} from "../src/index";
+import { buildStubs as buildCrmStubs, buildToolManual as buildCrmToolManual, CrmSyncApp, runCrmSyncExample } from "../../examples-ts/crm_sync";
+import { buildToolManual as buildNewsDigestToolManual, NewsDigestApp, runNewsDigestExample } from "../../examples-ts/news_digest";
+import {
+  buildStubs as buildWalletStubs,
+  buildToolManual as buildWalletToolManual,
+  runWalletBalanceExample,
+  WalletBalanceApp,
+} from "../../examples-ts/wallet_balance";
+
+const EXAMPLES = [
+  {
+    name: "crm_sync",
+    permissionClass: PermissionClass.ACTION,
+    createHarness: () => new AppTestHarness(new CrmSyncApp(), buildCrmStubs()),
+    createManual: () => buildCrmToolManual(),
+    taskType: "sync_crm_lead",
+  },
+  {
+    name: "news_digest",
+    permissionClass: PermissionClass.READ_ONLY,
+    createHarness: () => new AppTestHarness(new NewsDigestApp()),
+    createManual: () => buildNewsDigestToolManual(),
+    taskType: "news_digest",
+  },
+  {
+    name: "wallet_balance",
+    permissionClass: PermissionClass.READ_ONLY,
+    createHarness: () => new AppTestHarness(new WalletBalanceApp(), buildWalletStubs()),
+    createManual: () => buildWalletToolManual(),
+    taskType: "wallet_balance",
+  },
+] as const;
+
+describe("TypeScript example suite", () => {
+  it.each(EXAMPLES)("$name validates and clears the publish bar", async ({ createManual }) => {
+    const manual = createManual();
+    const [ok, issues] = validate_tool_manual(manual);
+    const report = score_tool_manual_offline(manual);
+
+    expect(ok).toBe(true);
+    expect(issues).toEqual([]);
+    expect(["A", "B"]).toContain(report.grade);
+  });
+
+  it.each(EXAMPLES)("$name runs through AppTestHarness", async ({ createHarness, permissionClass, taskType }) => {
+    const harness = createHarness();
+
+    expect(await harness.validate_manifest()).toEqual([]);
+
+    const dryRun = await harness.dry_run(taskType);
+    expect(dryRun.success).toBe(true);
+
+    if (permissionClass === PermissionClass.ACTION) {
+      const action = await harness.execute_action(taskType);
+      expect(action.success).toBe(true);
+      expect(harness.validate_receipt(action)).toEqual([]);
+    }
+  });
+
+  it("returns stable summary lines for crm_sync", async () => {
+    const lines = await runCrmSyncExample();
+
+    expect(lines[0]).toBe("tool_manual_valid: true 0");
+    expect(lines[1]).toMatch(/^quality_grade: [AB] \d+$/);
+    expect(lines[3]).toBe("dry_run: true");
+    expect(lines[4]).toBe("action: true");
+  });
+
+  it("returns stable summary lines for news_digest", async () => {
+    const lines = await runNewsDigestExample();
+
+    expect(lines[0]).toBe("tool_manual_valid: true 0");
+    expect(lines[1]).toMatch(/^quality_grade: [AB] \d+$/);
+    expect(lines[3]).toBe("dry_run: true");
+  });
+
+  it("returns stable summary lines for wallet_balance", async () => {
+    const lines = await runWalletBalanceExample();
+
+    expect(lines[0]).toBe("tool_manual_valid: true 0");
+    expect(lines[1]).toMatch(/^quality_grade: [AB] \d+$/);
+    expect(lines[3]).toBe("dry_run: true");
+  });
+});

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,13 +13,22 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from siglume_api_sdk import AppAdapter, AppTestHarness, PermissionClass, validate_tool_manual  # noqa: E402
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppTestHarness,
+    PermissionClass,
+    score_tool_manual_offline,
+    validate_tool_manual,
+)
 
 
 EXAMPLE_SPECS = [
     ("calendar_sync.py", PermissionClass.ACTION),
+    ("crm_sync.py", PermissionClass.ACTION),
     ("email_sender.py", PermissionClass.ACTION),
+    ("news_digest.py", PermissionClass.READ_ONLY),
     ("translation_hub.py", PermissionClass.READ_ONLY),
+    ("wallet_balance.py", PermissionClass.READ_ONLY),
     ("payment_quote.py", PermissionClass.PAYMENT),
 ]
 
@@ -34,8 +43,7 @@ def _load_module(example_name: str):
     return module
 
 
-async def _exercise_example(app: AppAdapter, permission_class: PermissionClass) -> None:
-    harness = AppTestHarness(app)
+async def _exercise_example(harness: AppTestHarness, app: AppAdapter, permission_class: PermissionClass) -> None:
     assert not harness.validate_manifest()
 
     dry_run = await harness.dry_run(task_type=app.supported_task_types()[0])
@@ -44,12 +52,14 @@ async def _exercise_example(app: AppAdapter, permission_class: PermissionClass) 
     if permission_class in (PermissionClass.ACTION, PermissionClass.PAYMENT):
         action = await harness.execute_action(task_type=app.supported_task_types()[0])
         assert action.success
+        assert not harness.validate_receipt(action)
 
     if permission_class == PermissionClass.PAYMENT:
         quote = await harness.execute_quote(task_type=app.supported_task_types()[0], input_params={"amount_usd": 9.5})
         payment = await harness.execute_payment(task_type=app.supported_task_types()[-1], input_params={"amount_usd": 9.5})
         assert quote.success
         assert payment.success
+        assert not harness.validate_receipt(payment)
 
 
 @pytest.mark.parametrize(("example_name", "permission_class"), EXAMPLE_SPECS)
@@ -62,12 +72,16 @@ def test_examples_validate_and_run(example_name: str, permission_class: Permissi
     ]
     assert len(subclasses) == 1
     app = subclasses[0]()
+    stubs = module.build_stubs() if hasattr(module, "build_stubs") else {}
+    harness = AppTestHarness(app, stubs=stubs)
 
     manual = module.build_tool_manual()
     ok, issues = validate_tool_manual(manual)
     assert ok, f"{example_name} tool manual invalid: {issues}"
+    report = score_tool_manual_offline(manual)
+    assert report.grade in {"A", "B"}, f"{example_name} tool manual fell below publish bar: {report.grade}"
 
-    asyncio.run(_exercise_example(app, permission_class))
+    asyncio.run(_exercise_example(harness, app, permission_class))
 
 
 def test_generate_tool_manual_example_requires_explicit_llm_api_key(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add the remaining v0.4 example set: `crm_sync`, `news_digest`, and `wallet_balance`
- add matching TypeScript examples under `examples-ts/` plus example smoke tests
- bump release-prep metadata for `0.4.0` and add `RELEASE_NOTES_v0.4.0.md`

## Test plan
- [x] `py -3.11 -m ruff check .`
- [x] `py -3.11 -m pytest` -> 121 passed
- [x] `py -3.11 scripts/contract_sync.py`
- [x] `npm run lint`
- [x] `npm test` -> 144 passed
- [x] `npm run build`
- [x] `py -3.11 examples/crm_sync.py`
- [x] `py -3.11 examples/news_digest.py`
- [x] `py -3.11 examples/wallet_balance.py`
- [x] `npx jiti ..\examples-ts\crm_sync.ts`
- [x] `npx jiti ..\examples-ts\news_digest.ts`
- [x] `npx jiti ..\examples-ts\wallet_balance.ts`

## Review
- [x] reviewer agent (Sagan): no critical / warning findings