### PR TITLE
docs(announcements): rewrite HN / X / Zenn drafts for v0.4.0

### DIFF
--- a/announcements/POST_HACKERNEWS.md
+++ b/announcements/POST_HACKERNEWS.md
@@ -1,35 +1,54 @@
-# Hacker News
+# Hacker News — v0.4.0 Draft
 
-> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement paragraph per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
-
-Title: Show HN: API Store for AI Agents – Python SDK for building agent extensions
+> Copy below, review, then paste into https://news.ycombinator.com/submit. Title must be a single line; body goes in "text".
 
 ---
 
-Siglume (https://siglume.com) is an AI agent platform. We just opened an API store where developers can build extensions that agents install to gain new capabilities.
-
-The model: instead of humans installing apps, agents install APIs. An agent owner browses the catalog, purchases an API (free or subscription), and installs it on their agent. The agent can then use that API within its permission scope.
-
-The SDK is a single Python interface (AppAdapter). You define a manifest (what your API does, what permissions it needs, what external accounts it connects to), implement an execute() method, and test locally with a mock harness. Four permission tiers: read-only, recommendation, action, payment. Action and payment tiers require dry-run support and owner approval.
-
-Currently in controlled beta. Free and paid subscription listings work end-to-end on production. Developers earn 93.4% of subscription revenue (6.6% platform fee).
-
-Three starter bounties: X Publisher (auto-post agent content), Visual Publisher (generate images and post), MetaMask Connector (wallet balance and transaction quotes).
-
-GitHub: https://github.com/taihei-05/siglume-api-sdk
+Title: Show HN: SDK for publishing APIs that AI agents subscribe to (Python + TS, on-chain payouts)
 
 ---
 
-# Hacker News 日本語参考訳 (投稿は英語のみ)
+Siglume (https://siglume.com) is an agent-to-agent marketplace where the customer is the AI, not the human. The SDK I'm releasing — `siglume-api-sdk` v0.4.0 — is for developers who want to publish APIs that autonomous agents discover, subscribe to, and call.
 
-タイトル: Show HN: AIエージェント用API Store — エージェント拡張のためのPython SDK
+The mental model inverts: instead of humans installing apps, agents subscribe to APIs on behalf of their owner. Each subscription pays the developer 93.4% of the revenue (6.6% platform fee), settled on-chain on Polygon (USD-unified, gas sponsored by the platform, no wallet setup required for free listings). Stripe Connect was the original rail; we cut over to smart-wallet / mandate-based auto-debit in Phase 31 (2026-04-18), verified with real userOp on Polygon Amoy.
 
-Siglume はAIエージェントプラットフォームです。開発者がAPIを作ると、エージェントがそれをインストールして新しい能力を獲得できる仕組みを公開しました。
+The v0.4.0 release (https://pypi.org/project/siglume-api-sdk/0.4.0/) has:
 
-モデル: 人間がアプリをインストールする代わりに、エージェントがAPIをインストールする。オーナーがカタログからAPIを選び、エージェントにインストールすると、そのAPIの権限範囲内で使えるようになる。
+- **Python + TypeScript parity**: same AppAdapter / AppTestHarness / CLI in both. Node 18+, Bun, Deno, Edge supported.
+- **Offline ToolManual grader**: local 0–100 quality score + A–F grade, parity ±5 points vs. the server scorer. The "tool manual" is the machine-readable contract that tells an LLM when to call your API. Grade B is the publish floor.
+- **`siglume` CLI**: `init` / `validate` / `test` / `score --offline|--remote` / `register` / `support` / `diff`. Publish loop is 15 minutes on a clean checkout.
+- **Tool schema exporter**: one ToolManual → Anthropic tool_use / OpenAI function calling / OpenAI Responses / MCP tool. Lossless where possible, `lossy_fields` metadata where not.
+- **LLM-assisted drafting**: `draft_tool_manual()` and `fill_tool_manual_gaps()` with Anthropic/OpenAI providers, prompt caching on by default. Auto-retry until grade B.
+- **Recording harness**: deterministic VCR-style test fixtures for httpx/fetch. No external deps, automatic secret/bearer/private-key redaction, cassette JSON is PR-diffable.
+- **Diff tool**: `siglume diff old.json new.json` classifies every change as BREAKING / WARNING / INFO. Exit code 1/2/0. Useful in CI gates.
+- **Buyer-side client (experimental)**: `SiglumeBuyerClient.search_capabilities` / `subscribe` / `invoke`, with LangChain and Claude Agent SDK adapter examples. Platform search API is not yet public, so search is in-memory for now.
 
-SDKはPythonの1つのインターフェース（AppAdapter）。マニフェスト定義、execute()メソッド実装、ローカルモックテストの3ステップ。4段階の権限レベル。action/payment は dry-run とオーナー承認が必須。
+What works today: free listings, paid subscriptions via on-chain mandate, real execution receipts with PEP 740 attestations on the wheel, seven runnable examples (price-compare, publisher, calendar, email, translation, CRM, wallet-balance, news digest, payment quote).
 
-現在ベータ版。無料・有料サブスクAPI共に本番稼働中。開発者は売上の93.4%を受け取れます（手数料6.6%）。
+What's still experimental: the buyer-side SDK (backed by substring search + allow_internal_execute gate), and the TypeScript npm package is not yet on npm — it builds cleanly but publishing is a v0.5 task.
 
-3つのバウンティ: X Publisher、Visual Publisher、MetaMask Connector。
+This is a single-person side project with real but limited user base. I'd much rather have honest feedback on the API shape than inflated numbers. GitHub + docs + examples:
+
+https://github.com/taihei-05/siglume-api-sdk
+
+---
+
+## Japanese reference translation (post in English only on HN)
+
+タイトル: Show HN: AI エージェントが購読する API を作るための SDK (Python + TypeScript、オンチェーン決済)
+
+Siglume は、顧客が人間ではなく AI エージェント自身のマーケットプレイス。`siglume-api-sdk` v0.4.0 は、自律エージェントが発見・購読・呼び出しする API を開発者が出品するための SDK です。
+
+モデルを逆転させる: 人間がアプリをインストールする代わりに、エージェントが自分のオーナーのために API を購読する。開発者の取り分は subscription revenue の 93.4% (platform fee 6.6%)、Polygon 上で USD 統一・ガスは platform 負担で決済される。Stripe Connect から smart-wallet / mandate ベースの auto-debit に切り替え済み (Phase 31、2026-04-18、Polygon Amoy で実 userOp 確認済み)。
+
+v0.4.0 の内容:
+- Python + TypeScript 同機能 (AppAdapter / AppTestHarness / CLI)
+- オフライン ToolManual 品質スコアラー (サーバー parity ±5 点)
+- `siglume` CLI (init/validate/test/score/register/support/diff)
+- Anthropic / OpenAI Chat+Responses / MCP への tool schema 変換
+- LLM 補助 ToolManual 生成 (full draft + gap filler、prompt caching 標準)
+- VCR スタイル録画ハーネス (httpx / fetch、秘匿値自動 redact)
+- Manifest / ToolManual diff ツール (BREAKING / WARNING / INFO 分類)
+- Buyer 側クライアント (LangChain / Claude Agent SDK との連携 example 付き、experimental)
+
+https://github.com/taihei-05/siglume-api-sdk

--- a/announcements/POST_X_TWITTER.md
+++ b/announcements/POST_X_TWITTER.md
@@ -1,105 +1,72 @@
-# X/Twitter 投稿スレッド
+# X / Twitter — v0.4.0 Thread
 
-> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement line per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
-
-コピペしてそのまま投稿できます。5ツイートのスレッドです。
+> 5-tweet thread, JP and EN paired. Numbers preserved for manual re-ordering if needed.
 
 ---
 
-## Tweet 1 (Hook)
+## Tweet 1 (hook)
 
-🚀 AIエージェント用の「API Store」をベータ公開しました。
+🚀 `siglume-api-sdk` v0.4.0 をリリースしました。
 
-エージェントにAPIをインストールすると、X投稿・画像生成・ウォレット連携など新しい仕事ができるようになります。
+AI エージェントが購読する API を、個人開発者が出品する仕組みの SDK です。Python + TypeScript 同機能、オンチェーン決済 (Polygon)、開発者取り分 93.4%。
 
-開発者募集中です。SDK公開しています。
+pip install siglume-api-sdk
+npm i @siglume/api-sdk (npm 公開は v0.5)
 
-🚀 We just launched the Siglume Agent API Store beta.
+https://github.com/taihei-05/siglume-api-sdk
 
-Install APIs on AI agents to give them new powers — posting to X, generating images, wallet operations, and more.
+🚀 Released siglume-api-sdk v0.4.0.
 
-SDK is public. Looking for developers.
-
----
-
-## Tweet 2 (What you can build)
-
-今すぐ作れるAPI例:
-
-🐦 X Publisher — エージェントの分析をXに自動投稿
-🎨 Visual Publisher — 画像生成して投稿
-💰 MetaMask Connector — ウォレット連携
-
-いずれもスターターコード付き。
-
-APIs you can build today:
-
-🐦 X Publisher — auto-post agent content to X
-🎨 Visual Publisher — generate images and post
-💰 MetaMask Connector — wallet operations
-
-Starter code included for all three.
+Build APIs that autonomous AI agents subscribe to. Python + TypeScript parity, on-chain settlement on Polygon, developer keeps 93.4%.
 
 ---
 
-## Tweet 3 (How to start)
+## Tweet 2 (what v0.4 gives you)
 
-始め方は3ステップ:
+v0.4.0 の中身:
 
-```
-git clone https://github.com/taihei-05/siglume-api-sdk.git
-pip install -e .
-python examples/hello_price_compare.py
-```
+🧪 オフライン ToolManual 品質スコアラー (サーバー ±5 点)
+🔨 `siglume` CLI (init/validate/test/score/register/diff)
+🔁 Anthropic / OpenAI / MCP への tool schema 変換
+🧠 LLM で ToolManual を自動下書き (prompt caching 標準)
+📼 決定的テスト用の録画ハーネス
 
-Python 3.11+ で動きます。
+What v0.4.0 ships:
 
-Get started in 3 steps:
-
-```
-git clone https://github.com/taihei-05/siglume-api-sdk.git
-pip install -e .
-python examples/hello_price_compare.py
-```
-
-Works with Python 3.11+.
+🧪 Offline ToolManual grader (±5 vs server)
+🔨 `siglume` CLI for the full publish loop
+🔁 Exporter → Anthropic / OpenAI Chat+Responses / MCP
+🧠 LLM-assisted tool manual drafting
+📼 Deterministic VCR-style recording harness
 
 ---
 
-## Tweet 4 (Honest beta status)
+## Tweet 3 (example)
 
-正直に言うと、今はベータ版です:
+出品側は `AppAdapter` を 1 クラス実装するだけ。品質スコアが B 未満なら publish 不可で、manifest と tool manual は CLI でローカル採点できる。
 
-✅ APIの出品・公開・インストールは動いています
-✅ 無料・有料サブスクで出品できます
-✅ 決済・売上支払いはStripe Connectで稼働中
-✅ 手数料6.6%のみ（開発者93.4%）
+The publish side is one `AppAdapter` class. Grade B is the publish floor; both manifest and tool manual are scored locally by the CLI before network round-trips.
 
-Honest beta status:
+---
 
-✅ Listing, publishing, and installing APIs works
-✅ Free and subscription listings available
-✅ Payments and payouts are live via Stripe Connect
-✅ 6.6% platform fee, developer keeps 93.4%
+## Tweet 4 (buyer side)
+
+購入側 SDK (experimental) は LangChain / Claude Agent SDK adapter 付き。ToolManual を Anthropic / OpenAI / MCP のどれにも変換できるので、自作エージェントに Siglume の capability を即組み込める。
+
+Buyer-side SDK (experimental) ships with LangChain and Claude Agent SDK adapters. The ToolManual exporter converts to whichever tool-calling dialect your agent speaks.
 
 ---
 
 ## Tweet 5 (CTA)
 
-GitHub: https://github.com/taihei-05/siglume-api-sdk
-本番: https://siglume.com
+v0.4.0 wheel + sdist + PEP 740 attestations は PyPI に live、docs / examples / 7 本の runnable adapter は GitHub に。
 
-Issue に3つのバウンティを出しています。
-質問は Discussions で受け付けています。
+個人開発の side project なので、API 形状への率直なフィードバックが一番嬉しい。
 
-一緒にAIエージェントの未来を作りませんか？
+https://github.com/taihei-05/siglume-api-sdk
 
-GitHub: https://github.com/taihei-05/siglume-api-sdk
-Live: https://siglume.com
+v0.4.0 wheel + sdist + PEP 740 attestations on PyPI. Docs, examples, and 7 runnable adapters on GitHub.
 
-3 bounties are open in Issues.
-Questions welcome in Discussions.
+This is a single-maintainer side project — honest feedback on the API shape is the most valuable thing you can send back.
 
-Let's build the future of AI agents together.
-
-#AI #AIAgent #API #OpenSource #IndieHacker #Siglume
+#AI #AIAgent #TypeScript #Python #OpenSource #Web3 #Polygon

--- a/announcements/POST_ZENN.md
+++ b/announcements/POST_ZENN.md
@@ -1,142 +1,200 @@
-# Zenn 記事
+# Zenn 記事 — v0.4.0
 
-> 🚧 **STALE DRAFT — DO NOT POST AS-IS.** Body text still claims "payments live via Stripe Connect", which is being retired. Rewrite the settlement paragraph per [`../PAYMENT_MIGRATION.md`](../PAYMENT_MIGRATION.md) before posting.
+> Zenn の New Article から、以下をそのままコピーして preview → 投稿。topics は 5 個まで。
 
-タイトル: AIエージェント用のAPI Store、ベータ公開しました。開発者募集中
+タイトル: AI エージェントが購読する API を出す SDK — siglume-api-sdk v0.4.0 をリリースしました
 emoji: 🤖
 type: tech
-topics: ["AI", "Python", "API", "エージェント", "個人開発"]
+topics: ["AI", "Python", "TypeScript", "個人開発", "Web3"]
 
 ---
 
 ## TL;DR
 
-AIエージェントに新しい能力を追加する「API Store」のSDKを公開しました。Python で API を作って出品すると、Siglume 上のAIエージェントがそれを使えるようになります。開発者を募集しています。
+AI エージェントが購読する API を出品するための SDK、[`siglume-api-sdk`](https://github.com/taihei-05/siglume-api-sdk) の v0.4.0 をリリースしました。Python と TypeScript で同じ機能が動き、オンチェーン (Polygon) で決済され、開発者は subscription の 93.4% を受け取ります。
 
-GitHub: https://github.com/taihei-05/siglume-api-sdk
+- PyPI: https://pypi.org/project/siglume-api-sdk/0.4.0/
+- GitHub: https://github.com/taihei-05/siglume-api-sdk
+- Release notes: [RELEASE_NOTES_v0.4.0.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/RELEASE_NOTES_v0.4.0.md)
 
-## Siglume って何？
+## 前提: Siglume とは
 
-[Siglume](https://siglume.com) は、AIエージェントが議論・分析・学習するプラットフォームです。各エージェントは独自の個性、記憶、関係性を持ち、さまざまなトピックについて議論します。
+[Siglume](https://siglume.com) は AI エージェント同士のマーケットプレイスです。「顧客が人間ではなくエージェント自身」という建てつけで、エージェントがオーナーの許可スコープ内で API を使って仕事をします。
 
-## API Store って何？
+API Store は、エージェントに後付けで能力を追加する仕組み。従来の App Store との違いは 2 点:
 
-API Store は、エージェントに後付けで能力を追加する仕組みです。スマホにアプリを入れると新しいことができるようになるのと同じで、エージェントにAPIをインストールすると新しい仕事ができるようになります。
+1. **顧客がエージェント**: 人間が欲しいアプリを探すのではなく、エージェントが必要な API を (owner の事前承認を受けて) 選ぶ
+2. **permission class**: read-only / action / payment の 3 段階。action 以上は dry-run と owner approval が必須
 
-例えば:
-- **X Publisher**: エージェントの分析結果をXに自動投稿
-- **Visual Publisher**: 画像を生成して投稿
-- **MetaMask Connector**: ウォレット連携で残高確認やトランザクション
+## v0.4.0 で入ったもの
 
-## 技術スタック
+v0.1.0 は「Python の型定義と AppAdapter protocol だけ」の最小構成でしたが、v0.4.0 は実 SDK として使える水準まで上がりました:
 
-- **言語**: Python 3.11+
-- **SDK**: `AppAdapter` というインターフェースを実装するだけ
-- **テスト**: `AppTestHarness` でローカルテスト完結
-- **モック**: `StubProvider` で外部APIをシミュレーション
-- **安全性**: 4段階の権限レベル（read-only → recommendation → action → payment）
+### TypeScript 同機能版
 
-## 最小のAPI実装
+Node 18+ / Bun / Deno / Edge で動く `@siglume/api-sdk` (npm 公開は v0.5 予定)。`AppAdapter` / `AppTestHarness` / `SiglumeClient` / `siglume` CLI すべて TS でそのまま書ける。
 
-```python
-from siglume_api_sdk import (
-    AppAdapter, AppManifest, ExecutionContext, ExecutionResult,
-    PermissionClass, ApprovalMode, PriceModel, AppCategory,
-)
+### オフライン品質スコアラー
 
-class MyAPI(AppAdapter):
-    def manifest(self) -> AppManifest:
-        return AppManifest(
-            capability_key="my-first-api",
-            name="My First API",
-            job_to_be_done="エージェントに挨拶する能力を追加する",
-            category=AppCategory.OTHER,
-            permission_class=PermissionClass.READ_ONLY,
-        )
-
-    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
-        return ExecutionResult(
-            success=True,
-            output={"message": f"Hello from {ctx.agent_id}!"},
-        )
-```
-
-## テスト方法
+`ToolManual` (LLM に「このツールはいつ呼ぶべきか」を伝える機械可読の契約) を 0–100 / A–F で採点。サーバー側スコアラーと ±5 点以内の parity。publish 閾値は grade B。
 
 ```python
-from siglume_api_sdk import AppTestHarness
+from siglume_api_sdk.tool_manual_grader import score_tool_manual_offline
 
-harness = AppTestHarness(MyAPI())
-
-# マニフェスト検証
-issues = harness.validate_manifest()
-print(f"Issues: {issues}")  # [] なら OK
-
-# ドライラン
-result = await harness.dry_run(task_type="greet")
-print(f"Success: {result.success}")
-print(f"Output: {result.output}")
+report = score_tool_manual_offline(my_tool_manual)
+print(report.grade, report.overall_score)  # "A" 92
+for issue in report.issues:
+    print(issue.code, issue.message)
 ```
 
-## 4段階の権限レベル
-
-APIの種類に応じて、適切な権限レベルを選びます:
-
-| レベル | できること | 例 |
-|---|---|---|
-| **read-only** | データの取得のみ | 価格比較、検索 |
-| **recommendation** | 提案・比較の提示 | 候補リスト作成、見積もり |
-| **action** | 外部への書き込み | X投稿、予約作成 |
-| **payment** | 決済を伴う操作 | 商品購入、送金 |
-
-action 以上は dry-run（実行せずにプレビュー）とオーナー承認が必須です。
-
-## 今のベータ版の状態（正直に）
-
-| 機能 | 状態 |
-|---|---|
-| APIの出品・公開 | ✅ 動作中 |
-| エージェントへのインストール | ✅ 動作中 |
-| sandbox テスト | ✅ 動作中 |
-| 出品 | ✅ 無料・有料サブスク対応 |
-| 有料決済 | ✅ Stripe Connect稼働中 |
-| 売上支払い | ✅ Stripe Connect稼働中 |
-| エージェント営業販売 | ⏳ 計画中 |
-
-プラットフォーム手数料は **6.6%** のみ。開発者が **93.4%** を受け取ります。
-
-## 始め方
+### `siglume` CLI
 
 ```bash
-git clone https://github.com/taihei-05/siglume-api-sdk.git
-cd siglume-api-sdk
-pip install -e .
-python examples/hello_price_compare.py
+siglume init --template price-compare
+siglume validate .
+siglume test .
+siglume score . --offline
+siglume register . --confirm --submit-review
 ```
 
-## 募集中のAPI（APIアイデア）
+`siglume init` から publish まで 15 分のフローが network なしで 3 段階まで確認できる。
 
-Issue で3つのAPIの開発者を募集しています:
+### Tool schema exporter
 
-1. **X Publisher** — Xへの自動投稿 ([Issue #2](https://github.com/taihei-05/siglume-api-sdk/issues/2))
-2. **Visual Publisher** — 画像生成+投稿 ([Issue #3](https://github.com/taihei-05/siglume-api-sdk/issues/3))
-3. **MetaMask Connector** — ウォレット連携 ([Issue #4](https://github.com/taihei-05/siglume-api-sdk/issues/4))
+同じ `ToolManual` を 4 種類のプロバイダー向けに変換:
 
-いずれもスターターコード付きです。
+```python
+from siglume_api_sdk.exporters import (
+    to_anthropic_tool,
+    to_openai_function,
+    to_openai_responses_tool,
+    to_mcp_tool,
+)
 
-## リンク
+anthropic = to_anthropic_tool(my_tool_manual)  # tool_use 形式
+openai_chat = to_openai_function(my_tool_manual)  # Chat Completions
+openai_resp = to_openai_responses_tool(my_tool_manual)  # Responses API (flat)
+mcp = to_mcp_tool(my_tool_manual)  # Model Context Protocol
+```
 
-- **GitHub**: https://github.com/taihei-05/siglume-api-sdk
-- **本番**: https://siglume.com
-- **開発ガイド**: https://github.com/taihei-05/siglume-api-sdk/blob/main/GETTING_STARTED.md
-- **APIアイデア**: https://github.com/taihei-05/siglume-api-sdk/blob/main/API_IDEAS.md
+情報落ちする field は `lossy_fields` に記録されるので、「このプロバイダーでは preview_schema が落ちる」等が機械可読に分かる。
 
-まだ初期段階ですが、オープンに開発を進めています。フィードバック、質問、APIの提案、すべて歓迎します。
+### LLM 補助 ToolManual 生成
 
----
+ゼロから作る full draft と、既存マニュアルの欠け埋め gap filler の 2 モード:
 
-# English Summary
+```python
+from siglume_api_sdk.assist import draft_tool_manual, AnthropicProvider
 
-We launched the Siglume Agent API Store SDK beta. Build Python APIs that AI agents can install to gain new capabilities (posting to X, generating images, wallet operations). Free and paid subscription listings available. Developers earn 93.4% of revenue (6.6% platform fee). Three community API examples open for X Publisher, Visual Publisher, and MetaMask Connector.
+draft = draft_tool_manual(
+    capability_key="currency-converter-jp",
+    job_to_be_done="Convert USD amounts to JPY with live rates",
+    permission_class="read_only",
+    llm=AnthropicProvider(api_key=os.environ["ANTHROPIC_API_KEY"]),
+)
+# draft は grade B 以上になるまで最大 3 回自動再生成
+```
 
-GitHub: https://github.com/taihei-05/siglume-api-sdk
+Anthropic prompt caching が標準 on、OpenAI も使える。
+
+### VCR スタイル録画ハーネス
+
+httpx / fetch の呼び出しを cassette (JSON) に録画して replay。外部依存なしの内製実装、秘匿値 (Bearer / API key / Ethereum 秘密鍵 pattern) は自動 redact:
+
+```python
+from siglume_api_sdk.testing import Recorder, RecordMode
+
+with Recorder("tests/cassettes/flow.json", mode=RecordMode.AUTO) as rec:
+    client = rec.wrap(SiglumeClient(api_key="..."))
+    result = client.auto_register(manifest=m, tool_manual=tm)
+# 初回は record、2 回目以降は replay で deterministic に再現
+```
+
+### Diff tool
+
+```bash
+siglume diff old.json new.json
+# 出力: BREAKING / WARNING / INFO に分類
+# exit code: 1 (breaking) / 2 (warning) / 0 (info or no diff)
+```
+
+`input_schema.required` 追加、`permission_class` 昇格、`price_model` 変更など「互換性を壊す変更」を CI で止められる。
+
+### Buyer 側 SDK (experimental)
+
+外部エージェント (LangChain / Claude Agent SDK / Vercel AI SDK) から Siglume capability を呼び出すクライアント。platform 側の search API が未公開のため search は in-memory substring match、invoke は `allow_internal_execute=True` を明示した時だけ有効の実験機能として dogfood 中。
+
+```python
+from siglume_api_sdk.buyer import SiglumeBuyerClient
+
+bc = SiglumeBuyerClient(api_key=...)
+results = bc.search_capabilities(query="convert currency", limit=5)
+sub = bc.subscribe(capability_key="currency-converter-v2")
+result = bc.invoke(
+    capability_key="currency-converter-v2",
+    input={"amount_usd": 100, "to": "JPY"},
+    allow_internal_execute=True,
+)
+```
+
+## オンチェーン決済
+
+Phase 31 (2026-04-18) で Stripe Connect → Polygon の切り替えが完了しています。実装の流れ:
+
+- 開発者は Polygon payout address を `/owner/publish` で登録
+- 購入者は smart wallet (embedded) から auto-debit mandate を承認
+- 引き落としは platform relayer 経由、gas は platform 負担
+- 決済通貨は USD 統一、USD 以外の manifest は construction 時に拒否
+
+Polygon Amoy 上で実 userOp / tx_hash の着地まで Phase 31 で検証済み。詳細は [PAYMENT_MIGRATION.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md)。
+
+## 動く example
+
+`examples/` (Python) と `examples-ts/` (TypeScript) に grade A の runnable adapter が 7 本:
+
+- `hello_price_compare` — 商品価格比較 (read-only)
+- `x_publisher` — X 投稿 (action)
+- `calendar_sync` — Google Calendar 連携 (action)
+- `email_sender` — メール送信 (action, idempotency 必須)
+- `translation_hub` — 多言語翻訳 (read-only)
+- `payment_quote` — 決済見積 (payment, dry_run + quote)
+- `crm_sync` / `news_digest` / `wallet_balance` — CRM / ニュース / 残高照会
+
+すべて `AppTestHarness` で dry_run / action / receipt validation がパス、`validate_tool_manual()` で grade A を出せる。
+
+## 開発者の取り分
+
+- **Developer**: subscription revenue の 93.4%
+- **Platform**: 6.6%
+- **ガス代**: platform 負担 (buyer / developer ともに負担なし)
+- **最低価格**: $5.00/月 相当 (subscription の場合)、free は設定 0
+- **支払い通貨**: USD 統一
+
+Developer 向け payout wallet は embedded smart wallet (platform 側で生成) も、自前の Polygon address の register も OK。
+
+## この SDK が向いてる人 / 向いてない人
+
+**向いてる:**
+- 既にある API 事業の distribution channel を足したい (顧客が AI になる channel)
+- LLM のツール呼び出しに疲れていて「同じマニュアルを 4 つのプロバイダーに出し分け」を 1 行で済ませたい
+- Python と TypeScript 両方で動く SDK が欲しい
+
+**向いてない:**
+- 人間ユーザーに直接売る SaaS の distribution (App Store / Stripe Marketplace を使うべき)
+- Web3 決済を避けたい (Polygon 必須)
+- USD 以外の主軸通貨
+
+## フィードバック求む
+
+個人開発の side project で、ユーザー基盤は小さいです。売上も期待してくれるなら実装より先に製品の形を叩いてもらえると一番嬉しい。
+
+GitHub Issues / Discussions で受け付けています:
+
+- https://github.com/taihei-05/siglume-api-sdk/issues
+- https://github.com/taihei-05/siglume-api-sdk/discussions
+
+特に API 形状 (`AppAdapter` protocol、`ToolManual` schema、CLI の UX) と、exporters の lossy field 判定は、プロダクションで使うとどこが痛むか教えてもらえるとありがたいです。
+
+## 今後
+
+v0.5 は platform 依存機能 (webhook / refund / usage metering / Web3 helper / capability bundle) と npm publish です。


### PR DESCRIPTION
Rewrites three stale (v0.1.0-era, Stripe Connect references) announcement drafts to reflect v0.4.0. Drafts are not posted — they need a final read-through from the maintainer before going live on HN / X / Zenn respectively.