### PR TITLE
fix(recorder): redact all Authorization schemes + stop double-capturing httpx.request (Codex P1 on PR #105)

### DIFF
--- a/siglume-api-sdk-ts/src/testing/recorder.ts
+++ b/siglume-api-sdk-ts/src/testing/recorder.ts
@@ -67,8 +67,18 @@ function redactHeaderValue(key: string, value: string): string {
   if (key === "content-type" && value.toLowerCase().includes("multipart/form-data")) {
     return normalizeMultipartContentType(value);
   }
-  if (key === "authorization" && value.toLowerCase().startsWith("bearer ")) {
-    return "Bearer <REDACTED>";
+  if (key === "authorization") {
+    // Preserve the scheme token so cassettes stay readable, but redact
+    // every credential regardless of scheme (Bearer / Basic / Digest /
+    // custom tokens). Falling through to redactString only catches values
+    // that match our narrow secret regexes, which would leave plenty of
+    // credentials in the clear.
+    const stripped = value.trim();
+    if (!stripped) {
+      return "<REDACTED>";
+    }
+    const head = stripped.split(/\s+/)[0] ?? "";
+    return head ? `${head} <REDACTED>` : "<REDACTED>";
   }
   if (key === "cookie" || key === "set-cookie" || SECRET_KEY_RE.test(key)) {
     const redacted = redactString(value);

--- a/siglume-api-sdk-ts/test/recorder.test.ts
+++ b/siglume-api-sdk-ts/test/recorder.test.ts
@@ -546,4 +546,50 @@ describe("AppTestHarness recorder helpers", () => {
       Reflect.set(globalThis as object, "fetch", originalFetch);
     }
   });
+
+  it("redacts non-Bearer Authorization schemes (Codex P1 on PR #105)", async () => {
+    // Any Authorization value must be redacted, not only the Bearer form.
+    // Basic / Digest / custom-token schemes previously leaked through
+    // because they did not match the narrow secret regexes in redactString.
+    const dir = await mkdtemp(join(tmpdir(), "siglume-auth-scheme-"));
+    tempDirs.push(dir);
+    const cassettePath = join(dir, "auth_schemes.json");
+
+    const originalFetch = globalThis.fetch;
+    Reflect.set(globalThis as object, "fetch", async (input: RequestInfo | URL) => {
+      void input;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const recorder = new Recorder(cassettePath, { mode: RecordMode.RECORD });
+    await recorder.start();
+    try {
+      await recorder.withGlobalFetch(async () => {
+        await fetch("https://api.example.test/a", {
+          headers: { Authorization: "Basic dXNlcjpwYXNzd29yZA==" },
+        });
+        await fetch("https://api.example.test/b", {
+          headers: { Authorization: "Digest username=\"alice\", nonce=\"abc\"" },
+        });
+        await fetch("https://api.example.test/c", {
+          headers: { Authorization: "Sig-Token abcdef123456" },
+        });
+      });
+    } finally {
+      await recorder.close();
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+    }
+
+    const raw = await readFile(cassettePath, "utf8");
+    const data = JSON.parse(raw) as {
+      interactions: Array<{ request: { headers: Record<string, string> } }>;
+    };
+    const headers = data.interactions.map((i) => i.request.headers.authorization);
+    expect(headers[0]).toBe("Basic <REDACTED>");
+    expect(headers[1]).toBe("Digest <REDACTED>");
+    expect(headers[2]).toBe("Sig-Token <REDACTED>");
+  });
 });

--- a/siglume_api_sdk/testing/recorder.py
+++ b/siglume_api_sdk/testing/recorder.py
@@ -63,8 +63,17 @@ def _redact_string(value: str) -> str:
 def _redact_header_value(key: str, value: str) -> str:
     if key == "content-type" and "multipart/form-data" in value.lower():
         return _normalize_multipart_content_type(value)
-    if key == "authorization" and value.lower().startswith("bearer "):
-        return "Bearer <REDACTED>"
+    if key == "authorization":
+        # Preserve the scheme token so cassettes stay readable, but redact
+        # every credential regardless of scheme (Bearer / Basic / Digest /
+        # custom tokens). Falling through to _redact_string only catches
+        # values that match our narrow secret regexes, which would leave
+        # plenty of credentials in the clear.
+        stripped = value.strip()
+        if not stripped:
+            return "<REDACTED>"
+        head, _, _ = stripped.partition(" ")
+        return f"{head} <REDACTED>" if head else "<REDACTED>"
     if key in {"cookie", "set-cookie"} or _SECRET_KEY_RE.search(key):
         redacted = _redact_string(value)
         return redacted if redacted != value else "<REDACTED>"
@@ -273,11 +282,17 @@ class Recorder:
         )
 
     def _patch_httpx(self) -> None:
+        # Only patch Client.request. httpx.request (module-level) internally
+        # constructs a transient Client and calls Client.request on it, so
+        # the Client.request patch catches both paths. Patching both used
+        # to double-record module-level calls (the module wrapper delegated
+        # to the original httpx.request, whose internal Client hit the
+        # already-patched Client.request), producing cassettes ordered
+        # A,A,B,B and breaking replay.
         self._original_client_request = httpx.Client.request
-        self._original_module_request = httpx.request
+        self._original_module_request = None
         recorder = self
         original_client_request = self._original_client_request
-        original_module_request = self._original_module_request
 
         def client_request_wrapper(client_self: httpx.Client, method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
             request = client_self.build_request(
@@ -299,35 +314,11 @@ class Recorder:
             recorder._record_interaction(request, response, duration_ms)
             return response
 
-        def module_request_wrapper(method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
-            with httpx.Client() as temp_client:
-                request = temp_client.build_request(
-                    method,
-                    url,
-                    content=kwargs.get("content"),
-                    data=kwargs.get("data"),
-                    files=kwargs.get("files"),
-                    json=kwargs.get("json"),
-                    params=kwargs.get("params"),
-                    headers=kwargs.get("headers"),
-                    cookies=kwargs.get("cookies"),
-                )
-            if recorder._effective_mode == RecordMode.REPLAY:
-                return recorder._replay_request(request)
-            started = time.perf_counter()
-            response = original_module_request(method, url, *args, **kwargs)
-            duration_ms = int(round((time.perf_counter() - started) * 1000))
-            recorder._record_interaction(request, response, duration_ms)
-            return response
-
         httpx.Client.request = client_request_wrapper
-        httpx.request = module_request_wrapper
 
     def _restore_httpx(self) -> None:
         if self._original_client_request is not None:
             httpx.Client.request = self._original_client_request
-        if self._original_module_request is not None:
-            httpx.request = self._original_module_request
 
     def _record_interaction(self, request: httpx.Request, response: httpx.Response, duration_ms: int) -> None:
         self._interactions.append(

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -382,3 +382,58 @@ def test_python_recorder_replays_multipart_uploads(tmp_path: Path) -> None:
                     data={"note": "hello"},
                     files={"file": ("hello.bin", b"\x00\x01different", "application/octet-stream")},
                 )
+
+
+def test_recorder_redacts_non_bearer_auth_schemes(tmp_path: Path) -> None:
+    # Codex bot P1 on PR #105: any Authorization value must be redacted,
+    # not only the "Bearer " form. Basic / Digest / custom-token schemes
+    # previously leaked through because they did not match the narrow
+    # secret regexes in _redact_string.
+    cassette_path = tmp_path / "auth_schemes.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True})
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.example.test", transport=transport) as client:
+            client.get("/x", headers={"Authorization": "Basic dXNlcjpwYXNzd29yZA=="})
+            client.get("/y", headers={"Authorization": "Digest username=\"alice\", nonce=\"abc\""})
+            client.get("/z", headers={"Authorization": "Sig-Token abcdef123456"})
+
+    data = json.loads(cassette_path.read_text(encoding="utf-8"))
+    headers = [i["request"]["headers"] for i in data["interactions"]]
+    assert headers[0]["authorization"] == "Basic <REDACTED>"
+    assert headers[1]["authorization"] == "Digest <REDACTED>"
+    assert headers[2]["authorization"] == "Sig-Token <REDACTED>"
+
+
+def test_recorder_does_not_double_capture_module_level_httpx_request(tmp_path: Path) -> None:
+    # Codex bot P1 on PR #105: module-level httpx.request was patched in
+    # addition to Client.request, so module-level calls were recorded
+    # twice (once by the module wrapper, once by the internal Client path
+    # delegating to the still-patched Client.request), producing
+    # cassettes ordered A,A,B,B. Now we only patch Client.request, which
+    # catches both paths exactly once.
+    cassette_path = tmp_path / "module_level.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"path": str(request.url.path)})
+
+    original_request = httpx.request
+    try:
+        httpx.request = lambda method, url, **kwargs: httpx.Client(  # type: ignore[assignment]
+            transport=httpx.MockTransport(handler)
+        ).request(method, url, **kwargs)
+
+        with Recorder(cassette_path, mode=RecordMode.RECORD):
+            httpx.request("GET", "https://api.example.test/a")
+            httpx.request("GET", "https://api.example.test/b")
+    finally:
+        httpx.request = original_request
+
+    data = json.loads(cassette_path.read_text(encoding="utf-8"))
+    assert len(data["interactions"]) == 2
+    paths = [i["request"]["url"] for i in data["interactions"]]
+    assert paths[0].endswith("/a")
+    assert paths[1].endswith("/b")


### PR DESCRIPTION
Fixes three Codex bot P1 findings on PR #105. Full rationale in commit message. Regression tests added in Python and TS.