### PR TITLE
fix(sdk): preserve zero metrics, resolve native token, sync User-Agent to 0.4.0

### DIFF
--- a/examples/wallet_balance.py
+++ b/examples/wallet_balance.py
@@ -61,7 +61,13 @@ class WalletBalanceApp(AppAdapter):
     async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
         chain = str(ctx.input_params.get("chain") or "ethereum").lower()
         default_symbol, default_balance, default_price = CHAIN_DEFAULTS.get(chain, CHAIN_DEFAULTS["ethereum"])
-        token_symbol = str(ctx.input_params.get("token_symbol") or default_symbol).upper()
+        raw_symbol = str(ctx.input_params.get("token_symbol") or default_symbol).upper()
+        # Tool manual defaults token_symbol to "native" to mean "chain's
+        # native asset" (ETH on Ethereum, MATIC on Polygon). Resolve NATIVE
+        # to the chain's concrete symbol before routing, otherwise the
+        # equality check below misses and we fall through to the synthetic
+        # ERC-20 branch, contradicting the manual's own contract.
+        token_symbol = default_symbol if raw_symbol == "NATIVE" else raw_symbol
         if token_symbol == default_symbol:
             balance = default_balance
             usd_price = default_price

--- a/siglume-api-sdk-ts/src/buyer.ts
+++ b/siglume-api-sdk-ts/src/buyer.ts
@@ -294,7 +294,7 @@ export class SiglumeBuyerClient {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.4.0-dev.0",
+      "User-Agent": "siglume-api-sdk-ts/0.4.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -749,7 +749,7 @@ export class SiglumeClient implements SiglumeClientShape {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.4.0-dev.0",
+      "User-Agent": "siglume-api-sdk-ts/0.4.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume_api_sdk/buyer.py
+++ b/siglume_api_sdk/buyer.py
@@ -547,9 +547,15 @@ def _build_execution_result(data: Mapping[str, Any], *, payload: Mapping[str, An
     usage_event = _to_dict(data.get("usage_event"))
     receipt = _to_dict(data.get("receipt"))
     execution_kind = _coerce_execution_kind(str(receipt.get("execution_kind") or payload.get("execution_kind") or "action"), ExecutionKind)
-    amount_minor = int(receipt.get("amount_minor") or usage_event.get("amount_minor") or 0)
+    # Use explicit None checks instead of `or` chains so a legitimate zero
+    # (free execution, denied execution, metered-but-zero-units run) does
+    # not silently collapse to the next fallback. The TS implementation
+    # uses `??` for the same reason — keep parity.
+    amount_minor_raw = receipt.get("amount_minor") if receipt.get("amount_minor") is not None else usage_event.get("amount_minor")
+    amount_minor = int(amount_minor_raw) if amount_minor_raw is not None else 0
     currency = str(receipt.get("currency") or usage_event.get("currency") or "USD")
-    units_consumed = int(usage_event.get("units_consumed") or 1)
+    units_raw = usage_event.get("units_consumed")
+    units_consumed = int(units_raw) if units_raw is not None else 1
     if accepted:
         return ExecutionResult(
             success=True,

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -621,7 +621,7 @@ class SiglumeClient:
             headers={
                 "Authorization": f"Bearer {self.api_key}",
                 "Accept": "application/json",
-                "User-Agent": "siglume-api-sdk/0.3.1",
+                "User-Agent": "siglume-api-sdk/0.4.0",
             },
         )
         self._pending_confirmations: dict[str, dict[str, Any]] = {}

--- a/tests/test_buyer.py
+++ b/tests/test_buyer.py
@@ -270,3 +270,39 @@ def test_invoke_requires_explicit_opt_in_for_internal_execute() -> None:
 
     with pytest.raises(SiglumeExperimentalError, match="allow_internal_execute=True"):
         client.invoke(capability_key="currency-converter-v2", input={"amount_usd": 100})
+
+
+def test_invoke_preserves_legitimate_zero_amount_and_units() -> None:
+    # Codex bot P1 on PR #106: `or` chains were clobbering legitimate
+    # zeros — units_consumed=0 became 1, receipt.amount_minor=0 fell
+    # through to usage_event.amount_minor (or the default). Use explicit
+    # None checks instead so free / denied / zero-billed executions
+    # surface honest metrics.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path != "/v1/internal/market/capability/execute":
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "accepted": True,
+                    "allowed": True,
+                    "reason": "accepted",
+                    "reason_code": None,
+                    # usage_event would previously rewrite these zeros via the `or` chain.
+                    "usage_event": {"units_consumed": 0, "amount_minor": 500, "execution_kind": "read_only"},
+                    "result": {"summary": "Free tier cached lookup."},
+                    "receipt": {"execution_kind": "read_only", "currency": "USD", "amount_minor": 0},
+                }
+            ),
+        )
+
+    client = build_client(handler, default_agent_id="agent_demo", allow_internal_execute=True)
+    result = client.invoke(capability_key="cached-lookup", input={"query": "x"})
+
+    assert result.success is True
+    # Zero from the receipt must win over usage_event's 500; the old `or`
+    # chain would have returned 500 here.
+    assert result.amount_minor == 0
+    # Zero units_consumed must be preserved; the old code replaced it with 1.
+    assert result.units_consumed == 0

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -102,3 +102,38 @@ def test_buyer_langchain_example_runs_with_mock_client(capsys) -> None:
     output = capsys.readouterr().out.strip().splitlines()
     assert output[0].startswith("tool_name: currency_converter_v2")
     assert output[-1].startswith("result_currency: JPY")
+
+
+def test_wallet_balance_example_resolves_native_symbol_to_chain_default() -> None:
+    # Codex bot P2 on PR #107: the tool manual defaults token_symbol to
+    # "native" but the adapter uppercased "NATIVE" and fell through to
+    # the synthetic ERC-20 branch, contradicting its own schema default.
+    # Passing "native" must route to the chain's native asset (ETH on
+    # ethereum, MATIC on polygon).
+    module = _load_module("wallet_balance.py")
+    app_cls = next(
+        member
+        for _, member in inspect.getmembers(module, inspect.isclass)
+        if issubclass(member, AppAdapter) and member is not AppAdapter and member.__module__ == module.__name__
+    )
+    app = app_cls()
+
+    async def _run() -> None:
+        from siglume_api_sdk import ExecutionContext, ExecutionKind
+
+        for chain, expected_symbol, expected_balance in (("ethereum", "ETH", 1.2345), ("polygon", "MATIC", 542.1)):
+            ctx = ExecutionContext(
+                agent_id="agent_test",
+                owner_user_id="user_test",
+                task_type=app.supported_task_types()[0],
+                input_params={"chain": chain, "token_symbol": "native"},
+                execution_kind=ExecutionKind.DRY_RUN,
+            )
+            result = await app.execute(ctx)
+            assert result.success
+            assert result.output["token_symbol"] == expected_symbol, (
+                f"'native' on {chain} should resolve to {expected_symbol}, got {result.output['token_symbol']}"
+            )
+            assert result.output["balance"] == expected_balance
+
+    asyncio.run(_run())


### PR DESCRIPTION
Three Codex bot findings bundled: P1 on PR #106 (buyer zero-clobber), P2x2 on PR #107 (wallet_balance native routing + User-Agent version mismatch). Full rationale in commit message. Regression tests added.