### PR TITLE
fix(recorder): fully redact scheme-less auth + patch AsyncClient + fix npm contradiction

### DIFF
--- a/announcements/POST_X_TWITTER.md
+++ b/announcements/POST_X_TWITTER.md
@@ -11,7 +11,7 @@
 AI エージェントが購読する API を、個人開発者が出品する仕組みの SDK です。Python + TypeScript 同機能、オンチェーン決済 (Polygon)、開発者取り分 93.4%。
 
 pip install siglume-api-sdk
-npm i @siglume/api-sdk (npm 公開は v0.5)
+(TypeScript 版は v0.5 で npm 公開予定 / TS package lands in v0.5)
 
 https://github.com/taihei-05/siglume-api-sdk
 

--- a/siglume-api-sdk-ts/src/testing/recorder.ts
+++ b/siglume-api-sdk-ts/src/testing/recorder.ts
@@ -77,6 +77,13 @@ function redactHeaderValue(key: string, value: string): string {
     if (!stripped) {
       return "<REDACTED>";
     }
+    // If the value has no whitespace separator, there is no scheme to
+    // preserve — the entire value IS the credential (e.g. a bare
+    // GitHub PAT `ghp_...` or a hex-encoded API key). Returning
+    // `${head} <REDACTED>` in that case would echo the secret back.
+    if (!/\s/.test(stripped)) {
+      return "<REDACTED>";
+    }
     const head = stripped.split(/\s+/)[0] ?? "";
     return head ? `${head} <REDACTED>` : "<REDACTED>";
   }

--- a/siglume-api-sdk-ts/test/recorder.test.ts
+++ b/siglume-api-sdk-ts/test/recorder.test.ts
@@ -592,4 +592,51 @@ describe("AppTestHarness recorder helpers", () => {
     expect(headers[1]).toBe("Digest <REDACTED>");
     expect(headers[2]).toBe("Sig-Token <REDACTED>");
   });
+
+  it("fully redacts scheme-less Authorization headers (Codex P1 on PR #109)", async () => {
+    // A bare-token Authorization (no whitespace, no scheme prefix — e.g.
+    // a raw GitHub PAT or hex API key) was previously written back as
+    // "${secret} <REDACTED>" because the first split token was treated as
+    // the "scheme" and preserved. The whole value IS the credential in
+    // that case and must be fully redacted.
+    const dir = await mkdtemp(join(tmpdir(), "siglume-auth-bare-"));
+    tempDirs.push(dir);
+    const cassettePath = join(dir, "bare_token.json");
+
+    const originalFetch = globalThis.fetch;
+    Reflect.set(globalThis as object, "fetch", async (input: RequestInfo | URL) => {
+      void input;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const recorder = new Recorder(cassettePath, { mode: RecordMode.RECORD });
+    await recorder.start();
+    try {
+      await recorder.withGlobalFetch(async () => {
+        await fetch("https://api.example.test/a", {
+          headers: { Authorization: "ghp_abcdef0123456789abcdef0123456789abcdef" },
+        });
+        await fetch("https://api.example.test/b", {
+          headers: { Authorization: "0xdeadbeefcafe1234567890abcdef0123456789ab" },
+        });
+      });
+    } finally {
+      await recorder.close();
+      Reflect.set(globalThis as object, "fetch", originalFetch);
+    }
+
+    const raw = await readFile(cassettePath, "utf8");
+    const data = JSON.parse(raw) as {
+      interactions: Array<{ request: { headers: Record<string, string> } }>;
+    };
+    const headers = data.interactions.map((i) => i.request.headers.authorization);
+    // Must be the fully-masked form — not `ghp_... <REDACTED>` which would leak.
+    expect(headers[0]).toBe("<REDACTED>");
+    expect(headers[1]).toBe("<REDACTED>");
+    expect(raw).not.toContain("ghp_abcdef");
+    expect(raw).not.toContain("0xdeadbeefcafe");
+  });
 });

--- a/siglume_api_sdk/testing/recorder.py
+++ b/siglume_api_sdk/testing/recorder.py
@@ -72,8 +72,14 @@ def _redact_header_value(key: str, value: str) -> str:
         stripped = value.strip()
         if not stripped:
             return "<REDACTED>"
-        head, _, _ = stripped.partition(" ")
-        return f"{head} <REDACTED>" if head else "<REDACTED>"
+        head, sep, _ = stripped.partition(" ")
+        # If the value has no whitespace separator, there is no scheme to
+        # preserve — the entire value IS the credential (e.g. a bare
+        # GitHub PAT `ghp_...` or a hex-encoded API key). Returning
+        # `{head} <REDACTED>` in that case would echo the secret back.
+        if not sep:
+            return "<REDACTED>"
+        return f"{head} <REDACTED>"
     if key in {"cookie", "set-cookie"} or _SECRET_KEY_RE.search(key):
         redacted = _redact_string(value)
         return redacted if redacted != value else "<REDACTED>"
@@ -282,17 +288,19 @@ class Recorder:
         )
 
     def _patch_httpx(self) -> None:
-        # Only patch Client.request. httpx.request (module-level) internally
-        # constructs a transient Client and calls Client.request on it, so
-        # the Client.request patch catches both paths. Patching both used
-        # to double-record module-level calls (the module wrapper delegated
-        # to the original httpx.request, whose internal Client hit the
-        # already-patched Client.request), producing cassettes ordered
-        # A,A,B,B and breaking replay.
+        # Patch both sync Client.request AND AsyncClient.request. httpx.request
+        # (module-level) internally constructs a transient sync Client and
+        # calls Client.request, so the sync patch catches both paths there.
+        # AsyncClient takes an entirely separate code path — without patching
+        # it, async callers (a common pattern in app adapters) hit the real
+        # network in REPLAY mode, making cassette-based tests non-deterministic
+        # and leaking external calls.
         self._original_client_request = httpx.Client.request
+        self._original_async_client_request = httpx.AsyncClient.request
         self._original_module_request = None
         recorder = self
         original_client_request = self._original_client_request
+        original_async_client_request = self._original_async_client_request
 
         def client_request_wrapper(client_self: httpx.Client, method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
             request = client_self.build_request(
@@ -314,11 +322,34 @@ class Recorder:
             recorder._record_interaction(request, response, duration_ms)
             return response
 
+        async def async_client_request_wrapper(client_self: httpx.AsyncClient, method: str, url: Any, *args: Any, **kwargs: Any) -> httpx.Response:
+            request = client_self.build_request(
+                method,
+                url,
+                content=kwargs.get("content"),
+                data=kwargs.get("data"),
+                files=kwargs.get("files"),
+                json=kwargs.get("json"),
+                params=kwargs.get("params"),
+                headers=kwargs.get("headers"),
+                cookies=kwargs.get("cookies"),
+            )
+            if recorder._effective_mode == RecordMode.REPLAY:
+                return recorder._replay_request(request)
+            started = time.perf_counter()
+            response = await original_async_client_request(client_self, method, url, *args, **kwargs)
+            duration_ms = int(round((time.perf_counter() - started) * 1000))
+            recorder._record_interaction(request, response, duration_ms)
+            return response
+
         httpx.Client.request = client_request_wrapper
+        httpx.AsyncClient.request = async_client_request_wrapper
 
     def _restore_httpx(self) -> None:
         if self._original_client_request is not None:
             httpx.Client.request = self._original_client_request
+        if getattr(self, "_original_async_client_request", None) is not None:
+            httpx.AsyncClient.request = self._original_async_client_request
 
     def _record_interaction(self, request: httpx.Request, response: httpx.Response, duration_ms: int) -> None:
         self._interactions.append(

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -437,3 +437,57 @@ def test_recorder_does_not_double_capture_module_level_httpx_request(tmp_path: P
     paths = [i["request"]["url"] for i in data["interactions"]]
     assert paths[0].endswith("/a")
     assert paths[1].endswith("/b")
+
+
+def test_recorder_fully_redacts_scheme_less_authorization(tmp_path: Path) -> None:
+    # Codex bot P1 on PR #109: a bare-token Authorization header (no whitespace,
+    # no scheme prefix — e.g. a raw GitHub PAT or hex API key) was being
+    # written back as "<secret> <REDACTED>" because the code took the
+    # partition head as the "scheme" and kept it. The whole value IS the
+    # credential in that case and must be redacted.
+    cassette_path = tmp_path / "bare_token.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True})
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.example.test", transport=transport) as client:
+            client.get("/a", headers={"Authorization": "ghp_abcdef0123456789abcdef0123456789abcdef"})
+            client.get("/b", headers={"Authorization": "0xdeadbeefcafe1234567890abcdef0123456789ab"})
+
+    data = json.loads(cassette_path.read_text(encoding="utf-8"))
+    headers = [i["request"]["headers"] for i in data["interactions"]]
+    # Must be the fully-masked form — not `ghp_... <REDACTED>` which would leak.
+    assert headers[0]["authorization"] == "<REDACTED>"
+    assert headers[1]["authorization"] == "<REDACTED>"
+    cassette_text = cassette_path.read_text(encoding="utf-8")
+    assert "ghp_abcdef" not in cassette_text
+    assert "0xdeadbeefcafe" not in cassette_text
+
+
+def test_recorder_patches_async_client_request(tmp_path: Path) -> None:
+    # Codex bot P2 on PR #105: AsyncClient was not patched, so async callers
+    # (a common pattern in app adapters) hit the real network in REPLAY mode
+    # and leaked external calls in RECORD mode. Patch AsyncClient.request too.
+    import asyncio
+
+    cassette_path = tmp_path / "async_client.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "path": str(request.url.path)})
+
+    async def run_async_calls() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(base_url="https://api.example.test", transport=transport) as client:
+            await client.get("/async-a")
+            await client.get("/async-b")
+
+    with Recorder(cassette_path, mode=RecordMode.RECORD):
+        asyncio.run(run_async_calls())
+
+    data = json.loads(cassette_path.read_text(encoding="utf-8"))
+    assert len(data["interactions"]) == 2
+    paths = [i["request"]["url"] for i in data["interactions"]]
+    assert paths[0].endswith("/async-a")
+    assert paths[1].endswith("/async-b")


### PR DESCRIPTION
Bundled follow-up to 3 Codex bot findings:

- **P1 on #109 (Python + TS)**: Scheme-less Authorization headers (bare `ghp_...` or `0x...` tokens) were written back as `{secret} <REDACTED>` because the split-head was kept even without a whitespace separator. Fully redact when no separator is present.
- **P2 on #69 (Python Recorder._patch_httpx)**: `httpx.AsyncClient.request` was not patched — async callers leaked real external calls in RECORD and were non-deterministic in REPLAY. Patch it alongside sync Client.
- **P2 on #108 (POST_X_TWITTER.md)**: removed the `npm i @siglume/api-sdk` line that contradicted the "npm 公開は v0.5" parenthetical.

Tests: 2 new Python tests + 1 new TS test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)