### PR TITLE
fix(ts): event_types required in create_webhook_subscription interface

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -133,7 +133,12 @@ export interface SiglumeClientShape {
   create_webhook_subscription(options: {
     callback_url: string;
     description?: string;
-    event_types?: string[];
+    // Required by the concrete implementation (SiglumeClient.
+    // create_webhook_subscription immediately calls
+    // options.event_types.map(...)). Make it required at the type
+    // level so TS consumers get a compile-time error instead of a
+    // runtime TypeError before the intended validation runs.
+    event_types: string[];
     metadata?: Record<string, unknown>;
   }): Promise<WebhookSubscriptionRecord>;
   list_webhook_subscriptions(): Promise<WebhookSubscriptionRecord[]>;


### PR DESCRIPTION
Codex bot P1 on PR #112: SiglumeClientShape declared event_types as optional while the implementation requires it, so callers could hit a runtime TypeError. Align interface with implementation.