### PR TITLE
fix(metering): preserve zero units_consumed, handle string price_model, flat-module fallback

### DIFF
--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import abc
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Mapping
 
 # ISO 3166-1 alpha-2 country code, optionally with a sub-region suffix.
 # Examples: "US", "US-CA", "JP", "GB", "DE", "SG".
@@ -860,6 +861,69 @@ class StubProvider:
 
 # ── Test Harness ──
 
+def _normalize_usage_record_flat(record: Any) -> dict[str, Any]:
+    """Flat-module fallback mirroring siglume_api_sdk.metering._normalize_usage_record.
+
+    Keeps simulate_metering usable when the package-layout metering module is
+    not available (legacy single-file consumers).
+    """
+    if isinstance(record, Mapping):
+        payload: dict[str, Any] = dict(record)
+    elif hasattr(record, "__dict__"):
+        payload = {
+            key: getattr(record, key)
+            for key in ("capability_key", "dimension", "units", "external_id", "occurred_at_iso", "agent_id")
+            if hasattr(record, key)
+        }
+    else:
+        raise ValueError("Usage records must be mappings or UsageRecord-like objects.")
+
+    capability_key = str(payload.get("capability_key") or "").strip()
+    if not capability_key:
+        raise ValueError("UsageRecord.capability_key is required.")
+    dimension = str(payload.get("dimension") or "").strip()
+    if not dimension:
+        raise ValueError("UsageRecord.dimension is required.")
+    external_id = str(payload.get("external_id") or "").strip()
+    if not external_id:
+        raise ValueError("UsageRecord.external_id is required.")
+
+    occurred_text = str(payload.get("occurred_at_iso") or "").strip()
+    if not occurred_text:
+        raise ValueError("UsageRecord.occurred_at_iso is required.")
+    candidate = occurred_text[:-1] + "+00:00" if occurred_text.endswith("Z") else occurred_text
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ValueError("UsageRecord.occurred_at_iso must be RFC3339 with timezone.") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("UsageRecord.occurred_at_iso must be RFC3339 with timezone.")
+
+    units_value = payload.get("units")
+    if isinstance(units_value, bool):
+        raise ValueError("UsageRecord.units must be a non-negative integer.")
+    if isinstance(units_value, int):
+        units = units_value
+    elif isinstance(units_value, str) and re.fullmatch(r"-?\d+", units_value.strip()):
+        units = int(units_value.strip())
+    else:
+        raise ValueError("UsageRecord.units must be a non-negative integer.")
+    if units < 0:
+        raise ValueError("UsageRecord.units must be a non-negative integer.")
+
+    normalized: dict[str, Any] = {
+        "capability_key": capability_key,
+        "dimension": dimension,
+        "units": units,
+        "external_id": external_id,
+        "occurred_at_iso": occurred_text,
+    }
+    agent_id = str(payload.get("agent_id") or "").strip()
+    if agent_id:
+        normalized["agent_id"] = agent_id
+    return normalized
+
+
 class AppTestHarness:
     """Helper for testing apps locally before submission.
 
@@ -1022,29 +1086,41 @@ class AppTestHarness:
         usage payload shape locally and returns a deterministic preview. It does
         not create a charge.
         """
-        from siglume_api_sdk.metering import _normalize_usage_record
+        try:
+            from siglume_api_sdk.metering import _normalize_usage_record as _normalize
+        except ModuleNotFoundError:
+            _normalize = _normalize_usage_record_flat
 
         manifest = self.app.manifest()
-        usage_record = _normalize_usage_record(record)
+        usage_record = _normalize(record)
+
+        price_model_raw = manifest.price_model
+        if isinstance(price_model_raw, PriceModel):
+            price_model_value = price_model_raw.value
+        else:
+            price_model_value = str(price_model_raw or "")
+
+        usage_based_matches = price_model_raw == PriceModel.USAGE_BASED or price_model_value == PriceModel.USAGE_BASED.value
+        per_action_matches = price_model_raw == PriceModel.PER_ACTION or price_model_value == PriceModel.PER_ACTION.value
         invoice_line_preview: dict[str, Any] | None = None
 
-        if manifest.price_model == PriceModel.USAGE_BASED:
+        if usage_based_matches:
             billable_units = int(usage_record["units"])
             invoice_line_preview = {
-                "price_model": manifest.price_model.value,
+                "price_model": price_model_value,
                 "billable_units": billable_units,
                 "unit_amount_minor": int(manifest.price_value_minor),
                 "subtotal_minor": billable_units * int(manifest.price_value_minor),
                 "currency": manifest.currency,
             }
-        elif manifest.price_model == PriceModel.PER_ACTION:
+        elif per_action_matches:
             billable_units = int(
                 execution_result is not None
                 and execution_result.success
                 and execution_result.execution_kind != ExecutionKind.DRY_RUN
             )
             invoice_line_preview = {
-                "price_model": manifest.price_model.value,
+                "price_model": price_model_value,
                 "billable_units": billable_units,
                 "unit_amount_minor": int(manifest.price_value_minor),
                 "subtotal_minor": billable_units * int(manifest.price_value_minor),
@@ -1052,7 +1128,7 @@ class AppTestHarness:
             }
 
         return {
-            "experimental": manifest.price_model in (PriceModel.USAGE_BASED, PriceModel.PER_ACTION),
+            "experimental": usage_based_matches or per_action_matches,
             "usage_record": usage_record,
             "invoice_line_preview": invoice_line_preview,
         }

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -579,7 +579,11 @@ def _parse_usage_event(data: Mapping[str, Any]) -> UsageEventRecord:
         dimension=_string_or_none(data.get("dimension")),
         environment=_string_or_none(data.get("environment")),
         task_type=_string_or_none(data.get("task_type")),
-        units_consumed=int(data.get("units_consumed") or data.get("units") or 0),
+        units_consumed=int(
+            data["units_consumed"]
+            if data.get("units_consumed") is not None
+            else (data["units"] if data.get("units") is not None else 0)
+        ),
         outcome=_string_or_none(data.get("outcome")),
         execution_kind=_string_or_none(data.get("execution_kind")),
         permission_class=_string_or_none(data.get("permission_class")),

--- a/tests/test_metering.py
+++ b/tests/test_metering.py
@@ -287,6 +287,86 @@ def test_app_test_harness_simulates_per_action_metering() -> None:
     assert preview["invoice_line_preview"]["subtotal_minor"] == 5
 
 
+def test_app_test_harness_simulate_metering_handles_str_price_model() -> None:
+    class _MutableManifestApp(MeteredApp):
+        def manifest(self) -> AppManifest:
+            manifest = super().manifest()
+            object.__setattr__(manifest, "price_model", "usage_based")
+            return manifest
+
+    harness = AppTestHarness(_MutableManifestApp(PriceModel.USAGE_BASED))
+    preview = harness.simulate_metering(
+        UsageRecord(
+            capability_key="translation-hub",
+            dimension="tokens_in",
+            units=200,
+            external_id="evt_usage_str",
+            occurred_at_iso="2026-04-19T10:00:00Z",
+        )
+    )
+    assert preview["experimental"] is True
+    assert preview["invoice_line_preview"] is not None
+    assert preview["invoice_line_preview"]["price_model"] == "usage_based"
+
+
+def test_flat_module_normalize_usage_record_fallback_handles_string_units() -> None:
+    import importlib.util
+    import sys as _sys
+
+    flat_path = ROOT / "siglume_api_sdk.py"
+    module_name = "_siglume_flat_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, flat_path)
+    assert spec is not None and spec.loader is not None
+    flat_sdk = importlib.util.module_from_spec(spec)
+    _sys.modules[module_name] = flat_sdk
+    try:
+        spec.loader.exec_module(flat_sdk)
+    except Exception:
+        _sys.modules.pop(module_name, None)
+        raise
+
+    normalized = flat_sdk._normalize_usage_record_flat({
+        "capability_key": "translation-hub",
+        "dimension": "tokens_in",
+        "units": "5",
+        "external_id": "evt_flat_001",
+        "occurred_at_iso": "2026-04-19T10:00:00Z",
+    })
+    assert normalized["units"] == 5
+
+    with pytest.raises(ValueError):
+        flat_sdk._normalize_usage_record_flat({
+            "capability_key": "translation-hub",
+            "dimension": "tokens_in",
+            "units": -1,
+            "external_id": "evt_flat_002",
+            "occurred_at_iso": "2026-04-19T10:00:00Z",
+        })
+
+
+def test_parse_usage_event_preserves_zero_units_consumed() -> None:
+    from siglume_api_sdk.client import _parse_usage_event
+
+    event = _parse_usage_event({
+        "usage_event_id": "uev_zero",
+        "capability_key": "translation-hub",
+        "units_consumed": 0,
+        "units": 42,
+    })
+    assert event.units_consumed == 0
+
+
+def test_parse_usage_event_falls_back_to_units_only_when_units_consumed_absent() -> None:
+    from siglume_api_sdk.client import _parse_usage_event
+
+    event = _parse_usage_event({
+        "usage_event_id": "uev_fallback",
+        "capability_key": "translation-hub",
+        "units": 7,
+    })
+    assert event.units_consumed == 7
+
+
 def test_app_test_harness_returns_no_invoice_preview_for_non_metered_models() -> None:
     harness = AppTestHarness(MeteredApp(PriceModel.SUBSCRIPTION))
 


### PR DESCRIPTION
## Summary

Addresses three Codex bot findings across [PR #115](https://github.com/taihei-05/siglume-api-sdk/pull/115) and the mirror [siglume#90](https://github.com/taihei-05/siglume/pull/90).

### P1 — `_parse_usage_event` drops zero \`units_consumed\`
`int(data.get("units_consumed") or data.get("units") or 0)` treated a legitimate \`units_consumed: 0\` as missing and silently replaced it with \`units\`. A mixed-version payload with \`units_consumed: 0\` and non-zero \`units\` (e.g., attempted vs consumed) would inflate the parsed count and distort analytics / future billing previews. Fix: explicit \`is not None\` checks.

### P2 — `simulate_metering` crashes on string \`price_model\`
`AppManifest` is a dataclass without runtime coercion, so a valid manifest loaded from JSON may carry \`price_model\` as a plain string. `manifest.price_model.value` then raised \`AttributeError\`. Fix: accept either \`PriceModel\` Enum or the underlying string value, compare both against each known price-model, and serialize using the coerced string.

### P2 — `simulate_metering` package-only import breaks flat-module consumers
\`from siglume_api_sdk.metering import _normalize_usage_record\` only works with the package layout. Legacy consumers using only \`siglume_api_sdk.py\` got \`ModuleNotFoundError\` on first call. Fix: inline \`_normalize_usage_record_flat\` in the flat module (raises \`ValueError\` because the flat module does not define \`SiglumeClientError\`).

## Test plan

- [x] \`python -m pytest tests/test_metering.py -q\` — 14 passed (4 new: preserve-zero, units-only fallback, string price_model, flat-module fallback)
- [x] Full Python suite (\`tests/\`) — 162 passed
- [x] Reviewer subagent — caught a missing \`_DIGITS_RE\` symbol in the first pass; fixed to use inline \`re.fullmatch\` in the flat fallback, plus added a test that exercises it via \`importlib\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)