### PR TITLE
docs(plan): defer capability bundle support to v0.6

### DIFF
--- a/docs/sdk/v0.6-plan.md
+++ b/docs/sdk/v0.6-plan.md
@@ -1,0 +1,31 @@
+# v0.6 Planning Notes
+
+## Deferred from v0.5
+
+### PR-M: Capability Bundle
+
+Status: deferred from `v0.5` to `v0.6`
+
+Reason:
+- The main platform has multi-capability pitch and validator support, but it
+  does not yet expose a public marketplace registration surface for bundling
+  multiple `ToolManual` objects under one listing.
+- No public `/v1/market/bundles`, `capability-bundles`, or equivalent bundle
+  registration/read API is available in the platform presentation layer or the
+  public OpenAPI contract.
+- The existing runtime references center on `planned_capability_release_ids`
+  for works/pitch orchestration, which is a different contract from a seller
+  publishing one `AppManifest` with multiple public `ToolManual` entries.
+
+Required platform work before SDK PR-M:
+- Add a public bundle registration/read contract with stable field names and
+  semantics.
+- Decide how bundle-level identity maps onto listing keys, release ids, and
+  per-tool quality validation.
+- Publish the bundle surface in the platform OpenAPI before adding SDK client
+  wrappers and `AppAdapter.list_tools()`-based registration helpers.
+
+Release note:
+- `v0.5.0` ships webhooks, refunds/disputes, experimental metering, and Web3
+  settlement helpers.
+- Capability bundles move to `v0.6` pending the platform-first API work above.


### PR DESCRIPTION
﻿## Summary
- document that PR-M capability-bundle support is deferred from v0.5 to v0.6
- record the platform-first API gap that blocks a safe SDK implementation today

## Why
- the platform has multi-capability pitch and validation work, but no public marketplace bundle registration/read API or OpenAPI contract yet
- shipping SDK-side bundle helpers before that contract exists would create a speculative surface and risk drift

## Validation
- reviewer agent (Gauss): no findings
