### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-20
+
+v0.5.0 is the platform-integration release for the public SDK. It layers
+seller-facing operations and settlement helpers on top of the v0.4 multi-runtime
+foundation: webhook verification, refund/dispute flows, experimental metering,
+and typed Web3 read/simulate helpers now ship in both Python and TypeScript.
+
+### Added
+
+- Webhook handler surface for Python and TypeScript:
+  `WebhookHandler`, typed webhook-event unions, HMAC-SHA256 signature
+  verification, timestamp tolerance checks, and idempotency/dedupe helpers.
+- Seller-side refund/dispute client:
+  `RefundClient`, typed `Refund` / `Dispute` models, partial/full refund
+  helpers, and dispute response helpers.
+- Experimental metering support:
+  `MeterClient`, `UsageRecord`, client-side batch chunking, and
+  `AppTestHarness.simulate_metering()` invoice previews.
+- Web3 settlement helpers:
+  typed Polygon mandate, settlement receipt, embedded-wallet charge, and
+  cross-currency quote models plus deterministic local simulation helpers.
+- New docs/examples for webhooks, refunds/disputes, metering, and Web3
+  settlement flows across Python and TypeScript.
+
+### Changed
+
+- The public OpenAPI surface now includes the marketplace webhook, refund,
+  dispute, metering, and Web3 settlement endpoints the SDK wraps.
+- README and Getting Started now point to the current v0.5.0 release line and
+  its new platform-integration surfaces.
+
+### Deferred
+
+- PR-M capability bundles move to v0.6 because the platform does not yet expose
+  a public bundle registration/read API for multiple `ToolManual` objects under
+  one listing. See `docs/sdk/v0.6-plan.md`.
+
+### Compatibility
+
+- v0.5.0 is additive for existing v0.4 users.
+- `usage_based` / `per_action` metering remains experimental because public
+  listing registration still accepts only `free` and `subscription`.
+- Web3 helpers mirror the public platform contract; real settlement remains
+  platform-owned.
+
 ## [0.4.0] - 2026-04-19
 
 First full multi-runtime SDK release. v0.4.0 adds offline ToolManual scoring,

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -721,7 +721,7 @@ The current on-chain flow (live as of Phase 31 on Polygon Amoy, 2026-04-18):
 - Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold the gas token.
 - Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades).
 
-SDK v0.4.0 (current release) ships the Web3 enum values for
+SDK v0.5.0 (current release) ships the Web3 enum values for
 payment-permission tools: `SettlementMode.POLYGON_MANDATE` and
 `SettlementMode.EMBEDDED_WALLET_CHARGE`. See
 [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full phase log.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → payout setup) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> 🚀 **v0.4.0 is out** — first full multi-runtime release. Python + TypeScript
-> parity across `AppAdapter` / `AppTestHarness` / `SiglumeClient` / the
-> `siglume` CLI, offline ToolManual grader (server parity ±5), LLM-assisted
-> tool-manual drafting, tool schema exporter (Anthropic / OpenAI Chat +
-> Responses / MCP), recording harness, manifest diff, buyer-side SDK
-> (experimental), webhook handlers, and seller-side refund / dispute client.
-> See [RELEASE_NOTES_v0.4.0.md](./RELEASE_NOTES_v0.4.0.md) for the full release.
+> 🚀 **v0.5.0 is out** — the platform-integration release. Python + TypeScript
+> now cover webhook handling, seller-side refund / dispute flows,
+> experimental usage metering, and typed Web3 settlement helpers on top of the
+> v0.4 runtime, grading, diffing, exporter, recorder, buyer-SDK, and example
+> set.
+> Capability bundles are deferred pending a platform-first public bundle API.
+> See [RELEASE_NOTES_v0.5.0.md](./RELEASE_NOTES_v0.5.0.md) for the full release.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 
@@ -325,7 +325,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is an early-stage project (v0.4.0, alpha) with a growing but still
+This is an early-stage project (v0.5.0, alpha) with a growing but still
 small user base. The SDK and platform are actively evolving. Start with
 a small read-only API to learn the flow.
 

--- a/RELEASE_NOTES_v0.5.0.md
+++ b/RELEASE_NOTES_v0.5.0.md
@@ -1,0 +1,51 @@
+# v0.5.0 - webhooks, seller operations, metering, and Web3 settlement helpers
+
+**2026-04-20**
+
+v0.5.0 is the Siglume SDK release focused on the seller and settlement edges of
+the public platform. Python and TypeScript now share typed webhook handling,
+refund/dispute helpers, experimental metering, and Web3 settlement read models
+without giving up the v0.4 runtime, grader, diff/exporter, recorder, buyer-SDK,
+and example coverage.
+
+## Highlights
+
+- **Webhook handling is first-class**: `WebhookHandler` verifies HMAC-SHA256
+  signatures, enforces timestamp freshness, provides typed event dispatch, and
+  includes dedupe helpers for replay-safe handlers in Python and TypeScript.
+- **Refunds and disputes are now public SDK flows**: `RefundClient` wraps
+  partial/full refunds and dispute responses, with typed receipt-linked models
+  and runnable examples.
+- **Experimental metering lands end-to-end**: `MeterClient` records usage-event
+  batches, reuses idempotency safely, and pairs with
+  `AppTestHarness.simulate_metering()` for deterministic invoice previews.
+- **Web3 settlement helpers mirror the platform**: use typed Polygon mandates,
+  settlement receipts, embedded-wallet charges, and cross-currency quotes
+  without duplicating chain logic in the SDK.
+- **Capability bundles are explicitly deferred**: PR-M moves to v0.6 until the
+  platform publishes a stable bundle registration/read API for multiple public
+  `ToolManual` entries on one listing.
+
+## Included PRs
+
+- PR-F: webhook + subscription lifecycle helpers
+- PR-I: refund / dispute client
+- PR-H: experimental usage metering
+- PR-G: typed Web3 settlement helpers and local simulation
+- PR-M: deferred to v0.6 pending platform-first bundle API
+
+## Compatibility
+
+- This release is additive for v0.4 users.
+- `usage_based` / `per_action` remain experimental on the public platform.
+- Real Web3 settlement remains platform-owned; the SDK exposes typed reads and
+  local simulation helpers only.
+- No change to the USD-only publishing rule, required `jurisdiction`, or the
+  manifest/tool-manual permission-class naming split.
+
+## Suggested upgrade
+
+```bash
+pip install --upgrade siglume-api-sdk==0.5.0
+npm install @siglume/api-sdk@0.5.0
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "type": "module",

--- a/siglume-api-sdk-ts/src/buyer.ts
+++ b/siglume-api-sdk-ts/src/buyer.ts
@@ -294,7 +294,7 @@ export class SiglumeBuyerClient {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.4.0",
+      "User-Agent": "siglume-api-sdk-ts/0.5.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -1347,7 +1347,7 @@ export class SiglumeClient implements SiglumeClientShape {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.4.0",
+      "User-Agent": "siglume-api-sdk-ts/0.5.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume-api-sdk-ts/src/metering.ts
+++ b/siglume-api-sdk-ts/src/metering.ts
@@ -124,7 +124,7 @@ export class MeterClient {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.4.0",
+      "User-Agent": "siglume-api-sdk-ts/0.5.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -772,7 +772,7 @@ class SiglumeClient:
             headers={
                 "Authorization": f"Bearer {self.api_key}",
                 "Accept": "application/json",
-                "User-Agent": "siglume-api-sdk/0.4.0",
+                "User-Agent": "siglume-api-sdk/0.5.0",
             },
         )
         self._pending_confirmations: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
﻿## Summary
- bump Python and TypeScript package versions from 0.4.0 to 0.5.0
- update User-Agent headers and docs to the new release line
- add changelog and release notes for webhooks, refunds/disputes, metering, and Web3 settlement helpers
- note that capability bundles are deferred to v0.6 pending a platform-first public API

## Validation
- `py -3.11 -m ruff check .`
- `py -3.11 -m pytest`
- `py -3.11 scripts/contract_sync.py`
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`
- reviewer agent (`Nash`): no findings
