### PR TITLE
feat(owner): expose agent behavior operations (PR-R)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ platform does not yet expose semantic search, buyer execution, or full
 `tool_manual` payloads on listing reads. The SDK falls back to local substring
 search, synthesized tool metadata, and mock-friendly invocation wiring.
 
+## Agent behavior operations
+
+Use the owner-operation surface when you need to inspect or tune an agent's
+charter, approval policy, or delegated budget from external tooling.
+
+- Python example: [examples/agent_behavior_adapter.py](./examples/agent_behavior_adapter.py)
+- TypeScript example: [examples-ts/agent_behavior_adapter.ts](./examples-ts/agent_behavior_adapter.ts)
+- API notes: [docs/agent-behavior.md](./docs/agent-behavior.md)
+
+These owner routes currently return the updated snapshot inline, so
+`update_agent_charter()`, `update_approval_policy()`, and
+`update_budget_policy()` resolve immediately with typed records.
+
 ## Refunds and disputes
 
 Use `RefundClient` when you need to reverse a completed marketplace charge or
@@ -225,7 +238,7 @@ quotes.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `refund_partial.py` shows the seller-side refund/dispute flow with mocked marketplace receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked marketplace receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 | Example | Permission | Runnable e2e | Description |
 |---|---|---|---|
@@ -236,6 +249,7 @@ quotes.
 | [email_sender.py](./examples/email_sender.py) | `ACTION` | ✅ | Preview and send email with explicit approval and idempotency hints |
 | [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
 | [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
+| [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
 | [refund_partial.py](./examples/refund_partial.py) | client | ✅ | Issue a partial refund and respond to a dispute for a prior receipt |
 | [metering_record.py](./examples/metering_record.py) | client | ✅ | Record experimental usage events and preview future invoice lines |
 | [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
@@ -261,6 +275,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | [Getting Started Guide](GETTING_STARTED.md) | Build and publish an API in 15 minutes |
 | [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide) | Write a tool manual that gets your API selected |
 | [Buyer-side SDK](docs/buyer-sdk.md) | Discover and invoke Siglume capabilities from LangChain / Claude-style runtimes |
+| [Agent Behavior Operations](docs/agent-behavior.md) | Inspect owned agents and mirror charter / approval / budget operations, with the example adapter stopping at an approval proposal preview |
 | [Metering](docs/metering.md) | Record usage events and preview future usage-based invoice lines |
 | [Refunds and Disputes](docs/refunds-disputes.md) | Reverse a receipt-backed charge and answer disputes |
 | [Web3 Settlement Helpers](docs/web3-settlement.md) | Read Polygon mandate / receipt data and simulate local settlement flows |

--- a/docs/agent-behavior.md
+++ b/docs/agent-behavior.md
@@ -1,0 +1,89 @@
+# Agent Behavior Operations
+
+Siglume's owner-operation surface now exposes the core agent-governance knobs
+that the first-party product already uses:
+
+- `list_agents()`
+- `get_agent(agent_id)`
+- `update_agent_charter(agent_id, charter_text, ...)`
+- `update_approval_policy(agent_id, policy)`
+- `update_budget_policy(agent_id, policy)`
+
+These methods let external tooling mirror the same owner workflow the platform
+uses for charter, approval-policy, and delegated-budget management. The example
+adapter below intentionally stops at an owner-review proposal preview instead
+of silently applying a live policy change.
+
+The corresponding execution-plane program lives in the main repo at
+`docs/owner_agent_operation_program_2026-04-20.md`. This public SDK page stays
+focused on the HTTP/client surface only.
+
+## Python
+
+```python
+from siglume_api_sdk import SiglumeClient
+
+client = SiglumeClient(api_key="sig_live_...")
+
+agents = client.list_agents()
+agent = client.get_agent(agents[0].agent_id)
+
+charter = client.update_agent_charter(
+    agent.agent_id,
+    "Prefer capped spend and explicit approval for unusual purchases.",
+    role="buyer",
+    success_metrics={"approval_rate_floor": 0.8},
+)
+
+policy = client.update_approval_policy(
+    agent.agent_id,
+    {
+        "auto_approve_below": {"JPY": 3000},
+        "always_require_approval_for": ["travel.booking"],
+        "approval_ttl_minutes": 720,
+        "structured_only": True,
+    },
+)
+
+budget = client.update_budget_policy(
+    agent.agent_id,
+    {
+        "currency": "JPY",
+        "period_limit_minor": 50000,
+        "per_order_limit_minor": 12000,
+        "auto_approve_below_minor": 3000,
+    },
+)
+```
+
+## TypeScript
+
+```ts
+import { SiglumeClient } from "@siglume/api-sdk";
+
+const client = new SiglumeClient({ api_key: process.env.SIGLUME_API_KEY! });
+const [agent] = await client.list_agents();
+
+await client.update_agent_charter(
+  agent.agent_id,
+  "Prefer capped spend and explicit approval for unusual purchases.",
+  { role: "buyer" },
+);
+```
+
+## Current behavior
+
+The public owner routes currently complete synchronously and return the updated
+snapshot inline. The SDK therefore returns `AgentCharter`, `ApprovalPolicy`, or
+`BudgetPolicy` immediately instead of an intent handle.
+
+`wait_for_completion=True` remains accepted on the update methods as a
+forward-compatible option, but it is currently a no-op because there is no
+separate public intent-polling surface for these routes yet.
+
+## Example adapter
+
+See [examples/agent_behavior_adapter.py](../examples/agent_behavior_adapter.py)
+and [examples-ts/agent_behavior_adapter.ts](../examples-ts/agent_behavior_adapter.ts)
+for a mock-friendly ACTION adapter that proposes governance changes back to the
+owner without silently writing them.

--- a/docs/sdk/v0.6-plan.md
+++ b/docs/sdk/v0.6-plan.md
@@ -29,3 +29,8 @@ Release note:
 - `v0.5.0` ships webhooks, refunds/disputes, experimental metering, and Web3
   settlement helpers.
 - Capability bundles move to `v0.6` pending the platform-first API work above.
+
+## PR-R reference
+
+- Owner-operation SDK notes: [../agent-behavior.md](../agent-behavior.md)
+- Execution-plane program (main repo): `docs/owner_agent_operation_program_2026-04-20.md`

--- a/examples-ts/agent_behavior_adapter.ts
+++ b/examples-ts/agent_behavior_adapter.ts
@@ -1,0 +1,220 @@
+/*
+API: first-party owner operation wrapper for agent behavior governance.
+Intended user: owners or automation builders who want to tune an agent safely.
+Connected account: none.
+*/
+import {
+  AppAdapter,
+  AppCategory,
+  AppTestHarness,
+  ApprovalMode,
+  PermissionClass,
+  PriceModel,
+  ToolManualPermissionClass,
+  score_tool_manual_offline,
+  validate_tool_manual,
+} from "../siglume-api-sdk-ts/src/index";
+import type { ExecutionContext, ExecutionResult, ToolManual } from "../siglume-api-sdk-ts/src/index";
+
+export class AgentBehaviorApp extends AppAdapter {
+  manifest() {
+    return {
+      capability_key: "agent-behavior",
+      name: "Agent Behavior Governance",
+      job_to_be_done: "Prepare owner-reviewed charter, approval-policy, and budget updates for an agent.",
+      category: AppCategory.OTHER,
+      permission_class: PermissionClass.ACTION,
+      approval_mode: ApprovalMode.ALWAYS_ASK,
+      dry_run_supported: true,
+      required_connected_accounts: [],
+      price_model: PriceModel.FREE,
+      jurisdiction: "US",
+      short_description: "Preview owner-governed behavior changes before creating an approval proposal.",
+      example_prompts: ["Propose a stricter approval policy for my travel-buying agent."],
+    };
+  }
+
+  async execute(ctx: ExecutionContext): Promise<ExecutionResult> {
+    const agent_id = String(ctx.input_params?.agent_id ?? "agt_owner_demo");
+    const charter_text = String(
+      ctx.input_params?.charter_text
+        ?? "Prioritize approval-safe bookings, explain trade-offs clearly, and stay within the delegated budget.",
+    );
+    const auto_approve_below_jpy = Math.trunc(Number(ctx.input_params?.auto_approve_below_jpy ?? 3000));
+    const period_limit_minor = Math.trunc(Number(ctx.input_params?.period_limit_minor ?? 50000));
+    const preview = {
+      summary: `Would ask the owner to update charter / approval / budget for ${agent_id}.`,
+      agent_id,
+      charter_text,
+      auto_approve_below_jpy,
+      period_limit_minor,
+    };
+
+    if (ctx.execution_kind === "dry_run") {
+      return {
+        success: true,
+        execution_kind: ctx.execution_kind,
+        output: preview,
+        needs_approval: true,
+        approval_prompt: `Create an owner-review proposal for agent ${agent_id}.`,
+        approval_hint: {
+          action_summary: `Propose governance changes for ${agent_id}`,
+          permission_class: "action",
+          side_effects: ["Creates an owner-review proposal; does not update the live agent until approved."],
+          preview,
+          reversible: true,
+        },
+      };
+    }
+
+    const proposal_id = `proposal_${agent_id}`;
+    return {
+      success: true,
+      execution_kind: ctx.execution_kind,
+      output: {
+        summary: `Created an owner-review proposal for ${agent_id}.`,
+        proposal_id,
+        agent_id,
+        charter_text,
+        auto_approve_below_jpy,
+        period_limit_minor,
+      },
+      receipt_summary: {
+        action: "owner_governance_proposal_created",
+        proposal_id,
+        agent_id,
+      },
+      artifacts: [
+        {
+          artifact_type: "owner_operation_proposal",
+          external_id: proposal_id,
+          title: `Governance proposal for ${agent_id}`,
+          summary: "Owner-reviewed proposal covering charter, approval policy, and delegated budget.",
+        },
+      ],
+      side_effects: [
+        {
+          action: "owner_governance_proposal_created",
+          provider: "siglume-owner-operations",
+          external_id: proposal_id,
+          reversible: true,
+          reversal_hint: "Discard the pending proposal before the owner approves it.",
+          metadata: {
+            agent_id,
+            auto_approve_below_jpy,
+            period_limit_minor,
+          },
+        },
+      ],
+    };
+  }
+
+  supported_task_types() {
+    return ["propose_agent_behavior"];
+  }
+}
+
+export function buildToolManual(): ToolManual {
+  return {
+    tool_name: "agent_behavior_governance",
+    job_to_be_done: "Prepare an owner-reviewed proposal that updates an agent's charter, approval policy, and delegated budget.",
+    summary_for_model: "Previews governance changes for an owned agent and creates a proposal only after the owner reviews the preview.",
+    trigger_conditions: [
+      "owner asks to tighten or loosen how their agent makes purchasing or action decisions",
+      "agent needs a formal proposal to change charter text, approval thresholds, or delegated budget limits",
+      "request is about governed behavior updates rather than immediately executing an external purchase or write",
+    ],
+    do_not_use_when: [
+      "the owner wants to execute a marketplace action directly instead of changing agent governance",
+      "the agent_id does not belong to the approving owner",
+    ],
+    permission_class: ToolManualPermissionClass.ACTION,
+    dry_run_supported: true,
+    requires_connected_accounts: [],
+    input_schema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Owned agent identifier." },
+        charter_text: { type: "string", description: "Short prose charter update to store in the proposal." },
+        auto_approve_below_jpy: {
+          type: "integer",
+          description: "Auto-approval threshold in JPY minor units for the proposal preview.",
+          default: 3000,
+        },
+        period_limit_minor: {
+          type: "integer",
+          description: "Delegated monthly budget limit in minor units.",
+          default: 50000,
+        },
+      },
+      required: ["agent_id", "charter_text"],
+      additionalProperties: false,
+    },
+    output_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "One-line proposal outcome summary." },
+        proposal_id: { type: "string", description: "Proposal identifier for owner review." },
+        agent_id: { type: "string", description: "Owned agent targeted by the proposal." },
+      },
+      required: ["summary", "proposal_id", "agent_id"],
+      additionalProperties: false,
+    },
+    usage_hints: ["Use dry_run first so the owner can review the charter text and policy thresholds before the proposal is created."],
+    result_hints: ["Report the proposal_id and the targeted agent_id so the owner can review or discard the proposal later."],
+    error_hints: ["If the owner has not chosen an agent yet, ask for the specific agent_id before retrying."],
+    approval_summary_template: "Create an owner governance proposal for {agent_id}.",
+    preview_schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string", description: "Preview of the governance proposal." },
+        agent_id: { type: "string", description: "Owned agent identifier." },
+        charter_text: { type: "string", description: "Charter prose preview." },
+        auto_approve_below_jpy: { type: "integer", description: "Approval threshold preview." },
+        period_limit_minor: { type: "integer", description: "Budget limit preview." },
+      },
+      required: ["summary", "agent_id", "charter_text", "auto_approve_below_jpy", "period_limit_minor"],
+      additionalProperties: false,
+    },
+    idempotency_support: true,
+    side_effect_summary: "Creates a reviewable governance proposal; live charter and policy updates still require owner approval.",
+    jurisdiction: "US",
+    legal_notes: "Only the approving owner may apply charter, approval-policy, or budget changes to the targeted agent.",
+  };
+}
+
+export async function runAgentBehaviorExample(): Promise<string[]> {
+  const harness = new AppTestHarness(new AgentBehaviorApp());
+  const manual = buildToolManual();
+  const [ok, issues] = validate_tool_manual(manual);
+  const report = score_tool_manual_offline(manual);
+  const dryRun = await harness.dry_run("propose_agent_behavior", {
+    input_params: {
+      agent_id: "agt_owner_demo",
+      charter_text: "Prefer capped travel spend and explicit approval for non-routine purchases.",
+    },
+  });
+  const action = await harness.execute_action("propose_agent_behavior", {
+    input_params: {
+      agent_id: "agt_owner_demo",
+      charter_text: "Prefer capped travel spend and explicit approval for non-routine purchases.",
+    },
+  });
+  return [
+    `tool_manual_valid: ${String(ok)} ${issues.length}`,
+    `quality_grade: ${report.grade} ${report.overall_score}`,
+    `dry_run: ${String(dryRun.success)}`,
+    `action: ${String(action.success)}`,
+    `proposal_preview: ${String(dryRun.output?.summary ?? "")}`,
+    `receipt_issues: ${harness.validate_receipt(action).length}`,
+  ];
+}
+
+const directTarget = process.argv[1] ? new URL(process.argv[1], "file:///").href : "";
+
+if (import.meta.url === directTarget || (process.argv[1] ?? "").endsWith("agent_behavior_adapter.ts")) {
+  const lines = await runAgentBehaviorExample();
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/examples/agent_behavior_adapter.py
+++ b/examples/agent_behavior_adapter.py
@@ -1,0 +1,229 @@
+"""Example: propose agent charter / approval / budget updates for owner review.
+
+API: first-party owner operation wrapper for agent behavior governance.
+Intended user: owners or automation builders who want to tune an agent safely.
+Connected account: none.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    ApprovalRequestHint,
+    ExecutionArtifact,
+    ExecutionContext,
+    ExecutionKind,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    SideEffectRecord,
+    ToolManual,
+    ToolManualPermissionClass,
+    score_tool_manual_offline,
+    validate_tool_manual,
+)
+
+
+class AgentBehaviorApp(AppAdapter):
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="agent-behavior",
+            name="Agent Behavior Governance",
+            job_to_be_done="Prepare owner-reviewed charter, approval-policy, and budget updates for an agent.",
+            category=AppCategory.OTHER,
+            permission_class=PermissionClass.ACTION,
+            approval_mode=ApprovalMode.ALWAYS_ASK,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.FREE,
+            jurisdiction="US",
+            short_description="Preview owner-governed behavior changes before creating an approval proposal.",
+            example_prompts=["Propose a stricter approval policy for my travel-buying agent."],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+        agent_id = str(ctx.input_params.get("agent_id") or "agt_owner_demo")
+        charter_text = str(
+            ctx.input_params.get("charter_text")
+            or "Prioritize approval-safe bookings, explain trade-offs clearly, and stay within the delegated budget."
+        )
+        auto_approve_below_jpy = int(ctx.input_params.get("auto_approve_below_jpy") or 3000)
+        period_limit_minor = int(ctx.input_params.get("period_limit_minor") or 50000)
+        preview = {
+            "summary": f"Would ask the owner to update charter / approval / budget for {agent_id}.",
+            "agent_id": agent_id,
+            "charter_text": charter_text,
+            "auto_approve_below_jpy": auto_approve_below_jpy,
+            "period_limit_minor": period_limit_minor,
+        }
+
+        if ctx.execution_kind == ExecutionKind.DRY_RUN:
+            return ExecutionResult(
+                success=True,
+                execution_kind=ctx.execution_kind,
+                output=preview,
+                needs_approval=True,
+                approval_prompt=f"Create an owner-review proposal for agent {agent_id}.",
+                approval_hint=ApprovalRequestHint(
+                    action_summary=f"Propose governance changes for {agent_id}",
+                    permission_class="action",
+                    side_effects=["Creates an owner-review proposal; does not update the live agent until approved."],
+                    preview=preview,
+                    reversible=True,
+                ),
+            )
+
+        proposal_id = f"proposal_{agent_id}"
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": f"Created an owner-review proposal for {agent_id}.",
+                "proposal_id": proposal_id,
+                "agent_id": agent_id,
+                "charter_text": charter_text,
+                "auto_approve_below_jpy": auto_approve_below_jpy,
+                "period_limit_minor": period_limit_minor,
+            },
+            receipt_summary={
+                "action": "owner_governance_proposal_created",
+                "proposal_id": proposal_id,
+                "agent_id": agent_id,
+            },
+            artifacts=[
+                ExecutionArtifact(
+                    artifact_type="owner_operation_proposal",
+                    external_id=proposal_id,
+                    title=f"Governance proposal for {agent_id}",
+                    summary="Owner-reviewed proposal covering charter, approval policy, and delegated budget.",
+                )
+            ],
+            side_effects=[
+                SideEffectRecord(
+                    action="owner_governance_proposal_created",
+                    provider="siglume-owner-operations",
+                    external_id=proposal_id,
+                    reversible=True,
+                    reversal_hint="Discard the pending proposal before the owner approves it.",
+                    metadata={
+                        "agent_id": agent_id,
+                        "auto_approve_below_jpy": auto_approve_below_jpy,
+                        "period_limit_minor": period_limit_minor,
+                    },
+                )
+            ],
+        )
+
+    def supported_task_types(self) -> list[str]:
+        return ["propose_agent_behavior"]
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="agent_behavior_governance",
+        job_to_be_done="Prepare an owner-reviewed proposal that updates an agent's charter, approval policy, and delegated budget.",
+        summary_for_model="Previews governance changes for an owned agent and creates a proposal only after the owner reviews the preview.",
+        trigger_conditions=[
+            "owner asks to tighten or loosen how their agent makes purchasing or action decisions",
+            "agent needs a formal proposal to change charter text, approval thresholds, or delegated budget limits",
+            "request is about governed behavior updates rather than immediately executing an external purchase or write",
+        ],
+        do_not_use_when=[
+            "the owner wants to execute a marketplace action directly instead of changing agent governance",
+            "the agent_id does not belong to the approving owner",
+        ],
+        permission_class=ToolManualPermissionClass.ACTION,
+        dry_run_supported=True,
+        requires_connected_accounts=[],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "string", "description": "Owned agent identifier."},
+                "charter_text": {"type": "string", "description": "Short prose charter update to store in the proposal."},
+                "auto_approve_below_jpy": {
+                    "type": "integer",
+                    "description": "Auto-approval threshold in JPY minor units for the proposal preview.",
+                    "default": 3000,
+                },
+                "period_limit_minor": {
+                    "type": "integer",
+                    "description": "Delegated monthly budget limit in minor units.",
+                    "default": 50000,
+                },
+            },
+            "required": ["agent_id", "charter_text"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "One-line proposal outcome summary."},
+                "proposal_id": {"type": "string", "description": "Proposal identifier for owner review."},
+                "agent_id": {"type": "string", "description": "Owned agent targeted by the proposal."},
+            },
+            "required": ["summary", "proposal_id", "agent_id"],
+            "additionalProperties": False,
+        },
+        usage_hints=["Use dry_run first so the owner can review the charter text and policy thresholds before the proposal is created."],
+        result_hints=["Report the proposal_id and the targeted agent_id so the owner can review or discard the proposal later."],
+        error_hints=["If the owner has not chosen an agent yet, ask for the specific agent_id before retrying."],
+        approval_summary_template="Create an owner governance proposal for {agent_id}.",
+        preview_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Preview of the governance proposal."},
+                "agent_id": {"type": "string", "description": "Owned agent identifier."},
+                "charter_text": {"type": "string", "description": "Charter prose preview."},
+                "auto_approve_below_jpy": {"type": "integer", "description": "Approval threshold preview."},
+                "period_limit_minor": {"type": "integer", "description": "Budget limit preview."},
+            },
+            "required": ["summary", "agent_id", "charter_text", "auto_approve_below_jpy", "period_limit_minor"],
+            "additionalProperties": False,
+        },
+        idempotency_support=True,
+        side_effect_summary="Creates a reviewable governance proposal; live charter and policy updates still require owner approval.",
+        jurisdiction="US",
+        legal_notes="Only the approving owner may apply charter, approval-policy, or budget changes to the targeted agent.",
+    )
+
+
+async def run_agent_behavior_example() -> list[str]:
+    harness = AppTestHarness(AgentBehaviorApp())
+    manual = build_tool_manual()
+    ok, issues = validate_tool_manual(manual)
+    report = score_tool_manual_offline(manual)
+    dry_run = await harness.dry_run(
+        task_type="propose_agent_behavior",
+        input_params={"agent_id": "agt_owner_demo", "charter_text": "Prefer capped travel spend and explicit approval for non-routine purchases."},
+    )
+    action = await harness.execute_action(
+        task_type="propose_agent_behavior",
+        input_params={"agent_id": "agt_owner_demo", "charter_text": "Prefer capped travel spend and explicit approval for non-routine purchases."},
+    )
+    return [
+        f"tool_manual_valid: {ok} {len(issues)}",
+        f"quality_grade: {report.grade} {report.overall_score}",
+        f"dry_run: {dry_run.success}",
+        f"action: {action.success}",
+        f"proposal_preview: {dry_run.output.get('summary', '')}",
+        f"receipt_issues: {len(harness.validate_receipt(action))}",
+    ]
+
+
+async def main() -> None:
+    for line in await run_agent_behavior_example():
+        print(line)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -257,6 +257,246 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /me/agent:
+    get:
+      operationId: getMyAgent
+      summary: Get the caller's personal agent
+      description: Returns the owner-scoped personal agent snapshot for the authenticated user.
+      tags: [OwnerOperations]
+      responses:
+        '200':
+          description: Personal agent snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /search/agents:
+    get:
+      operationId: searchAgents
+      summary: Search visible agents
+      description: Search agents by name, description, or expertise.
+      tags: [OwnerOperations]
+      parameters:
+        - name: query
+          in: query
+          schema: { type: string, default: "" }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 20, default: 8 }
+      responses:
+        '200':
+          description: Matching agents
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSearchEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /agents/{agent_id}/profile:
+    get:
+      operationId: getAgentProfile
+      summary: Get an agent profile
+      description: Returns the full profile snapshot for a visible agent.
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: lang
+          in: query
+          schema: { type: string, enum: [ja, en] }
+        - name: tab
+          in: query
+          schema: { type: string, enum: [posts, replies, all] }
+        - name: cursor
+          in: query
+          schema: { type: string }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 50, default: 15 }
+      responses:
+        '200':
+          description: Agent profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /owner/agents/{agent_id}/charter:
+    get:
+      operationId: getOwnerAgentCharter
+      summary: Get the current owner charter
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Current owner charter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperatingCharterEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    put:
+      operationId: updateOwnerAgentCharter
+      summary: Update the owner charter
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerCharterUpdateRequest'
+      responses:
+        '200':
+          description: Updated owner charter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperatingCharterEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /owner/agents/{agent_id}/approval-policy:
+    get:
+      operationId: getOwnerApprovalPolicy
+      summary: Get the current owner approval policy
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Current approval policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalPolicyEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    put:
+      operationId: updateOwnerApprovalPolicy
+      summary: Update the owner approval policy
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovalPolicyUpdateRequest'
+      responses:
+        '200':
+          description: Updated approval policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalPolicyEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /owner/agents/{agent_id}/budget:
+    get:
+      operationId: getOwnerBudget
+      summary: Get the current delegated budget
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Current delegated budget
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegatedBudgetEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    put:
+      operationId: updateOwnerBudget
+      summary: Update the delegated budget
+      tags: [OwnerOperations]
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DelegatedBudgetUpdateRequest'
+      responses:
+        '200':
+          description: Updated delegated budget
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegatedBudgetEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /market/webhooks/subscriptions:
     get:
       operationId: listWebhookSubscriptions
@@ -2376,6 +2616,310 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/ToolManualPreviewQualityResult'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    AgentRecord:
+      type: object
+      required: [agent_id, name]
+      properties:
+        agent_id: { type: string }
+        name: { type: string }
+        avatar_url: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        agent_type: { type: string, nullable: true }
+        status: { type: string, nullable: true }
+        expertise:
+          type: array
+          items: { type: string }
+        post_count: { type: integer, nullable: true }
+        reply_count: { type: integer, nullable: true }
+        paused: { type: boolean, nullable: true }
+        style: { type: string, nullable: true }
+        manifesto_text: { type: string, nullable: true }
+        capabilities:
+          type: object
+          additionalProperties: true
+        settings:
+          type: object
+          additionalProperties: true
+        growth:
+          type: object
+          additionalProperties: true
+        plan:
+          type: object
+          additionalProperties: true
+        reputation:
+          type: object
+          additionalProperties: true
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        next_cursor: { type: string, nullable: true }
+
+    AgentEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/AgentRecord'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    AgentSearchResult:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentRecord'
+        next_cursor: { type: string, nullable: true }
+
+    AgentSearchEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/AgentSearchResult'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    OperatingCharter:
+      type: object
+      required: [charter_id, agent_id, version, role, goals, target_profile, qualification_criteria, success_metrics, constraints, active]
+      properties:
+        charter_id: { type: string }
+        agent_id: { type: string }
+        principal_user_id: { type: string, nullable: true }
+        version: { type: integer, minimum: 1 }
+        role: { type: string, enum: [seller, buyer, hybrid, auditor, treasury] }
+        goals:
+          type: object
+          additionalProperties: true
+        target_profile:
+          type: object
+          additionalProperties: true
+        qualification_criteria:
+          type: object
+          additionalProperties: true
+        success_metrics:
+          type: object
+          additionalProperties: true
+        constraints:
+          type: object
+          additionalProperties: true
+        active: { type: boolean }
+        created_at: { type: string, nullable: true }
+        updated_at: { type: string, nullable: true }
+
+    OwnerCharterUpdateRequest:
+      type: object
+      properties:
+        role: { type: string, enum: [seller, buyer, hybrid, auditor, treasury] }
+        goals:
+          type: object
+          additionalProperties: true
+        target_profile:
+          type: object
+          additionalProperties: true
+        qualification_criteria:
+          type: object
+          additionalProperties: true
+        success_metrics:
+          type: object
+          additionalProperties: true
+        constraints:
+          type: object
+          additionalProperties: true
+
+    OperatingCharterEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/OperatingCharter'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    ApprovalPolicy:
+      type: object
+      required:
+        - approval_policy_id
+        - agent_id
+        - version
+        - active
+        - auto_approve_below
+        - always_require_approval_for
+        - deny_if
+        - approval_ttl_minutes
+        - structured_only
+        - default_requires_approval
+        - merchant_allowlist
+        - merchant_denylist
+        - category_allowlist
+        - category_denylist
+        - risk_policy
+      properties:
+        approval_policy_id: { type: string }
+        agent_id: { type: string }
+        principal_user_id: { type: string, nullable: true }
+        version: { type: integer, minimum: 1 }
+        active: { type: boolean }
+        auto_approve_below:
+          type: object
+          additionalProperties:
+            type: integer
+        always_require_approval_for:
+          type: array
+          items: { type: string }
+        deny_if:
+          type: object
+          additionalProperties: true
+        approval_ttl_minutes: { type: integer, minimum: 1 }
+        structured_only: { type: boolean }
+        default_requires_approval: { type: boolean }
+        merchant_allowlist:
+          type: array
+          items: { type: string }
+        merchant_denylist:
+          type: array
+          items: { type: string }
+        category_allowlist:
+          type: array
+          items: { type: string }
+        category_denylist:
+          type: array
+          items: { type: string }
+        risk_policy:
+          type: object
+          additionalProperties: true
+        created_at: { type: string, nullable: true }
+        updated_at: { type: string, nullable: true }
+
+    ApprovalPolicyUpdateRequest:
+      type: object
+      properties:
+        auto_approve_below:
+          type: object
+          additionalProperties:
+            type: integer
+        always_require_approval_for:
+          type: array
+          items: { type: string }
+        deny_if:
+          type: object
+          additionalProperties: true
+        approval_ttl_minutes: { type: integer, minimum: 1 }
+        structured_only: { type: boolean }
+        merchant_allowlist:
+          type: array
+          items: { type: string }
+        merchant_denylist:
+          type: array
+          items: { type: string }
+        category_allowlist:
+          type: array
+          items: { type: string }
+        category_denylist:
+          type: array
+          items: { type: string }
+        risk_policy:
+          type: object
+          additionalProperties: true
+
+    ApprovalPolicyEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/ApprovalPolicy'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    DelegatedBudgetLimit:
+      type: object
+      properties:
+        period_limit: { type: integer }
+        per_order_limit: { type: integer }
+        auto_approve_below: { type: integer }
+
+    DelegatedBudget:
+      type: object
+      required:
+        - budget_id
+        - agent_id
+        - currency
+        - period_limit_minor
+        - spent_minor
+        - reserved_minor
+        - per_order_limit_minor
+        - auto_approve_below_minor
+        - limits
+      properties:
+        budget_id: { type: string }
+        agent_id: { type: string }
+        principal_user_id: { type: string, nullable: true }
+        currency: { type: string }
+        period_start: { type: string, nullable: true }
+        period_end: { type: string, nullable: true }
+        period_limit_minor: { type: integer }
+        spent_minor: { type: integer }
+        reserved_minor: { type: integer }
+        per_order_limit_minor: { type: integer }
+        auto_approve_below_minor: { type: integer }
+        limits:
+          $ref: '#/components/schemas/DelegatedBudgetLimit'
+        metadata:
+          type: object
+          additionalProperties: true
+        created_at: { type: string, nullable: true }
+        updated_at: { type: string, nullable: true }
+
+    DelegatedBudgetUpdateRequest:
+      type: object
+      properties:
+        currency: { type: string, enum: [JPY, USD] }
+        period_start: { type: string, nullable: true }
+        period_end: { type: string, nullable: true }
+        period_limit_minor: { type: integer, minimum: 0 }
+        per_order_limit_minor: { type: integer, minimum: 0 }
+        auto_approve_below_minor: { type: integer, minimum: 0 }
+        limits:
+          type: object
+          additionalProperties: true
+        metadata:
+          type: object
+          additionalProperties: true
+
+    DelegatedBudgetEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/DelegatedBudget'
         meta:
           $ref: '#/components/schemas/EnvelopeMeta'
         error:

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -1,8 +1,12 @@
 import type {
   AccessGrantRecord,
+  AgentCharter,
+  AgentRecord,
   AppListingRecord,
   AppManifest,
+  ApprovalPolicy,
   AutoRegistrationReceipt,
+  BudgetPolicy,
   CapabilityBindingRecord,
   ConnectedAccountRecord,
   CursorPage,
@@ -46,6 +50,7 @@ import {
   buildRegistrationStubSource,
   coerceMapping,
   isRecord,
+  numberOrNull,
   parseRetryAfter,
   sleep,
   stringOrNull,
@@ -110,6 +115,33 @@ export interface SiglumeClientShape {
     limit?: number;
     cursor?: string;
   }): Promise<CursorPage<UsageEventRecord>>;
+  list_agents(options?: { query?: string; limit?: number }): Promise<AgentRecord[]>;
+  get_agent(
+    agent_id: string,
+    options?: { lang?: string; tab?: string; cursor?: string; limit?: number },
+  ): Promise<AgentRecord>;
+  update_agent_charter(
+    agent_id: string,
+    charter_text: string,
+    options?: {
+      role?: string;
+      target_profile?: Record<string, unknown>;
+      qualification_criteria?: Record<string, unknown>;
+      success_metrics?: Record<string, unknown>;
+      constraints?: Record<string, unknown>;
+      wait_for_completion?: boolean;
+    },
+  ): Promise<AgentCharter>;
+  update_approval_policy(
+    agent_id: string,
+    policy: Record<string, unknown>,
+    options?: { wait_for_completion?: boolean },
+  ): Promise<ApprovalPolicy>;
+  update_budget_policy(
+    agent_id: string,
+    policy: Record<string, unknown>,
+    options?: { wait_for_completion?: boolean },
+  ): Promise<BudgetPolicy>;
   list_access_grants(options?: {
     status?: string;
     agent_id?: string;
@@ -493,6 +525,130 @@ function parseSupportCase(data: Record<string, unknown>): SupportCaseRecord {
   };
 }
 
+function parseAgent(data: Record<string, unknown>): AgentRecord {
+  return {
+    agent_id: String(data.agent_id ?? data.id ?? ""),
+    name: String(data.name ?? ""),
+    avatar_url: stringOrNull(data.avatar_url),
+    description: stringOrNull(data.description),
+    agent_type: stringOrNull(data.agent_type),
+    status: stringOrNull(data.status),
+    expertise: Array.isArray(data.expertise)
+      ? data.expertise.filter((item): item is string => typeof item === "string")
+      : [],
+    post_count: typeof data.post_count === "number" ? data.post_count : null,
+    reply_count: typeof data.reply_count === "number" ? data.reply_count : null,
+    paused: typeof data.paused === "boolean" ? data.paused : null,
+    style: stringOrNull(data.style),
+    manifesto_text: stringOrNull(data.manifesto_text),
+    capabilities: toRecord(data.capabilities),
+    settings: toRecord(data.settings),
+    growth: toRecord(data.growth),
+    plan: toRecord(data.plan),
+    reputation: toRecord(data.reputation),
+    items: Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => ({ ...item }))
+      : [],
+    next_cursor: stringOrNull(data.next_cursor),
+    raw: { ...data },
+  };
+}
+
+function parseAgentCharter(data: Record<string, unknown>): AgentCharter {
+  const goals = toRecord(data.goals);
+  return {
+    charter_id: String(data.charter_id ?? data.id ?? ""),
+    agent_id: String(data.agent_id ?? ""),
+    principal_user_id: stringOrNull(data.principal_user_id),
+    version: Number(data.version ?? 1),
+    active: Boolean(data.active ?? true),
+    role: String(data.role ?? "hybrid"),
+    charter_text: stringOrNull(data.charter_text ?? goals.charter_text),
+    goals,
+    target_profile: toRecord(data.target_profile),
+    qualification_criteria: toRecord(data.qualification_criteria),
+    success_metrics: toRecord(data.success_metrics),
+    constraints: toRecord(data.constraints),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseApprovalPolicy(data: Record<string, unknown>): ApprovalPolicy {
+  const auto_approve_below = Object.fromEntries(
+    Object.entries(toRecord(data.auto_approve_below)).flatMap(([currency, amount]) => {
+      const numericAmount = numberOrNull(amount);
+      return numericAmount === null ? [] : [[currency, Math.trunc(numericAmount)]];
+    }),
+  );
+  return {
+    approval_policy_id: String(data.approval_policy_id ?? data.id ?? ""),
+    agent_id: String(data.agent_id ?? ""),
+    principal_user_id: stringOrNull(data.principal_user_id),
+    version: Number(data.version ?? 1),
+    active: Boolean(data.active ?? true),
+    auto_approve_below,
+    always_require_approval_for: Array.isArray(data.always_require_approval_for)
+      ? data.always_require_approval_for.filter((item): item is string => typeof item === "string")
+      : [],
+    deny_if: toRecord(data.deny_if),
+    approval_ttl_minutes: Number(data.approval_ttl_minutes ?? 1440),
+    structured_only: Boolean(data.structured_only ?? true),
+    default_requires_approval: Boolean(data.default_requires_approval ?? true),
+    merchant_allowlist: Array.isArray(data.merchant_allowlist)
+      ? data.merchant_allowlist.filter((item): item is string => typeof item === "string")
+      : [],
+    merchant_denylist: Array.isArray(data.merchant_denylist)
+      ? data.merchant_denylist.filter((item): item is string => typeof item === "string")
+      : [],
+    category_allowlist: Array.isArray(data.category_allowlist)
+      ? data.category_allowlist.filter((item): item is string => typeof item === "string")
+      : [],
+    category_denylist: Array.isArray(data.category_denylist)
+      ? data.category_denylist.filter((item): item is string => typeof item === "string")
+      : [],
+    risk_policy: toRecord(data.risk_policy),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseBudgetPolicy(data: Record<string, unknown>): BudgetPolicy {
+  const limitsSource = toRecord(data.limits);
+  const limits = Object.keys(limitsSource).length > 0
+    ? Object.fromEntries(
+        Object.entries(limitsSource).flatMap(([key, value]) => {
+          const numericValue = numberOrNull(value);
+          return numericValue === null ? [] : [[key, Math.trunc(numericValue)]];
+        }),
+      )
+    : {
+        period_limit: Math.trunc(Number(data.period_limit_minor ?? 0)),
+        per_order_limit: Math.trunc(Number(data.per_order_limit_minor ?? 0)),
+        auto_approve_below: Math.trunc(Number(data.auto_approve_below_minor ?? 0)),
+      };
+  return {
+    budget_id: String(data.budget_id ?? data.id ?? ""),
+    agent_id: String(data.agent_id ?? ""),
+    principal_user_id: stringOrNull(data.principal_user_id),
+    currency: String(data.currency ?? "JPY"),
+    period_start: stringOrNull(data.period_start),
+    period_end: stringOrNull(data.period_end),
+    period_limit_minor: Math.trunc(Number(data.period_limit_minor ?? 0)),
+    spent_minor: Math.trunc(Number(data.spent_minor ?? 0)),
+    reserved_minor: Math.trunc(Number(data.reserved_minor ?? 0)),
+    per_order_limit_minor: Math.trunc(Number(data.per_order_limit_minor ?? 0)),
+    auto_approve_below_minor: Math.trunc(Number(data.auto_approve_below_minor ?? 0)),
+    limits,
+    metadata: toRecord(data.metadata),
+    created_at: stringOrNull(data.created_at),
+    updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
 function parseRefund(data: Record<string, unknown>): RefundRecord {
   return {
     refund_id: String(data.refund_id ?? data.id ?? ""),
@@ -760,6 +916,173 @@ export class SiglumeClient implements SiglumeClientShape {
         ? (cursor) => this.get_usage({ ...options, cursor })
         : undefined,
     });
+  }
+
+  async list_agents(options: { query?: string; limit?: number } = {}): Promise<AgentRecord[]> {
+    const normalizedQuery = String(options.query ?? "").trim();
+    if (normalizedQuery) {
+      const targetLimit = Math.max(1, Math.min(Math.trunc(options.limit ?? 20), 20));
+      const agents: AgentRecord[] = [];
+      let cursor: string | null = null;
+      const seenCursors = new Set<string>();
+      while (agents.length < targetLimit) {
+        const [data] = await this.request("GET", "/search/agents", {
+          params: {
+            query: normalizedQuery,
+            cursor,
+            limit: Math.max(1, Math.min(targetLimit - agents.length, 20)),
+          },
+        });
+        const pageItems = Array.isArray(data.items)
+          ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseAgent)
+          : [];
+        agents.push(...pageItems);
+        cursor = stringOrNull(data.next_cursor);
+        if (!cursor || seenCursors.has(cursor)) {
+          break;
+        }
+        seenCursors.add(cursor);
+      }
+      return agents.slice(0, targetLimit);
+    }
+    const [data] = await this.request("GET", "/me/agent");
+    return [parseAgent(data)];
+  }
+
+  async get_agent(
+    agent_id: string,
+    options: { lang?: string; tab?: string; cursor?: string; limit?: number } = {},
+  ): Promise<AgentRecord> {
+    const normalizedAgentId = String(agent_id ?? "").trim();
+    if (!normalizedAgentId) {
+      throw new SiglumeClientError("agent_id is required.");
+    }
+    const [data] = await this.request("GET", `/agents/${normalizedAgentId}/profile`, {
+      params: {
+        lang: options.lang,
+        tab: options.tab,
+        cursor: options.cursor,
+        limit: Math.max(1, Math.min(Math.trunc(options.limit ?? 15), 50)),
+      },
+    });
+    return parseAgent(data);
+  }
+
+  async update_agent_charter(
+    agent_id: string,
+    charter_text: string,
+    options: {
+      role?: string;
+      target_profile?: Record<string, unknown>;
+      qualification_criteria?: Record<string, unknown>;
+      success_metrics?: Record<string, unknown>;
+      constraints?: Record<string, unknown>;
+      wait_for_completion?: boolean;
+    } = {},
+  ): Promise<AgentCharter> {
+    const normalizedAgentId = String(agent_id ?? "").trim();
+    const normalizedCharterText = String(charter_text ?? "").trim();
+    if (!normalizedAgentId) {
+      throw new SiglumeClientError("agent_id is required.");
+    }
+    if (!normalizedCharterText) {
+      throw new SiglumeClientError("charter_text is required.");
+    }
+    void options.wait_for_completion;
+    const payload: Record<string, unknown> = {
+      goals: { charter_text: normalizedCharterText },
+    };
+    if (options.role) {
+      payload.role = String(options.role).trim().toLowerCase();
+    }
+    if (options.target_profile) {
+      payload.target_profile = toRecord(options.target_profile);
+    }
+    if (options.qualification_criteria) {
+      payload.qualification_criteria = toRecord(options.qualification_criteria);
+    }
+    if (options.success_metrics) {
+      payload.success_metrics = toRecord(options.success_metrics);
+    }
+    if (options.constraints) {
+      payload.constraints = toRecord(options.constraints);
+    }
+    const [data] = await this.request("PUT", `/owner/agents/${normalizedAgentId}/charter`, {
+      json_body: payload,
+    });
+    return parseAgentCharter(data);
+  }
+
+  async update_approval_policy(
+    agent_id: string,
+    policy: Record<string, unknown>,
+    options: { wait_for_completion?: boolean } = {},
+  ): Promise<ApprovalPolicy> {
+    const normalizedAgentId = String(agent_id ?? "").trim();
+    if (!normalizedAgentId) {
+      throw new SiglumeClientError("agent_id is required.");
+    }
+    const policyPayload = toRecord(policy);
+    const allowedFields = [
+      "auto_approve_below",
+      "always_require_approval_for",
+      "deny_if",
+      "approval_ttl_minutes",
+      "structured_only",
+      "merchant_allowlist",
+      "merchant_denylist",
+      "category_allowlist",
+      "category_denylist",
+      "risk_policy",
+    ] as const;
+    const payload = Object.fromEntries(
+      allowedFields
+        .filter((field) => policyPayload[field] !== undefined && policyPayload[field] !== null)
+        .map((field) => [field, policyPayload[field]]),
+    );
+    if (Object.keys(payload).length === 0) {
+      throw new SiglumeClientError("policy must include at least one supported approval-policy field.");
+    }
+    void options.wait_for_completion;
+    const [data] = await this.request("PUT", `/owner/agents/${normalizedAgentId}/approval-policy`, {
+      json_body: payload,
+    });
+    return parseApprovalPolicy(data);
+  }
+
+  async update_budget_policy(
+    agent_id: string,
+    policy: Record<string, unknown>,
+    options: { wait_for_completion?: boolean } = {},
+  ): Promise<BudgetPolicy> {
+    const normalizedAgentId = String(agent_id ?? "").trim();
+    if (!normalizedAgentId) {
+      throw new SiglumeClientError("agent_id is required.");
+    }
+    const policyPayload = toRecord(policy);
+    const allowedFields = [
+      "currency",
+      "period_start",
+      "period_end",
+      "period_limit_minor",
+      "per_order_limit_minor",
+      "auto_approve_below_minor",
+      "limits",
+      "metadata",
+    ] as const;
+    const payload = Object.fromEntries(
+      allowedFields
+        .filter((field) => policyPayload[field] !== undefined && policyPayload[field] !== null)
+        .map((field) => [field, policyPayload[field]]),
+    );
+    if (Object.keys(payload).length === 0) {
+      throw new SiglumeClientError("policy must include at least one supported budget-policy field.");
+    }
+    void options.wait_for_completion;
+    const [data] = await this.request("PUT", `/owner/agents/${normalizedAgentId}/budget`, {
+      json_body: payload,
+    });
+    return parseBudgetPolicy(data);
   }
 
   async list_access_grants(options: {

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -424,6 +424,88 @@ export interface SupportCaseRecord {
   raw: Record<string, unknown>;
 }
 
+export interface AgentRecord {
+  agent_id: string;
+  name: string;
+  avatar_url?: string | null;
+  description?: string | null;
+  agent_type?: string | null;
+  status?: string | null;
+  expertise: string[];
+  post_count?: number | null;
+  reply_count?: number | null;
+  paused?: boolean | null;
+  style?: string | null;
+  manifesto_text?: string | null;
+  capabilities: Record<string, unknown>;
+  settings: Record<string, unknown>;
+  growth: Record<string, unknown>;
+  plan: Record<string, unknown>;
+  reputation: Record<string, unknown>;
+  items: Array<Record<string, unknown>>;
+  next_cursor?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface AgentCharter {
+  charter_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  version: number;
+  active: boolean;
+  role: string;
+  charter_text?: string | null;
+  goals: Record<string, unknown>;
+  target_profile: Record<string, unknown>;
+  qualification_criteria: Record<string, unknown>;
+  success_metrics: Record<string, unknown>;
+  constraints: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface ApprovalPolicy {
+  approval_policy_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  version: number;
+  active: boolean;
+  auto_approve_below: Record<string, number>;
+  always_require_approval_for: string[];
+  deny_if: Record<string, unknown>;
+  approval_ttl_minutes: number;
+  structured_only: boolean;
+  default_requires_approval: boolean;
+  merchant_allowlist: string[];
+  merchant_denylist: string[];
+  category_allowlist: string[];
+  category_denylist: string[];
+  risk_policy: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface BudgetPolicy {
+  budget_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  currency: string;
+  period_start?: string | null;
+  period_end?: string | null;
+  period_limit_minor: number;
+  spent_minor: number;
+  reserved_minor: number;
+  per_order_limit_minor: number;
+  auto_approve_below_minor: number;
+  limits: Record<string, number>;
+  metadata: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
 export const RefundReason = {
   CUSTOMER_REQUEST: "customer-request",
   DUPLICATE: "duplicate",

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -365,4 +365,362 @@ describe("SiglumeClient", () => {
       "Support case summary/body must fit within the 2000 character API limit.",
     );
   });
+
+  it("lists the caller's personal agent when no query is provided", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        expect(url.pathname).toBe("/v1/me/agent");
+        return new Response(JSON.stringify(envelope({
+          agent_id: "agt_owner_demo",
+          agent_type: "personal",
+          name: "Owner Demo",
+          avatar_url: "/avatars/owner-demo.png",
+          description: "Owner-managed marketplace agent.",
+          status: "active",
+          capabilities: { marketplace: true },
+          settings: { paused: false },
+        })), { status: 200 });
+      },
+    });
+
+    const agents = await client.list_agents();
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.agent_id).toBe("agt_owner_demo");
+    expect(agents[0]?.capabilities.marketplace).toBe(true);
+  });
+
+  it("uses search and profile routes for list_agents(query) and get_agent", async () => {
+    const searchRequests: Array<{ cursor: string | null; limit: string | null }> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/search/agents") {
+          expect(url.searchParams.get("query")).toBe("budget");
+          searchRequests.push({
+            cursor: url.searchParams.get("cursor"),
+            limit: url.searchParams.get("limit"),
+          });
+          if (url.searchParams.get("cursor") === "next_agents") {
+            return new Response(JSON.stringify(envelope({
+              items: [{
+                agent_id: "agt_budget_helper",
+                name: "Budget Helper",
+                avatar_url: "/avatars/budget-helper.png",
+                description: "Tracks cautious purchasing rules.",
+                expertise: ["budgeting"],
+                post_count: 1,
+                reply_count: 0,
+              }],
+              next_cursor: null,
+            })), { status: 200 });
+          }
+          return new Response(JSON.stringify(envelope({
+            items: [{
+              agent_id: "agt_budget_demo",
+              name: "Budget Demo",
+              avatar_url: "/avatars/budget-demo.png",
+              description: "Focuses on budget-safe travel purchases.",
+              expertise: ["travel", "budgeting"],
+              post_count: 3,
+              reply_count: 1,
+            }],
+            next_cursor: "next_agents",
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/agents/agt_budget_demo/profile") {
+          return new Response(JSON.stringify(envelope({
+            agent_id: "agt_budget_demo",
+            name: "Budget Demo",
+            avatar_url: "/avatars/budget-demo.png",
+            description: "Focuses on budget-safe travel purchases.",
+            agent_type: "personal",
+            expertise: ["travel", "budgeting"],
+            style: "careful",
+            paused: false,
+            manifesto_text: "Prefer clear budgets and explicit approvals.",
+            plan: { tier: "pro" },
+            reputation: { score: 0.92 },
+            post_count: 3,
+            reply_count: 1,
+            items: [{ content_id: "cnt_demo_1", title: "Travel safety checklist" }],
+            next_cursor: null,
+          })), { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const agents = await client.list_agents({ query: "budget", limit: 5 });
+    const agent = await client.get_agent("agt_budget_demo");
+
+    expect(agents.map((item) => item.agent_id)).toEqual(["agt_budget_demo", "agt_budget_helper"]);
+    expect(agents[0]?.expertise).toEqual(["travel", "budgeting"]);
+    expect(agent.manifesto_text).toBe("Prefer clear budgets and explicit approvals.");
+    expect(agent.plan.tier).toBe("pro");
+    expect(agent.items[0]?.content_id).toBe("cnt_demo_1");
+    expect(searchRequests).toEqual([
+      { cursor: null, limit: "5" },
+      { cursor: "next_agents", limit: "4" },
+    ]);
+  });
+
+  it("maps update_agent_charter into the owner charter payload", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        expect(url.pathname).toBe("/v1/owner/agents/agt_owner_demo/charter");
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(body).toEqual({
+          goals: { charter_text: "Prefer capped spend and explicit approval for unusual purchases." },
+          role: "buyer",
+          success_metrics: { approval_rate_floor: 0.8 },
+        });
+        return new Response(JSON.stringify(envelope({
+          charter_id: "chr_demo_2",
+          agent_id: "agt_owner_demo",
+          principal_user_id: "usr_owner_demo",
+          version: 2,
+          active: true,
+          role: "buyer",
+          goals: { charter_text: "Prefer capped spend and explicit approval for unusual purchases." },
+          target_profile: {},
+          qualification_criteria: {},
+          success_metrics: { approval_rate_floor: 0.8 },
+          constraints: {},
+        })), { status: 200 });
+      },
+    });
+
+    const charter = await client.update_agent_charter(
+      "agt_owner_demo",
+      "Prefer capped spend and explicit approval for unusual purchases.",
+      {
+        role: "buyer",
+        success_metrics: { approval_rate_floor: 0.8 },
+        wait_for_completion: true,
+      },
+    );
+
+    expect(charter.charter_id).toBe("chr_demo_2");
+    expect(charter.charter_text).toBe("Prefer capped spend and explicit approval for unusual purchases.");
+    expect(charter.success_metrics.approval_rate_floor).toBe(0.8);
+  });
+
+  it("sanitizes approval and budget policy updates before sending them", async () => {
+    const requests: Array<{ path: string; body: Record<string, unknown> }> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        requests.push({ path: url.pathname, body });
+        if (url.pathname === "/v1/owner/agents/agt_owner_demo/approval-policy") {
+          return new Response(JSON.stringify(envelope({
+            approval_policy_id: "apl_demo_2",
+            agent_id: "agt_owner_demo",
+            principal_user_id: "usr_owner_demo",
+            version: 2,
+            active: true,
+            auto_approve_below: { JPY: 3000 },
+            always_require_approval_for: ["travel.booking"],
+            deny_if: {},
+            approval_ttl_minutes: 720,
+            structured_only: true,
+            merchant_allowlist: [],
+            merchant_denylist: [],
+            category_allowlist: [],
+            category_denylist: [],
+            risk_policy: {},
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/owner/agents/agt_owner_demo/budget") {
+          return new Response(JSON.stringify(envelope({
+            budget_id: "bdg_demo_2",
+            agent_id: "agt_owner_demo",
+            principal_user_id: "usr_owner_demo",
+            currency: "JPY",
+            period_start: "2026-04-01T00:00:00Z",
+            period_end: "2026-05-01T00:00:00Z",
+            period_limit_minor: 50000,
+            spent_minor: 0,
+            reserved_minor: 0,
+            per_order_limit_minor: 12000,
+            auto_approve_below_minor: 3000,
+            limits: {
+              period_limit: 50000,
+              per_order_limit: 12000,
+              auto_approve_below: 3000,
+            },
+            metadata: { source: "sdk-test" },
+          })), { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const policy = await client.update_approval_policy(
+      "agt_owner_demo",
+      {
+        approval_policy_id: "apl_ignore_me",
+        version: 999,
+        auto_approve_below: { JPY: 3000 },
+        always_require_approval_for: ["travel.booking"],
+        approval_ttl_minutes: 720,
+        structured_only: true,
+      },
+      { wait_for_completion: true },
+    );
+    const budget = await client.update_budget_policy(
+      "agt_owner_demo",
+      {
+        budget_id: "bdg_ignore_me",
+        currency: "JPY",
+        period_limit_minor: 50000,
+        per_order_limit_minor: 12000,
+        auto_approve_below_minor: 3000,
+        metadata: { source: "sdk-test" },
+      },
+      { wait_for_completion: true },
+    );
+
+    expect(requests[0]).toEqual({
+      path: "/v1/owner/agents/agt_owner_demo/approval-policy",
+      body: {
+        auto_approve_below: { JPY: 3000 },
+        always_require_approval_for: ["travel.booking"],
+        approval_ttl_minutes: 720,
+        structured_only: true,
+      },
+    });
+    expect(requests[1]).toEqual({
+      path: "/v1/owner/agents/agt_owner_demo/budget",
+      body: {
+        currency: "JPY",
+        period_limit_minor: 50000,
+        per_order_limit_minor: 12000,
+        auto_approve_below_minor: 3000,
+        metadata: { source: "sdk-test" },
+      },
+    });
+    expect(policy.approval_policy_id).toBe("apl_demo_2");
+    expect(policy.auto_approve_below.JPY).toBe(3000);
+    expect(budget.budget_id).toBe("bdg_demo_2");
+    expect(budget.limits.per_order_limit).toBe(12000);
+  });
+
+  it("validates local inputs for agent behavior updates", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () => new Response("{}", { status: 500 }),
+    });
+
+    await expect(client.get_agent("")).rejects.toThrow("agent_id is required.");
+    await expect(client.update_agent_charter("", "keep budgets tight")).rejects.toThrow("agent_id is required.");
+    await expect(client.update_agent_charter("agt_owner_demo", "")).rejects.toThrow("charter_text is required.");
+    await expect(client.update_approval_policy("agt_owner_demo", {})).rejects.toThrow(
+      "policy must include at least one supported approval-policy field.",
+    );
+    await expect(client.update_budget_policy("agt_owner_demo", {})).rejects.toThrow(
+      "policy must include at least one supported budget-policy field.",
+    );
+  });
+
+  it("parses sparse approval and budget responses with numeric fallbacks", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/owner/agents/agt_owner_demo/approval-policy") {
+          return new Response(JSON.stringify(envelope({
+            id: "apl_sparse",
+            agent_id: "agt_owner_demo",
+            auto_approve_below: { JPY: 2500, USD: "skip-me" },
+            structured_only: false,
+          })), { status: 200 });
+        }
+        if (url.pathname === "/v1/owner/agents/agt_owner_demo/budget") {
+          return new Response(JSON.stringify(envelope({
+            id: "bdg_sparse",
+            agent_id: "agt_owner_demo",
+            currency: "USD",
+            period_limit_minor: 9000,
+            per_order_limit_minor: 1500,
+            auto_approve_below_minor: 500,
+            limits: null,
+          })), { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const policy = await client.update_approval_policy("agt_owner_demo", {
+      auto_approve_below: { JPY: 2500 },
+    });
+    const budget = await client.update_budget_policy("agt_owner_demo", {
+      currency: "USD",
+      period_limit_minor: 9000,
+      per_order_limit_minor: 1500,
+      auto_approve_below_minor: 500,
+    });
+
+    expect(policy.approval_policy_id).toBe("apl_sparse");
+    expect(policy.auto_approve_below).toEqual({ JPY: 2500 });
+    expect(budget.budget_id).toBe("bdg_sparse");
+    expect(budget.limits).toEqual({
+      period_limit: 9000,
+      per_order_limit: 1500,
+      auto_approve_below: 500,
+    });
+  });
+
+  it("accepts raw array payloads for webhook list endpoints", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/webhooks/subscriptions") {
+          return new Response(JSON.stringify([
+            {
+              id: "whsub_123",
+              event_type: "subscription.created",
+              url: "https://example.test/webhooks/siglume",
+              status: "active",
+            },
+          ]), { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const subscriptions = await client.list_webhook_subscriptions();
+
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions[0]?.subscription_id).toBe("whsub_123");
+    expect(subscriptions[0]?.event_types).toEqual([]);
+  });
+
+  it("wraps non-Error transport failures as SiglumeClientError", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      max_retries: 1,
+      fetch: async () => {
+        throw "transport exploded";
+      },
+    });
+
+    await expect(client.list_agents()).rejects.toThrow("Siglume request failed.");
+  });
 });

--- a/siglume-api-sdk-ts/test/examples.test.ts
+++ b/siglume-api-sdk-ts/test/examples.test.ts
@@ -6,6 +6,11 @@ import {
   score_tool_manual_offline,
   validate_tool_manual,
 } from "../src/index";
+import {
+  AgentBehaviorApp,
+  buildToolManual as buildAgentBehaviorToolManual,
+  runAgentBehaviorExample,
+} from "../../examples-ts/agent_behavior_adapter";
 import { buildStubs as buildCrmStubs, buildToolManual as buildCrmToolManual, CrmSyncApp, runCrmSyncExample } from "../../examples-ts/crm_sync";
 import { buildToolManual as buildNewsDigestToolManual, NewsDigestApp, runNewsDigestExample } from "../../examples-ts/news_digest";
 import {
@@ -24,6 +29,13 @@ import { runRefundPartialExample } from "../../examples-ts/refund_partial";
 import { runMockWebhookExpressExample } from "../../examples-ts/webhook_handler_express";
 
 const EXAMPLES = [
+  {
+    name: "agent_behavior_adapter",
+    permissionClass: PermissionClass.ACTION,
+    createHarness: () => new AppTestHarness(new AgentBehaviorApp()),
+    createManual: () => buildAgentBehaviorToolManual(),
+    taskType: "propose_agent_behavior",
+  },
   {
     name: "crm_sync",
     permissionClass: PermissionClass.ACTION,
@@ -95,6 +107,17 @@ describe("TypeScript example suite", () => {
     expect(lines[1]).toMatch(/^quality_grade: [AB] \d+$/);
     expect(lines[3]).toBe("dry_run: true");
     expect(lines[4]).toBe("action: true");
+  });
+
+  it("returns stable summary lines for agent_behavior_adapter", async () => {
+    const lines = await runAgentBehaviorExample();
+
+    expect(lines[0]).toBe("tool_manual_valid: true 0");
+    expect(lines[1]).toMatch(/^quality_grade: [AB] \d+$/);
+    expect(lines[2]).toBe("dry_run: true");
+    expect(lines[3]).toBe("action: true");
+    expect(lines[4]).toBe("proposal_preview: Would ask the owner to update charter / approval / budget for agt_owner_demo.");
+    expect(lines[5]).toBe("receipt_issues: 0");
   });
 
   it("returns stable summary lines for news_digest", async () => {

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -57,8 +57,12 @@ for _name in _LEGACY_PUBLIC_EXPORTS:
 
 from .client import (  # noqa: E402, F401
     AccessGrantRecord,
+    AgentCharter,
+    AgentRecord,
     AppListingRecord,
+    ApprovalPolicy,
     AutoRegistrationReceipt,
+    BudgetPolicy,
     CapabilityBindingRecord,
     ConnectedAccountRecord,
     CursorPage,
@@ -175,8 +179,12 @@ __all__ = sorted(
         _LEGACY_PUBLIC_EXPORTS
         + [
             "AccessGrantRecord",
+            "AgentCharter",
+            "AgentRecord",
             "AppListingRecord",
+            "ApprovalPolicy",
             "AutoRegistrationReceipt",
+            "BudgetPolicy",
             "CapabilityBindingRecord",
             "CapabilityListing",
             "Change",

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -278,6 +278,92 @@ class SupportCaseRecord:
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
 
 
+@dataclass
+class AgentRecord:
+    agent_id: str
+    name: str
+    avatar_url: str | None = None
+    description: str | None = None
+    agent_type: str | None = None
+    status: str | None = None
+    expertise: list[str] = field(default_factory=list)
+    post_count: int | None = None
+    reply_count: int | None = None
+    paused: bool | None = None
+    style: str | None = None
+    manifesto_text: str | None = None
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    settings: dict[str, Any] = field(default_factory=dict)
+    growth: dict[str, Any] = field(default_factory=dict)
+    plan: dict[str, Any] = field(default_factory=dict)
+    reputation: dict[str, Any] = field(default_factory=dict)
+    items: list[dict[str, Any]] = field(default_factory=list)
+    next_cursor: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class AgentCharter:
+    charter_id: str
+    agent_id: str
+    principal_user_id: str | None = None
+    version: int = 1
+    active: bool = True
+    role: str = "hybrid"
+    charter_text: str | None = None
+    goals: dict[str, Any] = field(default_factory=dict)
+    target_profile: dict[str, Any] = field(default_factory=dict)
+    qualification_criteria: dict[str, Any] = field(default_factory=dict)
+    success_metrics: dict[str, Any] = field(default_factory=dict)
+    constraints: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class ApprovalPolicy:
+    approval_policy_id: str
+    agent_id: str
+    principal_user_id: str | None = None
+    version: int = 1
+    active: bool = True
+    auto_approve_below: dict[str, int] = field(default_factory=dict)
+    always_require_approval_for: list[str] = field(default_factory=list)
+    deny_if: dict[str, Any] = field(default_factory=dict)
+    approval_ttl_minutes: int = 1440
+    structured_only: bool = True
+    default_requires_approval: bool = True
+    merchant_allowlist: list[str] = field(default_factory=list)
+    merchant_denylist: list[str] = field(default_factory=list)
+    category_allowlist: list[str] = field(default_factory=list)
+    category_denylist: list[str] = field(default_factory=list)
+    risk_policy: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class BudgetPolicy:
+    budget_id: str
+    agent_id: str
+    principal_user_id: str | None = None
+    currency: str = "JPY"
+    period_start: str | None = None
+    period_end: str | None = None
+    period_limit_minor: int = 0
+    spent_minor: int = 0
+    reserved_minor: int = 0
+    per_order_limit_minor: int = 0
+    auto_approve_below_minor: int = 0
+    limits: dict[str, int] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
 class RefundReason(str, Enum):
     CUSTOMER_REQUEST = "customer-request"
     DUPLICATE = "duplicate"
@@ -349,6 +435,21 @@ class Dispute:
 def _string_or_none(value: Any) -> str | None:
     text = str(value).strip() if value is not None else ""
     return text or None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
 
 
 def _to_dict(value: Any) -> dict[str, Any]:
@@ -620,6 +721,126 @@ def _parse_support_case(data: Mapping[str, Any]) -> SupportCaseRecord:
         trace_id=_string_or_none(data.get("trace_id")),
         environment=_string_or_none(data.get("environment")),
         resolution_note=_string_or_none(data.get("resolution_note")),
+        metadata=_to_dict(data.get("metadata")),
+        created_at=_string_or_none(data.get("created_at")),
+        updated_at=_string_or_none(data.get("updated_at")),
+        raw=dict(data),
+    )
+
+
+def _parse_agent(data: Mapping[str, Any]) -> AgentRecord:
+    items = data.get("items") if isinstance(data.get("items"), list) else []
+    expertise = data.get("expertise") if isinstance(data.get("expertise"), list) else []
+    return AgentRecord(
+        agent_id=str(data.get("agent_id") or data.get("id") or ""),
+        name=str(data.get("name") or ""),
+        avatar_url=_string_or_none(data.get("avatar_url")),
+        description=_string_or_none(data.get("description")),
+        agent_type=_string_or_none(data.get("agent_type")),
+        status=_string_or_none(data.get("status")),
+        expertise=[str(item) for item in expertise if isinstance(item, str)],
+        post_count=_int_or_none(data.get("post_count")),
+        reply_count=_int_or_none(data.get("reply_count")),
+        paused=_bool_or_none(data.get("paused")) if "paused" in data else None,
+        style=_string_or_none(data.get("style")),
+        manifesto_text=_string_or_none(data.get("manifesto_text")),
+        capabilities=_to_dict(data.get("capabilities")),
+        settings=_to_dict(data.get("settings")),
+        growth=_to_dict(data.get("growth")),
+        plan=_to_dict(data.get("plan")),
+        reputation=_to_dict(data.get("reputation")),
+        items=[dict(item) for item in items if isinstance(item, Mapping)],
+        next_cursor=_string_or_none(data.get("next_cursor")),
+        raw=dict(data),
+    )
+
+
+def _parse_agent_charter(data: Mapping[str, Any]) -> AgentCharter:
+    goals = _to_dict(data.get("goals"))
+    return AgentCharter(
+        charter_id=str(data.get("charter_id") or data.get("id") or ""),
+        agent_id=str(data.get("agent_id") or ""),
+        principal_user_id=_string_or_none(data.get("principal_user_id")),
+        version=int(data.get("version") or 1),
+        active=bool(data.get("active", True)),
+        role=str(data.get("role") or "hybrid"),
+        charter_text=_string_or_none(data.get("charter_text")) or _string_or_none(goals.get("charter_text")),
+        goals=goals,
+        target_profile=_to_dict(data.get("target_profile")),
+        qualification_criteria=_to_dict(data.get("qualification_criteria")),
+        success_metrics=_to_dict(data.get("success_metrics")),
+        constraints=_to_dict(data.get("constraints")),
+        created_at=_string_or_none(data.get("created_at")),
+        updated_at=_string_or_none(data.get("updated_at")),
+        raw=dict(data),
+    )
+
+
+def _parse_approval_policy(data: Mapping[str, Any]) -> ApprovalPolicy:
+    auto_approve_below_raw = _to_dict(data.get("auto_approve_below"))
+    auto_approve_below = {
+        str(currency): int(amount)
+        for currency, amount in auto_approve_below_raw.items()
+        if _int_or_none(amount) is not None
+    }
+    return ApprovalPolicy(
+        approval_policy_id=str(data.get("approval_policy_id") or data.get("id") or ""),
+        agent_id=str(data.get("agent_id") or ""),
+        principal_user_id=_string_or_none(data.get("principal_user_id")),
+        version=int(data.get("version") or 1),
+        active=bool(data.get("active", True)),
+        auto_approve_below=auto_approve_below,
+        always_require_approval_for=[
+            str(item)
+            for item in data.get("always_require_approval_for", [])
+            if isinstance(item, str)
+        ] if isinstance(data.get("always_require_approval_for"), list) else [],
+        deny_if=_to_dict(data.get("deny_if")),
+        approval_ttl_minutes=int(data.get("approval_ttl_minutes") or 1440),
+        structured_only=bool(data.get("structured_only", True)),
+        default_requires_approval=bool(data.get("default_requires_approval", True)),
+        merchant_allowlist=[
+            str(item) for item in data.get("merchant_allowlist", []) if isinstance(item, str)
+        ] if isinstance(data.get("merchant_allowlist"), list) else [],
+        merchant_denylist=[
+            str(item) for item in data.get("merchant_denylist", []) if isinstance(item, str)
+        ] if isinstance(data.get("merchant_denylist"), list) else [],
+        category_allowlist=[
+            str(item) for item in data.get("category_allowlist", []) if isinstance(item, str)
+        ] if isinstance(data.get("category_allowlist"), list) else [],
+        category_denylist=[
+            str(item) for item in data.get("category_denylist", []) if isinstance(item, str)
+        ] if isinstance(data.get("category_denylist"), list) else [],
+        risk_policy=_to_dict(data.get("risk_policy")),
+        created_at=_string_or_none(data.get("created_at")),
+        updated_at=_string_or_none(data.get("updated_at")),
+        raw=dict(data),
+    )
+
+
+def _parse_budget_policy(data: Mapping[str, Any]) -> BudgetPolicy:
+    limits = _to_dict(data.get("limits"))
+    return BudgetPolicy(
+        budget_id=str(data.get("budget_id") or data.get("id") or ""),
+        agent_id=str(data.get("agent_id") or ""),
+        principal_user_id=_string_or_none(data.get("principal_user_id")),
+        currency=str(data.get("currency") or "JPY"),
+        period_start=_string_or_none(data.get("period_start")),
+        period_end=_string_or_none(data.get("period_end")),
+        period_limit_minor=int(data.get("period_limit_minor") or 0),
+        spent_minor=int(data.get("spent_minor") or 0),
+        reserved_minor=int(data.get("reserved_minor") or 0),
+        per_order_limit_minor=int(data.get("per_order_limit_minor") or 0),
+        auto_approve_below_minor=int(data.get("auto_approve_below_minor") or 0),
+        limits={
+            str(key): int(value)
+            for key, value in limits.items()
+            if _int_or_none(value) is not None
+        } or {
+            "period_limit": int(data.get("period_limit_minor") or 0),
+            "per_order_limit": int(data.get("per_order_limit_minor") or 0),
+            "auto_approve_below": int(data.get("auto_approve_below_minor") or 0),
+        },
         metadata=_to_dict(data.get("metadata")),
         created_at=_string_or_none(data.get("created_at")),
         updated_at=_string_or_none(data.get("updated_at")),
@@ -982,6 +1203,174 @@ class SiglumeClient:
                 )
             ) if next_cursor else None,
         )
+
+    def list_agents(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 20,
+    ) -> list[AgentRecord]:
+        normalized_query = str(query or "").strip()
+        if normalized_query:
+            target_limit = max(1, min(int(limit), 20))
+            items: list[AgentRecord] = []
+            cursor: str | None = None
+            seen_cursors: set[str] = set()
+            while len(items) < target_limit:
+                params: dict[str, Any] = {
+                    "query": normalized_query,
+                    "limit": max(1, min(target_limit - len(items), 20)),
+                }
+                if cursor:
+                    params["cursor"] = cursor
+                data, _meta = self._request("GET", "/search/agents", params=params)
+                page_items = data.get("items") if isinstance(data.get("items"), list) else []
+                items.extend(
+                    _parse_agent(item)
+                    for item in page_items
+                    if isinstance(item, Mapping)
+                )
+                next_cursor = _string_or_none(data.get("next_cursor"))
+                if not next_cursor or next_cursor in seen_cursors:
+                    break
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
+            return items[:target_limit]
+        data, _meta = self._request("GET", "/me/agent")
+        return [_parse_agent(data)]
+
+    def get_agent(
+        self,
+        agent_id: str,
+        *,
+        lang: str | None = None,
+        tab: str | None = None,
+        cursor: str | None = None,
+        limit: int = 15,
+    ) -> AgentRecord:
+        normalized_agent_id = str(agent_id or "").strip()
+        if not normalized_agent_id:
+            raise SiglumeClientError("agent_id is required.")
+        params: dict[str, Any] = {"limit": max(1, min(int(limit), 50))}
+        if lang:
+            params["lang"] = lang
+        if tab:
+            params["tab"] = tab
+        if cursor:
+            params["cursor"] = cursor
+        data, _meta = self._request("GET", f"/agents/{normalized_agent_id}/profile", params=params)
+        return _parse_agent(data)
+
+    def update_agent_charter(
+        self,
+        agent_id: str,
+        charter_text: str,
+        *,
+        role: str | None = None,
+        target_profile: Mapping[str, Any] | None = None,
+        qualification_criteria: Mapping[str, Any] | None = None,
+        success_metrics: Mapping[str, Any] | None = None,
+        constraints: Mapping[str, Any] | None = None,
+        wait_for_completion: bool = False,
+    ) -> AgentCharter:
+        normalized_agent_id = str(agent_id or "").strip()
+        normalized_charter_text = str(charter_text or "").strip()
+        if not normalized_agent_id:
+            raise SiglumeClientError("agent_id is required.")
+        if not normalized_charter_text:
+            raise SiglumeClientError("charter_text is required.")
+        payload: dict[str, Any] = {"goals": {"charter_text": normalized_charter_text}}
+        if role:
+            payload["role"] = str(role).strip().lower()
+        if target_profile is not None:
+            payload["target_profile"] = _coerce_mapping(target_profile, "target_profile")
+        if qualification_criteria is not None:
+            payload["qualification_criteria"] = _coerce_mapping(qualification_criteria, "qualification_criteria")
+        if success_metrics is not None:
+            payload["success_metrics"] = _coerce_mapping(success_metrics, "success_metrics")
+        if constraints is not None:
+            payload["constraints"] = _coerce_mapping(constraints, "constraints")
+        _ = wait_for_completion
+        data, _meta = self._request(
+            "PUT",
+            f"/owner/agents/{normalized_agent_id}/charter",
+            json_body=payload,
+        )
+        return _parse_agent_charter(data)
+
+    def update_approval_policy(
+        self,
+        agent_id: str,
+        policy: Mapping[str, Any],
+        *,
+        wait_for_completion: bool = False,
+    ) -> ApprovalPolicy:
+        normalized_agent_id = str(agent_id or "").strip()
+        if not normalized_agent_id:
+            raise SiglumeClientError("agent_id is required.")
+        policy_payload = _coerce_mapping(policy, "policy")
+        allowed_fields = (
+            "auto_approve_below",
+            "always_require_approval_for",
+            "deny_if",
+            "approval_ttl_minutes",
+            "structured_only",
+            "merchant_allowlist",
+            "merchant_denylist",
+            "category_allowlist",
+            "category_denylist",
+            "risk_policy",
+        )
+        payload = {
+            field_name: policy_payload[field_name]
+            for field_name in allowed_fields
+            if policy_payload.get(field_name) is not None
+        }
+        if not payload:
+            raise SiglumeClientError("policy must include at least one supported approval-policy field.")
+        _ = wait_for_completion
+        data, _meta = self._request(
+            "PUT",
+            f"/owner/agents/{normalized_agent_id}/approval-policy",
+            json_body=payload,
+        )
+        return _parse_approval_policy(data)
+
+    def update_budget_policy(
+        self,
+        agent_id: str,
+        policy: Mapping[str, Any],
+        *,
+        wait_for_completion: bool = False,
+    ) -> BudgetPolicy:
+        normalized_agent_id = str(agent_id or "").strip()
+        if not normalized_agent_id:
+            raise SiglumeClientError("agent_id is required.")
+        policy_payload = _coerce_mapping(policy, "policy")
+        allowed_fields = (
+            "currency",
+            "period_start",
+            "period_end",
+            "period_limit_minor",
+            "per_order_limit_minor",
+            "auto_approve_below_minor",
+            "limits",
+            "metadata",
+        )
+        payload = {
+            field_name: policy_payload[field_name]
+            for field_name in allowed_fields
+            if policy_payload.get(field_name) is not None
+        }
+        if not payload:
+            raise SiglumeClientError("policy must include at least one supported budget-policy field.")
+        _ = wait_for_completion
+        data, _meta = self._request(
+            "PUT",
+            f"/owner/agents/{normalized_agent_id}/budget",
+            json_body=payload,
+        )
+        return _parse_budget_policy(data)
 
     def list_access_grants(
         self,

--- a/siglume_api_sdk_client.ts
+++ b/siglume_api_sdk_client.ts
@@ -180,6 +180,88 @@ export interface SupportCaseRecord {
   raw: Record<string, unknown>;
 }
 
+export interface AgentRecord {
+  agent_id: string;
+  name: string;
+  avatar_url?: string | null;
+  description?: string | null;
+  agent_type?: string | null;
+  status?: string | null;
+  expertise: string[];
+  post_count?: number | null;
+  reply_count?: number | null;
+  paused?: boolean | null;
+  style?: string | null;
+  manifesto_text?: string | null;
+  capabilities: Record<string, unknown>;
+  settings: Record<string, unknown>;
+  growth: Record<string, unknown>;
+  plan: Record<string, unknown>;
+  reputation: Record<string, unknown>;
+  items: Array<Record<string, unknown>>;
+  next_cursor?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface AgentCharter {
+  charter_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  version: number;
+  active: boolean;
+  role: string;
+  charter_text?: string | null;
+  goals: Record<string, unknown>;
+  target_profile: Record<string, unknown>;
+  qualification_criteria: Record<string, unknown>;
+  success_metrics: Record<string, unknown>;
+  constraints: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface ApprovalPolicy {
+  approval_policy_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  version: number;
+  active: boolean;
+  auto_approve_below: Record<string, number>;
+  always_require_approval_for: string[];
+  deny_if: Record<string, unknown>;
+  approval_ttl_minutes: number;
+  structured_only: boolean;
+  default_requires_approval: boolean;
+  merchant_allowlist: string[];
+  merchant_denylist: string[];
+  category_allowlist: string[];
+  category_denylist: string[];
+  risk_policy: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface BudgetPolicy {
+  budget_id: string;
+  agent_id: string;
+  principal_user_id?: string | null;
+  currency: string;
+  period_start?: string | null;
+  period_end?: string | null;
+  period_limit_minor: number;
+  spent_minor: number;
+  reserved_minor: number;
+  per_order_limit_minor: number;
+  auto_approve_below_minor: number;
+  limits: Record<string, number>;
+  metadata: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
 export interface SettlementReceipt {
   receipt_id: string;
   chain_receipt_id?: string | null;
@@ -378,6 +460,11 @@ export interface SiglumeClientShape {
   get_developer_portal(): Promise<DeveloperPortalSummary> | DeveloperPortalSummary;
   create_sandbox_session(...args: unknown[]): Promise<SandboxSession> | SandboxSession;
   get_usage(...args: unknown[]): Promise<CursorPage<UsageEventRecord>> | CursorPage<UsageEventRecord>;
+  list_agents(...args: unknown[]): Promise<AgentRecord[]> | AgentRecord[];
+  get_agent(...args: unknown[]): Promise<AgentRecord> | AgentRecord;
+  update_agent_charter(...args: unknown[]): Promise<AgentCharter> | AgentCharter;
+  update_approval_policy(...args: unknown[]): Promise<ApprovalPolicy> | ApprovalPolicy;
+  update_budget_policy(...args: unknown[]): Promise<BudgetPolicy> | BudgetPolicy;
   list_access_grants(...args: unknown[]): Promise<CursorPage<AccessGrantRecord>> | CursorPage<AccessGrantRecord>;
   bind_agent_to_grant(...args: unknown[]): Promise<GrantBindingResult> | GrantBindingResult;
   list_connected_accounts(...args: unknown[]): Promise<CursorPage<ConnectedAccountRecord>> | CursorPage<ConnectedAccountRecord>;

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -614,3 +614,272 @@ def test_retry_and_api_error_capture_status_code_and_trace_id() -> None:
     assert error.error_code == "CONFLICT"
     assert error.trace_id == "trc_conflict"
     assert error.details["capability_key"] == "price-compare-helper"
+
+
+def test_list_agents_without_query_returns_personal_agent_singleton() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/me/agent"
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "agent_id": "agt_owner_demo",
+                    "agent_type": "personal",
+                    "name": "Owner Demo",
+                    "avatar_url": "/avatars/owner-demo.png",
+                    "description": "Owner-managed marketplace agent.",
+                    "status": "active",
+                    "capabilities": {"marketplace": True},
+                    "settings": {"paused": False},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        agents = client.list_agents()
+
+    assert len(agents) == 1
+    assert agents[0].agent_id == "agt_owner_demo"
+    assert agents[0].capabilities["marketplace"] is True
+    assert agents[0].settings["paused"] is False
+
+
+def test_list_agents_with_query_and_get_agent_parse_search_and_profile_shapes() -> None:
+    search_calls: list[dict[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/search/agents":
+            assert request.url.params["query"] == "budget"
+            search_calls.append(
+                {
+                    "cursor": request.url.params.get("cursor"),
+                    "limit": request.url.params.get("limit"),
+                }
+            )
+            if request.url.params.get("cursor") == "next_agents":
+                return httpx.Response(
+                    200,
+                    json=envelope(
+                        {
+                            "items": [
+                                {
+                                    "agent_id": "agt_budget_helper",
+                                    "name": "Budget Helper",
+                                    "avatar_url": "/avatars/budget-helper.png",
+                                    "description": "Tracks cautious purchasing rules.",
+                                    "expertise": ["budgeting"],
+                                    "post_count": 1,
+                                    "reply_count": 0,
+                                }
+                            ],
+                            "next_cursor": None,
+                        }
+                    ),
+                )
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "items": [
+                            {
+                                "agent_id": "agt_budget_demo",
+                                "name": "Budget Demo",
+                                "avatar_url": "/avatars/budget-demo.png",
+                                "description": "Focuses on budget-safe travel purchases.",
+                                "expertise": ["travel", "budgeting"],
+                                "post_count": 3,
+                                "reply_count": 1,
+                            }
+                        ],
+                        "next_cursor": "next_agents",
+                    }
+                ),
+            )
+        if request.url.path == "/v1/agents/agt_budget_demo/profile":
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "agent_id": "agt_budget_demo",
+                        "name": "Budget Demo",
+                        "avatar_url": "/avatars/budget-demo.png",
+                        "description": "Focuses on budget-safe travel purchases.",
+                        "agent_type": "personal",
+                        "expertise": ["travel", "budgeting"],
+                        "style": "careful",
+                        "paused": False,
+                        "manifesto_text": "Prefer clear budgets and explicit approvals.",
+                        "plan": {"tier": "pro"},
+                        "reputation": {"score": 0.92},
+                        "post_count": 3,
+                        "reply_count": 1,
+                        "items": [{"content_id": "cnt_demo_1", "title": "Travel safety checklist"}],
+                        "next_cursor": None,
+                    }
+                ),
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    with build_client(handler) as client:
+        agents = client.list_agents(query="budget", limit=5)
+        agent = client.get_agent("agt_budget_demo")
+
+    assert [item.agent_id for item in agents] == ["agt_budget_demo", "agt_budget_helper"]
+    assert agents[0].expertise == ["travel", "budgeting"]
+    assert agent.manifesto_text == "Prefer clear budgets and explicit approvals."
+    assert agent.plan["tier"] == "pro"
+    assert agent.items[0]["content_id"] == "cnt_demo_1"
+    assert search_calls == [
+        {"cursor": None, "limit": "5"},
+        {"cursor": "next_agents", "limit": "4"},
+    ]
+
+
+def test_update_agent_charter_maps_charter_text_into_goals_payload() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/owner/agents/agt_owner_demo/charter"
+        assert request.method == "PUT"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["goals"]["charter_text"] == "Prefer capped spend and explicit approval for unusual purchases."
+        assert payload["role"] == "buyer"
+        assert payload["success_metrics"]["approval_rate_floor"] == 0.8
+        assert "wait_for_completion" not in payload
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "charter_id": "chr_demo_2",
+                    "agent_id": "agt_owner_demo",
+                    "principal_user_id": "usr_owner_demo",
+                    "version": 2,
+                    "active": True,
+                    "role": "buyer",
+                    "goals": {"charter_text": payload["goals"]["charter_text"]},
+                    "target_profile": {},
+                    "qualification_criteria": {},
+                    "success_metrics": payload["success_metrics"],
+                    "constraints": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        charter = client.update_agent_charter(
+            "agt_owner_demo",
+            "Prefer capped spend and explicit approval for unusual purchases.",
+            role="buyer",
+            success_metrics={"approval_rate_floor": 0.8},
+            wait_for_completion=True,
+        )
+
+    assert charter.charter_id == "chr_demo_2"
+    assert charter.charter_text == "Prefer capped spend and explicit approval for unusual purchases."
+    assert charter.success_metrics["approval_rate_floor"] == 0.8
+
+
+def test_update_approval_policy_sanitizes_server_managed_fields() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/owner/agents/agt_owner_demo/approval-policy"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload == {
+            "auto_approve_below": {"JPY": 3000},
+            "always_require_approval_for": ["travel.booking"],
+            "approval_ttl_minutes": 720,
+            "structured_only": True,
+        }
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "approval_policy_id": "apl_demo_2",
+                    "agent_id": "agt_owner_demo",
+                    "principal_user_id": "usr_owner_demo",
+                    "version": 2,
+                    "active": True,
+                    "auto_approve_below": {"JPY": 3000},
+                    "always_require_approval_for": ["travel.booking"],
+                    "deny_if": {},
+                    "approval_ttl_minutes": 720,
+                    "structured_only": True,
+                    "merchant_allowlist": [],
+                    "merchant_denylist": [],
+                    "category_allowlist": [],
+                    "category_denylist": [],
+                    "risk_policy": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        policy = client.update_approval_policy(
+            "agt_owner_demo",
+            {
+                "approval_policy_id": "apl_ignore_me",
+                "version": 999,
+                "auto_approve_below": {"JPY": 3000},
+                "always_require_approval_for": ["travel.booking"],
+                "approval_ttl_minutes": 720,
+                "structured_only": True,
+            },
+            wait_for_completion=True,
+        )
+
+    assert policy.approval_policy_id == "apl_demo_2"
+    assert policy.auto_approve_below["JPY"] == 3000
+    assert policy.default_requires_approval is True
+    assert policy.approval_ttl_minutes == 720
+
+
+def test_update_budget_policy_sanitizes_server_managed_fields() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/owner/agents/agt_owner_demo/budget"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload == {
+            "currency": "JPY",
+            "period_limit_minor": 50000,
+            "per_order_limit_minor": 12000,
+            "auto_approve_below_minor": 3000,
+            "metadata": {"source": "sdk-test"},
+        }
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "budget_id": "bdg_demo_2",
+                    "agent_id": "agt_owner_demo",
+                    "principal_user_id": "usr_owner_demo",
+                    "currency": "JPY",
+                    "period_start": "2026-04-01T00:00:00Z",
+                    "period_end": "2026-05-01T00:00:00Z",
+                    "period_limit_minor": 50000,
+                    "spent_minor": 0,
+                    "reserved_minor": 0,
+                    "per_order_limit_minor": 12000,
+                    "auto_approve_below_minor": 3000,
+                    "limits": {
+                        "period_limit": 50000,
+                        "per_order_limit": 12000,
+                        "auto_approve_below": 3000,
+                    },
+                    "metadata": {"source": "sdk-test"},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        budget = client.update_budget_policy(
+            "agt_owner_demo",
+            {
+                "budget_id": "bdg_ignore_me",
+                "currency": "JPY",
+                "period_limit_minor": 50000,
+                "per_order_limit_minor": 12000,
+                "auto_approve_below_minor": 3000,
+                "metadata": {"source": "sdk-test"},
+            },
+            wait_for_completion=True,
+        )
+
+    assert budget.budget_id == "bdg_demo_2"
+    assert budget.period_limit_minor == 50000
+    assert budget.limits["per_order_limit"] == 12000

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -23,6 +23,7 @@ from siglume_api_sdk import (  # noqa: E402
 
 
 EXAMPLE_SPECS = [
+    ("agent_behavior_adapter.py", PermissionClass.ACTION),
     ("calendar_sync.py", PermissionClass.ACTION),
     ("crm_sync.py", PermissionClass.ACTION),
     ("email_sender.py", PermissionClass.ACTION),
@@ -151,6 +152,19 @@ def test_polygon_mandate_adapter_example_runs_with_simulated_web3_receipts() -> 
     assert output[5] == "quote: True"
     assert output[6] == "payment: True"
     assert output[7] == "receipt_issues: 0"
+
+
+def test_agent_behavior_adapter_example_returns_owner_review_preview() -> None:
+    module = _load_module("agent_behavior_adapter.py")
+
+    output = asyncio.run(module.run_agent_behavior_example())
+
+    assert output[0] == "tool_manual_valid: True 0"
+    assert output[1].startswith("quality_grade: ")
+    assert output[2] == "dry_run: True"
+    assert output[3] == "action: True"
+    assert output[4] == "proposal_preview: Would ask the owner to update charter / approval / budget for agt_owner_demo."
+    assert output[5] == "receipt_issues: 0"
 
 
 def test_wallet_balance_example_resolves_native_symbol_to_chain_default() -> None:


### PR DESCRIPTION
## Summary
- adds owner-agent behavior operations to the public SDK surface in Python and TypeScript
- exposes `list_agents`, `get_agent`, `update_agent_charter`, `update_approval_policy`, and `update_budget_policy`
- adds mock-friendly ACTION examples plus `docs/agent-behavior.md`
- syncs the public OpenAPI surface for owner charter / approval-policy / budget routes

## Test plan
- [x] `py -3.11 -m ruff check .`
- [x] `py -3.11 -m pytest` -> 178 passed
- [x] `py -3.11 scripts\\contract_sync.py` -> passed
- [x] `npm run lint`
- [x] `npm test` -> 216 passed, branch coverage 73.74%
- [x] `npm run build`
- [x] reviewer agent -> no critical / warning

## Notes
- owner update routes currently return updated snapshots synchronously, so `wait_for_completion` is accepted as a forward-compatible no-op
- `agent_behavior_adapter` intentionally creates an owner-review proposal preview instead of silently mutating live policy state