### PR TITLE
fix(owner): forward null period_start/period_end to clear budget boundaries (Codex PR #123 follow-up)

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -1070,11 +1070,15 @@ export class SiglumeClient implements SiglumeClientShape {
       "limits",
       "metadata",
     ] as const;
-    const payload = Object.fromEntries(
-      allowedFields
-        .filter((field) => policyPayload[field] !== undefined && policyPayload[field] !== null)
-        .map((field) => [field, policyPayload[field]]),
-    );
+    const nullableFields = new Set<string>(["period_start", "period_end"]);
+    const payload: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (!Object.prototype.hasOwnProperty.call(policyPayload, field)) continue;
+      const value = policyPayload[field];
+      if (value === undefined) continue;
+      if (value === null && !nullableFields.has(field)) continue;
+      payload[field] = value;
+    }
     if (Object.keys(payload).length === 0) {
       throw new SiglumeClientError("policy must include at least one supported budget-policy field.");
     }

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -684,6 +684,73 @@ describe("SiglumeClient", () => {
     });
   });
 
+  it("forwards null period_start / period_end so callers can clear budget date boundaries", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        expect(url.pathname).toBe("/v1/owner/agents/agt_owner_demo/budget");
+        captured = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        return new Response(JSON.stringify(envelope({
+          id: "bdg_clear_dates",
+          agent_id: "agt_owner_demo",
+          currency: "JPY",
+          period_start: null,
+          period_end: null,
+          period_limit_minor: 50000,
+        })), { status: 200 });
+      },
+    });
+
+    await client.update_budget_policy("agt_owner_demo", {
+      period_start: null,
+      period_end: null,
+    });
+
+    expect(captured).toEqual({ period_start: null, period_end: null });
+  });
+
+  it("still strips null for non-nullable budget fields like currency", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        expect(url.pathname).toBe("/v1/owner/agents/agt_owner_demo/budget");
+        captured = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        return new Response(JSON.stringify(envelope({
+          id: "bdg_strip",
+          agent_id: "agt_owner_demo",
+          currency: "USD",
+          period_limit_minor: 1000,
+        })), { status: 200 });
+      },
+    });
+
+    await client.update_budget_policy("agt_owner_demo", {
+      currency: null,
+      period_limit_minor: 1000,
+    });
+
+    expect(captured).toEqual({ period_limit_minor: 1000 });
+  });
+
+  it("rejects budget policy update when only filtered nulls remain", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () => {
+        throw new Error("fetch should not be called for stripped-only payload");
+      },
+    });
+
+    await expect(client.update_budget_policy("agt_owner_demo", { currency: null }))
+      .rejects.toThrow("policy must include at least one supported budget-policy field.");
+  });
+
   it("accepts raw array payloads for webhook list endpoints", async () => {
     const client = new SiglumeClient({
       api_key: "sig_test_key",

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -1357,11 +1357,15 @@ class SiglumeClient:
             "limits",
             "metadata",
         )
-        payload = {
-            field_name: policy_payload[field_name]
-            for field_name in allowed_fields
-            if policy_payload.get(field_name) is not None
-        }
+        nullable_fields = frozenset({"period_start", "period_end"})
+        payload: dict[str, Any] = {}
+        for field_name in allowed_fields:
+            if field_name not in policy_payload:
+                continue
+            value = policy_payload[field_name]
+            if value is None and field_name not in nullable_fields:
+                continue
+            payload[field_name] = value
         if not payload:
             raise SiglumeClientError("policy must include at least one supported budget-policy field.")
         _ = wait_for_completion

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -19,6 +20,7 @@ from siglume_api_sdk import (  # noqa: E402
     PriceModel,
     SiglumeAPIError,
     SiglumeClient,
+    SiglumeClientError,
     ToolManual,
     ToolManualPermissionClass,
 )
@@ -883,3 +885,86 @@ def test_update_budget_policy_sanitizes_server_managed_fields() -> None:
     assert budget.budget_id == "bdg_demo_2"
     assert budget.period_limit_minor == 50000
     assert budget.limits["per_order_limit"] == 12000
+
+
+def test_update_budget_policy_forwards_null_period_dates_to_clear_them() -> None:
+    """period_start / period_end are nullable — sending None must clear the boundary on the server."""
+
+    captured_payload: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/owner/agents/agt_owner_demo/budget"
+        captured_payload.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "budget_id": "bdg_clear_dates",
+                    "agent_id": "agt_owner_demo",
+                    "principal_user_id": "usr_owner_demo",
+                    "currency": "JPY",
+                    "period_start": None,
+                    "period_end": None,
+                    "period_limit_minor": 50000,
+                    "spent_minor": 0,
+                    "reserved_minor": 0,
+                    "limits": {},
+                    "metadata": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        client.update_budget_policy(
+            "agt_owner_demo",
+            {"period_start": None, "period_end": None},
+        )
+
+    assert captured_payload == {"period_start": None, "period_end": None}
+
+
+def test_update_budget_policy_still_strips_nulls_for_non_nullable_fields() -> None:
+    """Non-nullable fields like currency must still be filtered when None is passed."""
+
+    captured_payload: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payload.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "budget_id": "bdg_strip_nonnullable",
+                    "agent_id": "agt_owner_demo",
+                    "principal_user_id": "usr_owner_demo",
+                    "currency": "USD",
+                    "period_limit_minor": 1000,
+                    "spent_minor": 0,
+                    "reserved_minor": 0,
+                    "limits": {},
+                    "metadata": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        client.update_budget_policy(
+            "agt_owner_demo",
+            {"currency": None, "period_limit_minor": 1000},
+        )
+
+    assert captured_payload == {"period_limit_minor": 1000}
+
+
+def test_update_budget_policy_rejects_payload_with_only_filtered_fields() -> None:
+    """If the only field provided is a non-nullable None, the whole call should still error."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("handler should not be called")
+
+    with build_client(handler) as client:
+        try:
+            client.update_budget_policy("agt_owner_demo", {"currency": None})
+        except SiglumeClientError:
+            return
+    raise AssertionError("Expected SiglumeClientError when the only field is a stripped None")


### PR DESCRIPTION
## Summary

Codex bot ([feedback on #123](https://github.com/taihei-05/siglume-api-sdk/pull/123)) flagged that `update_budget_policy` in both the Python and TypeScript SDK filters out all `None` / `null` values from the payload. This breaks the contract for the nullable date boundary fields (`period_start`, `period_end`):

- `update_budget_policy(agent, {\"period_end\": None})` silently drops the field
- If it is the only provided field, the call errors with \"policy must include at least one supported budget-policy field\"

## Fix

Both SDKs now use a `nullable_fields = {period_start, period_end}` allowlist:

| input | behavior |
|---|---|
| key absent | skip (unchanged) |
| value present, non-None | include (unchanged) |
| value None, field in nullable set | **include — forward null on the wire** |
| value None, field NOT in nullable set (e.g. currency) | skip (unchanged) |

`update_approval_policy` was reviewed and left alone — none of its fields are nullable in the server schema.

## Server-side dependency

The server endpoint at `marketplace_api.py` does `payload.model_dump(exclude_none=True)`, and `upsert_owner_budget` uses `payload.get(\"period_start\") or base.get(\"period_start\")`. Both layers currently strip / fall back on null, so this SDK change is a **precondition** rather than a full end-to-end clear-boundary contract. A companion PR in siglume will tighten the server to honor explicit null on these two fields.

## Test plan

- [x] `pytest tests/test_client.py -k budget_policy` — 4 / 4 passing (3 new)
- [x] `vitest run test/client.test.ts` — 16 / 16 passing (3 new)
- [x] Full pytest suite — 184 / 184 passing
- [x] Full TS client + web3 — 34 / 34 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)