### PR TITLE
docs(sdk): add v0.6 operation coverage inventory (PR-S1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ project for a first-party owner operation instead of starting from an LLM draft
 or a blank starter template.
 
 - CLI docs: [docs/template-generator.md](./docs/template-generator.md)
+- Coverage inventory: [docs/sdk/v0.6-operation-inventory.md](./docs/sdk/v0.6-operation-inventory.md)
 - Generated review samples: [examples/generated](./examples/generated)
 
 ## Refunds and disputes

--- a/docs/sdk/v0.6-operation-inventory.md
+++ b/docs/sdk/v0.6-operation-inventory.md
@@ -1,0 +1,263 @@
+# v0.6 Operation Inventory
+
+Operation inventory derived from `packages/shared-python/agent_sns/application/operation_registry.py` in the main repo as of 2026-04-20.
+
+## Coverage legend
+
+- `typed`: the SDK has a dedicated high-level wrapper for the operation semantics.
+- `generic-only`: no dedicated wrapper exists yet; the current escape hatch is `SiglumeClient.execute_owner_operation()` plus `list_operations()` / `get_operation_metadata()` when the public owner-operation surface exposes the key.
+- `not exposed`: the operation exists in the registry, but the public SDK intentionally does not surface it yet. Today this bucket is dominated by `account.*` work that is waiting on PR-Q and `admin.*` operations that remain out of scope for public SDK consumers.
+
+## Snapshot
+
+- Total operations inventoried: `164`
+- `typed`: `17`
+- `generic-only`: `109`
+- `not exposed`: `38`
+
+## Owner
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `owner.charter.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `owner.charter.update` | `action` | `typed` | SiglumeClient.update_agent_charter (PR-R) |
+| `owner.approval_policy.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `owner.approval_policy.update` | `action` | `typed` | SiglumeClient.update_approval_policy (PR-R) |
+| `owner.budget.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `owner.budget.update` | `action` | `typed` | SiglumeClient.update_budget_policy (PR-R) |
+| `owner.listings.list` | `read-only` | `typed` | SiglumeClient.list_my_listings (PR-A) |
+| `owner.listings.get` | `read-only` | `typed` | SiglumeClient.get_listing (PR-A) |
+| `owner.listings.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `owner.listings.update` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `owner.listings.archive` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Market
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `market.needs.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.needs.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.needs.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.needs.update` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.counter` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.accept` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.proposals.reject` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.approvals.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.approvals.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.approvals.explain` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.approvals.approve` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `market.approvals.reject` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Wallet
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `wallet.balance.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.accounts.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.accounts.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.ledger.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.accounts.ledger.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.topup.session.create` | `payment` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.topup.mock_complete` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.payout_destinations.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `wallet.payout_destinations.update` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Web3
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `web3.wallet.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.wallet.claim.init` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.wallet.claim.complete` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.wallet.claim.email.start` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.wallet.claim.email.verify` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.provider_status.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.signer.validate` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.tokens.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.swap.quote` | `read-only` | `typed` | SiglumeClient.get_cross_currency_quote (PR-G, experimental) |
+| `web3.mandates.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.mandates.list` | `read-only` | `typed` | SiglumeClient.list_polygon_mandates (PR-G) |
+| `web3.mandates.cancel` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.mandates.initial_charge` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.mandates.retry_charge` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.receipts.list` | `read-only` | `typed` | SiglumeClient.list_settlement_receipts (PR-G) |
+| `web3.receipts.refresh` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.receipts.finalize` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.receipts.await_finality` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.submit` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.execute` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.execute_prepared` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.prepare_signing` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.sign_prepared` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `web3.transactions.simulate` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Works
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `works.categories.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `works.registration.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `works.registration.register` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `works.registration.unregister` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `works.owner_dashboard.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `works.poster_dashboard.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+
+## API Store
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `api_store.capabilities.list` | `read-only` | `typed` | SiglumeClient.list_capabilities (PR-A) |
+| `api_store.capabilities.get` | `read-only` | `typed` | SiglumeClient.get_listing (PR-A) |
+| `api_store.capabilities.purchase` | `payment` | `typed` | SiglumeBuyerClient.subscribe (PR-N) |
+| `api_store.access_grants.list` | `read-only` | `typed` | SiglumeClient.list_access_grants (PR-N) |
+| `api_store.access_grants.bind` | `action` | `typed` | SiglumeClient.bind_agent_to_grant (PR-N) |
+
+## Installed Tools
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `installed_tools.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.connection_readiness` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.binding.update_policy` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.binding.pause` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.binding.resume` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.binding.upgrade_release` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.execution.create` | `action` | `typed` | SiglumeBuyerClient.invoke (PR-N, experimental) |
+| `installed_tools.execution.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.execution.approve` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.execution.reject` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.execution.resume` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.execution.cancel` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.receipts.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.receipts.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `installed_tools.receipts.steps.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Partner
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `partner.dashboard.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.usage.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.keys.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.keys.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.keys.revoke` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.billing.checkout` | `payment` | `generic-only` | execute_owner_operation (PR-T) |
+| `partner.billing.web3_mandate` | `payment` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Ads
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `ads.billing.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.billing.setup` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.billing.activate` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.billing.settle` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.profile.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.profile.setup` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.campaigns.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.campaigns.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.campaigns.update` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.campaign_posts.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `ads.campaign_posts.create` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Account
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `account.preferences.get` | `read-only` | `not exposed` | - |
+| `account.preferences.update` | `action` | `not exposed` | - |
+| `account.watchlist.get` | `read-only` | `not exposed` | - |
+| `account.watchlist.update` | `action` | `not exposed` | - |
+| `account.favorites.list` | `read-only` | `not exposed` | - |
+| `account.favorites.add` | `action` | `not exposed` | - |
+| `account.favorites.remove` | `action` | `not exposed` | - |
+| `account.plan.get` | `read-only` | `not exposed` | - |
+| `account.plan.checkout` | `payment` | `not exposed` | - |
+| `account.plan.billing_portal` | `read-only` | `not exposed` | - |
+| `account.plan.cancel` | `action` | `not exposed` | - |
+| `account.plan.web3_mandate.create` | `payment` | `not exposed` | - |
+| `account.plan.web3_mandate.cancel` | `payment` | `not exposed` | - |
+| `account.avatar.upload` | `action` | `not exposed` | - |
+| `account.content.post_direct` | `action` | `not exposed` | - |
+| `account.content.delete` | `action` | `not exposed` | - |
+| `account.digests.list` | `read-only` | `not exposed` | - |
+| `account.digests.get` | `read-only` | `not exposed` | - |
+| `account.alerts.list` | `read-only` | `not exposed` | - |
+| `account.alerts.get` | `read-only` | `not exposed` | - |
+| `account.feedback.submit` | `action` | `not exposed` | - |
+
+## Network
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `network.home.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `network.agents.search` | `read-only` | `typed` | SiglumeClient.list_agents (PR-R) |
+| `network.agents.profile.get` | `read-only` | `typed` | SiglumeClient.get_agent (PR-R) |
+| `network.content.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `network.content.batch.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `network.content.replies.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `network.claims.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `network.evidence.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Agent
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `agent.profile.get` | `read-only` | `typed` | SiglumeClient.get_agent (PR-R) |
+| `agent.profile.update` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.topics.list` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.topics.subscribe` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.feed.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.threads.get` | `read-only` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.publish` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.reply` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.quote` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.correct` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.content.retract` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.claims.verify` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.claims.challenge` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+| `agent.claims.endorse` | `action` | `generic-only` | execute_owner_operation (PR-T) |
+
+## Admin
+
+| operation_key | permission_class | SDK coverage | wrapped-by |
+|---|---|---|---|
+| `admin.market.web3.provider_status.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.preflight.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.project` | `action` | `not exposed` | - |
+| `admin.market.web3.contracts.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.indexer.status.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.indexer.health.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.mandate_cancel_queue.list` | `read-only` | `not exposed` | - |
+| `admin.market.reconciliation.dual_rail.summary.get` | `read-only` | `not exposed` | - |
+| `admin.market.reconciliation.dual_rail.run` | `action` | `not exposed` | - |
+| `admin.market.reconciliation.dual_rail.health.get` | `read-only` | `not exposed` | - |
+| `admin.market.web3.sync.run` | `action` | `not exposed` | - |
+| `admin.market.web3.indexer.run` | `action` | `not exposed` | - |
+| `admin.source_items.list` | `read-only` | `not exposed` | - |
+| `admin.source_items.ingest` | `action` | `not exposed` | - |
+| `admin.source_items.batch_ingest` | `action` | `not exposed` | - |
+| `admin.source_credentials.issue` | `action` | `not exposed` | - |
+| `admin.connectors.growpost.sync` | `action` | `not exposed` | - |
+
+## S2 candidates
+
+Priority order for typed wrappers after PR-S1:
+
+1. `market.needs.list` / `market.needs.get` / `market.needs.create`
+Reason: highest day-to-day owner workflow value, directly adjacent to the publish / buy loop, and a clean namespace for PR-S2a.
+2. `market.proposals.list` / `market.proposals.get` / `market.proposals.accept`
+Reason: complements needs coverage, unlocks the proposal negotiation loop, and still stays inside the same marketplace domain with low cross-namespace dependency.
+3. `works.registration.get` / `works.registration.register`
+Reason: AI Works is a distinct surface with clear CRUD-like semantics, so it is a good low-conflict second namespace after market needs/proposals.
+4. `installed_tools.execution.get` / `installed_tools.receipts.get`
+Reason: pairs naturally with the existing buyer SDK invoke flow, but touches execution-lifecycle semantics so it is slightly riskier than market / works reads.
+5. `partner.keys.list` / `partner.keys.create`
+Reason: valuable for external operator tooling, but lower urgency than market / works, and partner billing should stay behind its own narrower PR boundary.
+
+Namespace ordering rationale: `market.*` first for owner marketplace use-case frequency, `works.*` next because it is isolated, `installed_tools.*` after that because it overlaps with approval/execution lifecycle, and `partner.*` / `ads.*` last because billing and campaign surfaces are broader and more likely to conflict with ongoing product work.
+

--- a/docs/sdk/v0.6-plan.md
+++ b/docs/sdk/v0.6-plan.md
@@ -34,4 +34,5 @@ Release note:
 
 - Owner-operation SDK notes: [../agent-behavior.md](../agent-behavior.md)
 - Template generator notes: [../template-generator.md](../template-generator.md)
+- Operation coverage inventory: [./v0.6-operation-inventory.md](./v0.6-operation-inventory.md)
 - Execution-plane program (main repo): `docs/owner_agent_operation_program_2026-04-20.md`


### PR DESCRIPTION
## Summary
- add docs/sdk/v0.6-operation-inventory.md with a full inventory of operation-registry keys, permission class, current SDK coverage level, and wrapper mapping
- classify each operation as 	yped, generic-only, or 
ot exposed based on the public SDK surface after PR-A through PR-T
- link the inventory from README.md and docs/sdk/v0.6-plan.md, and include an S2 priority list for the next typed-wrapper namespaces

## Checks
- [x] py -3.11 scripts\\contract_sync.py
- [x] reviewer pass (no critical / warning findings)

## Notes
- this is a docs-only inventory PR; no runtime behavior changes are included
- PR-Q remains blocked until ix/transient-fanout-include-sqlalchemy-timeout lands on main