### PR TITLE
fix(v0.6): address chatgpt-codex-connector[bot] findings on PR-Qb

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -161,9 +161,13 @@ export interface SiglumeClientShape {
   remove_account_favorite(agent_id: string): Promise<FavoriteAgentMutation>;
   post_account_content_direct(text: string, options?: { lang?: string }): Promise<AccountContentPostResult>;
   delete_account_content(content_id: string): Promise<AccountContentDeleteResult>;
-  list_account_digests(): Promise<CursorPage<AccountDigestSummary>>;
+  list_account_digests(
+    options?: { cursor?: string; limit?: number },
+  ): Promise<CursorPage<AccountDigestSummary>>;
   get_account_digest(digest_id: string): Promise<AccountDigest>;
-  list_account_alerts(): Promise<CursorPage<AccountAlert>>;
+  list_account_alerts(
+    options?: { cursor?: string; limit?: number },
+  ): Promise<CursorPage<AccountAlert>>;
   get_account_alert(alert_id: string): Promise<AccountAlert>;
   submit_account_feedback(
     ref_type: string,
@@ -1407,9 +1411,13 @@ export class SiglumeClient implements SiglumeClientShape {
       throw new SiglumeClientError("agent_id is required.");
     }
     const [data] = await this.request("PUT", `/me/favorites/${normalizedAgentId}/remove`);
+    // Only infer status="removed" when the server actually confirmed
+    // success. Forcing the default on every response masked failures
+    // (e.g. {"ok": false} with no status field) as successful removals.
+    const defaultStatus = Boolean((data as { ok?: unknown }).ok) ? "removed" : undefined;
     return parseFavoriteAgentMutation(data, {
       defaultAgentId: normalizedAgentId,
-      defaultStatus: "removed",
+      defaultStatus,
     });
   }
 
@@ -1438,18 +1446,32 @@ export class SiglumeClient implements SiglumeClientShape {
     return parseAccountContentDeleteResult(data);
   }
 
-  async list_account_digests(): Promise<CursorPage<AccountDigestSummary>> {
-    const [data, meta] = await this.request("GET", "/digests");
+  async list_account_digests(
+    options: { cursor?: string; limit?: number } = {},
+  ): Promise<CursorPage<AccountDigestSummary>> {
+    const params: Record<string, string | number | boolean | null | undefined> = {};
+    if (options.cursor !== undefined && String(options.cursor).trim()) {
+      params.cursor = String(options.cursor).trim();
+    }
+    if (options.limit !== undefined) {
+      params.limit = Number(options.limit);
+    }
+    const requestOptions = Object.keys(params).length > 0 ? { params } : undefined;
+    const [data, meta] = await this.request("GET", "/digests", requestOptions);
     const items = Array.isArray(data.items)
       ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => parseAccountDigestSummary(item))
       : [];
-    return {
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
       items,
-      next_cursor: stringOrNull(data.next_cursor) ?? null,
-      limit: null,
-      offset: null,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : options.limit ?? null,
+      offset: typeof data.offset === "number" ? data.offset : null,
       meta,
-    };
+      fetchNext: next_cursor
+        ? (cursor) => this.list_account_digests({ cursor, limit: options.limit }) as Promise<CursorPageResult<AccountDigestSummary>>
+        : undefined,
+    });
   }
 
   async get_account_digest(digest_id: string): Promise<AccountDigest> {
@@ -1461,18 +1483,32 @@ export class SiglumeClient implements SiglumeClientShape {
     return parseAccountDigest(data);
   }
 
-  async list_account_alerts(): Promise<CursorPage<AccountAlert>> {
-    const [data, meta] = await this.request("GET", "/alerts");
+  async list_account_alerts(
+    options: { cursor?: string; limit?: number } = {},
+  ): Promise<CursorPage<AccountAlert>> {
+    const params: Record<string, string | number | boolean | null | undefined> = {};
+    if (options.cursor !== undefined && String(options.cursor).trim()) {
+      params.cursor = String(options.cursor).trim();
+    }
+    if (options.limit !== undefined) {
+      params.limit = Number(options.limit);
+    }
+    const requestOptions = Object.keys(params).length > 0 ? { params } : undefined;
+    const [data, meta] = await this.request("GET", "/alerts", requestOptions);
     const items = Array.isArray(data.items)
       ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map((item) => parseAccountAlert(item))
       : [];
-    return {
+    const next_cursor = stringOrNull(data.next_cursor);
+    return new CursorPageResult({
       items,
-      next_cursor: stringOrNull(data.next_cursor) ?? null,
-      limit: null,
-      offset: null,
+      next_cursor,
+      limit: typeof data.limit === "number" ? data.limit : options.limit ?? null,
+      offset: typeof data.offset === "number" ? data.offset : null,
       meta,
-    };
+      fetchNext: next_cursor
+        ? (cursor) => this.list_account_alerts({ cursor, limit: options.limit }) as Promise<CursorPageResult<AccountAlert>>
+        : undefined,
+    });
   }
 
   async get_account_alert(alert_id: string): Promise<AccountAlert> {

--- a/siglume-api-sdk-ts/test/pr_qb_codex_bot_followup.test.ts
+++ b/siglume-api-sdk-ts/test/pr_qb_codex_bot_followup.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { SiglumeClient } from "../src/index";
+
+function envelope(data: Record<string, unknown>) {
+  return { data, meta: { request_id: "req_test", trace_id: "trc_test" }, error: null };
+}
+
+function urlOf(input: RequestInfo | URL): URL {
+  if (input instanceof Request) return new URL(input.url);
+  if (input instanceof URL) return input;
+  return new URL(String(input));
+}
+
+describe("PR-Qb codex bot follow-up", () => {
+  // ----- Q1: pagination wiring -------------------------------------------
+
+  it("list_account_digests forwards cursor and wires fetchNext", async () => {
+    const calls: Array<Record<string, string>> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = urlOf(input);
+        const params: Record<string, string> = {};
+        url.searchParams.forEach((value, key) => {
+          params[key] = value;
+        });
+        calls.push(params);
+        const cursor = url.searchParams.get("cursor");
+        if (cursor === null) {
+          return new Response(
+            JSON.stringify(
+              envelope({
+                items: [{ digest_id: "dig_p1_a" }, { digest_id: "dig_p1_b" }],
+                next_cursor: "cursor-page-2",
+              }),
+            ),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (cursor === "cursor-page-2") {
+          return new Response(
+            JSON.stringify(
+              envelope({ items: [{ digest_id: "dig_p2_a" }], next_cursor: null }),
+            ),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected cursor: ${cursor}`);
+      },
+    });
+
+    const page1 = await client.list_account_digests({ limit: 2 });
+    expect(page1.next_cursor).toBe("cursor-page-2");
+    expect(page1.items.length).toBe(2);
+
+    expect(page1.all_items).toBeDefined();
+    const all = await page1.all_items!();
+    expect(all.length).toBe(3);
+
+    expect(calls[0]?.limit).toBe("2");
+    expect(calls[0]?.cursor).toBeUndefined();
+    expect(calls[1]?.cursor).toBe("cursor-page-2");
+    expect(calls[1]?.limit).toBe("2");
+  });
+
+  it("list_account_alerts forwards cursor and wires fetchNext", async () => {
+    const calls: Array<Record<string, string>> = [];
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = urlOf(input);
+        const params: Record<string, string> = {};
+        url.searchParams.forEach((value, key) => {
+          params[key] = value;
+        });
+        calls.push(params);
+        const cursor = url.searchParams.get("cursor");
+        if (cursor === null) {
+          return new Response(
+            JSON.stringify(
+              envelope({
+                items: [{ alert_id: "alt_p1" }],
+                next_cursor: "cursor-alert-2",
+              }),
+            ),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (cursor === "cursor-alert-2") {
+          return new Response(
+            JSON.stringify(
+              envelope({ items: [{ alert_id: "alt_p2" }], next_cursor: null }),
+            ),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected cursor: ${cursor}`);
+      },
+    });
+
+    const page1 = await client.list_account_alerts({ limit: 1 });
+    expect(page1.all_items).toBeDefined();
+    const items = await page1.all_items!();
+    expect(items.map((i) => i.alert_id)).toEqual(["alt_p1", "alt_p2"]);
+    expect(calls[0]?.limit).toBe("1");
+    expect(calls[1]?.cursor).toBe("cursor-alert-2");
+  });
+
+  // ----- Q2: remove favorite status --------------------------------------
+
+  it("remove_account_favorite does not force status on failure", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () =>
+        new Response(JSON.stringify(envelope({ ok: false })), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+
+    const result = await client.remove_account_favorite("agt_missing");
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.agent_id).toBe("agt_missing");
+  });
+
+  it("remove_account_favorite infers status on success", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () =>
+        new Response(JSON.stringify(envelope({ ok: true })), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+
+    const result = await client.remove_account_favorite("agt_success");
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("removed");
+    expect(result.agent_id).toBe("agt_success");
+  });
+
+  it("remove_account_favorite passes through explicit status", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () =>
+        new Response(
+          JSON.stringify(envelope({ ok: true, status: "already_removed" })),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    });
+
+    const result = await client.remove_account_favorite("agt_explicit");
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("already_removed");
+  });
+});

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -1842,10 +1842,14 @@ class SiglumeClient:
         if not normalized_agent_id:
             raise SiglumeClientError("agent_id is required.")
         data, _meta = self._request("PUT", f"/me/favorites/{normalized_agent_id}/remove")
+        # Only infer status="removed" when the server actually confirmed
+        # success. Forcing the default on every response masked failures
+        # (e.g. {"ok": false} with no status field) as successful removals.
+        default_status = "removed" if bool(data.get("ok")) else None
         return _parse_favorite_agent_mutation(
             data,
             default_agent_id=normalized_agent_id,
-            default_status="removed",
+            default_status=default_status,
         )
 
     def post_account_content_direct(
@@ -1870,13 +1874,27 @@ class SiglumeClient:
         data, _meta = self._request("DELETE", f"/content/{normalized_content_id}")
         return _parse_account_content_delete_result(data)
 
-    def list_account_digests(self) -> CursorPage[AccountDigestSummary]:
-        data, meta = self._request("GET", "/digests")
+    def list_account_digests(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> CursorPage[AccountDigestSummary]:
+        params: dict[str, Any] = {}
+        if cursor is not None and str(cursor).strip():
+            params["cursor"] = str(cursor).strip()
+        if limit is not None:
+            params["limit"] = int(limit)
+        data, meta = self._request("GET", "/digests", params=params or None)
         items = data.get("items") if isinstance(data.get("items"), list) else []
+        next_cursor = _string_or_none(data.get("next_cursor"))
         return CursorPage(
             items=[_parse_account_digest_summary(item) for item in items if isinstance(item, Mapping)],
-            next_cursor=_string_or_none(data.get("next_cursor")),
+            next_cursor=next_cursor,
             meta=meta,
+            _fetch_next=(
+                lambda next_value: self.list_account_digests(cursor=next_value, limit=limit)
+            ) if next_cursor else None,
         )
 
     def get_account_digest(self, digest_id: str) -> AccountDigest:
@@ -1886,13 +1904,27 @@ class SiglumeClient:
         data, _meta = self._request("GET", f"/digests/{normalized_digest_id}")
         return _parse_account_digest(data)
 
-    def list_account_alerts(self) -> CursorPage[AccountAlert]:
-        data, meta = self._request("GET", "/alerts")
+    def list_account_alerts(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> CursorPage[AccountAlert]:
+        params: dict[str, Any] = {}
+        if cursor is not None and str(cursor).strip():
+            params["cursor"] = str(cursor).strip()
+        if limit is not None:
+            params["limit"] = int(limit)
+        data, meta = self._request("GET", "/alerts", params=params or None)
         items = data.get("items") if isinstance(data.get("items"), list) else []
+        next_cursor = _string_or_none(data.get("next_cursor"))
         return CursorPage(
             items=[_parse_account_alert(item) for item in items if isinstance(item, Mapping)],
-            next_cursor=_string_or_none(data.get("next_cursor")),
+            next_cursor=next_cursor,
             meta=meta,
+            _fetch_next=(
+                lambda next_value: self.list_account_alerts(cursor=next_value, limit=limit)
+            ) if next_cursor else None,
         )
 
     def get_account_alert(self, alert_id: str) -> AccountAlert:

--- a/tests/test_pr_qb_codex_bot_followup.py
+++ b/tests/test_pr_qb_codex_bot_followup.py
@@ -1,0 +1,191 @@
+"""Regression tests for the two chatgpt-codex-connector[bot] findings on
+PR-Qb (siglume-api-sdk#128):
+
+  Q1 — list_account_digests() and list_account_alerts() returned a
+       CursorPage with next_cursor but never accepted a `cursor`
+       argument or wired `_fetch_next`, so page 2+ was silently
+       truncated.
+  Q2 — remove_account_favorite() forced default_status="removed" on
+       every response, so a failed removal ({"ok": false}) was parsed
+       as status="removed".
+
+Both fixes are code-level; these tests pin the contract so a future
+refactor cannot silently regress.
+"""
+from __future__ import annotations
+
+import httpx
+
+from siglume_api_sdk.client import SiglumeClient
+
+
+def envelope(data):
+    return {"data": data, "meta": {"request_id": "req_test", "trace_id": "trc_test"}}
+
+
+def build_client(handler) -> SiglumeClient:
+    return SiglumeClient(
+        api_key="sig_test_key",
+        base_url="https://api.example.test/v1",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+# ----- Q1: pagination wiring ------------------------------------------------
+
+
+def test_list_account_digests_forwards_cursor_and_wires_fetch_next() -> None:
+    """list_account_digests must accept cursor= and wire _fetch_next so
+    CursorPage.pages() / all_items() can walk beyond page 1."""
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(dict(request.url.params))
+        cursor = request.url.params.get("cursor")
+        if cursor is None:
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "items": [{"digest_id": "dig_p1_a"}, {"digest_id": "dig_p1_b"}],
+                        "next_cursor": "cursor-page-2",
+                    }
+                ),
+            )
+        if cursor == "cursor-page-2":
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "items": [{"digest_id": "dig_p2_a"}],
+                        "next_cursor": None,
+                    }
+                ),
+            )
+        raise AssertionError(f"unexpected cursor: {cursor!r}")
+
+    with build_client(handler) as client:
+        page1 = client.list_account_digests(limit=2)
+        assert page1.next_cursor == "cursor-page-2"
+        assert len(page1.items) == 2
+
+        all_pages = list(page1.pages())
+        # First page is included in pages() iterator.
+        assert [p.next_cursor for p in all_pages] == ["cursor-page-2", None]
+        assert sum(len(p.items) for p in all_pages) == 3
+
+    # limit forwarded on both requests; cursor only on the second.
+    assert calls[0].get("limit") == "2"
+    assert "cursor" not in calls[0]
+    assert calls[1].get("cursor") == "cursor-page-2"
+    assert calls[1].get("limit") == "2"
+
+
+def test_list_account_alerts_forwards_cursor_and_wires_fetch_next() -> None:
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(dict(request.url.params))
+        cursor = request.url.params.get("cursor")
+        if cursor is None:
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "items": [{"alert_id": "alt_p1"}],
+                        "next_cursor": "cursor-alert-2",
+                    }
+                ),
+            )
+        if cursor == "cursor-alert-2":
+            return httpx.Response(
+                200,
+                json=envelope({"items": [{"alert_id": "alt_p2"}], "next_cursor": None}),
+            )
+        raise AssertionError(f"unexpected cursor: {cursor!r}")
+
+    with build_client(handler) as client:
+        page1 = client.list_account_alerts(limit=1)
+        items = page1.all_items()
+
+    assert [item.alert_id for item in items] == ["alt_p1", "alt_p2"]
+    assert calls[0].get("limit") == "1"
+    assert calls[1].get("cursor") == "cursor-alert-2"
+
+
+def test_list_account_digests_passes_cursor_without_limit() -> None:
+    """limit is optional — passing only cursor is valid."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params.get("cursor") == "explicit-cursor"
+        assert "limit" not in dict(request.url.params)
+        return httpx.Response(200, json=envelope({"items": [], "next_cursor": None}))
+
+    with build_client(handler) as client:
+        page = client.list_account_digests(cursor="explicit-cursor")
+    assert page.next_cursor is None
+
+
+def test_list_account_alerts_passes_cursor_without_limit() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params.get("cursor") == "explicit-alert-cursor"
+        assert "limit" not in dict(request.url.params)
+        return httpx.Response(200, json=envelope({"items": [], "next_cursor": None}))
+
+    with build_client(handler) as client:
+        page = client.list_account_alerts(cursor="explicit-alert-cursor")
+    assert page.next_cursor is None
+
+
+# ----- Q2: favorite removal status -----------------------------------------
+
+
+def test_remove_account_favorite_does_not_force_status_on_failure() -> None:
+    """A failed removal ({"ok": false}) without an explicit status must
+    NOT be parsed as status="removed" — the caller must be able to tell
+    the failure apart from the success path."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"ok": False}))
+
+    with build_client(handler) as client:
+        result = client.remove_account_favorite("agt_missing")
+
+    assert result.ok is False
+    assert result.status is None, (
+        "failed removal must not synthesize status='removed'; caller relies on "
+        "ok=False + status=None to distinguish failure from explicit revert."
+    )
+    assert result.agent_id == "agt_missing"
+
+
+def test_remove_account_favorite_infers_status_on_success() -> None:
+    """The default status is still applied when the server confirms ok=True
+    but omits the explicit status field — otherwise the happy path would
+    regress."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=envelope({"ok": True}))
+
+    with build_client(handler) as client:
+        result = client.remove_account_favorite("agt_success")
+
+    assert result.ok is True
+    assert result.status == "removed"
+    assert result.agent_id == "agt_success"
+
+
+def test_remove_account_favorite_passes_through_explicit_status() -> None:
+    """If the server returns an explicit status, don't override it."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=envelope({"ok": True, "status": "already_removed"}),
+        )
+
+    with build_client(handler) as client:
+        result = client.remove_account_favorite("agt_explicit")
+
+    assert result.ok is True
+    assert result.status == "already_removed"


### PR DESCRIPTION
## Summary
Addresses both P2 findings from the codex bot review on PR-Qb (siglume-api-sdk#128).

### Q1 — Pagination wiring (digests + alerts)
`list_account_digests()` / `list_account_alerts()` returned `CursorPage` with `next_cursor` but never accepted a cursor argument or wired `_fetch_next` / `fetchNext`. Pagination silently stopped after page 1.

Fix: both methods now accept `{cursor, limit}` options (Python + TS) and wire the continuation callback. Existing zero-arg call sites stay source-compatible.

### Q2 — Favorite removal status
`remove_account_favorite()` always passed `default_status="removed"`, so `{ "ok": false }` responses parsed as `status="removed"` and masked failures as successful.

Fix: the default is applied only when the server confirms `ok=true`. Failed responses keep `status=null/None` so callers rely on `ok` to distinguish paths. Python + TS parity.

### Regression coverage
- `tests/test_pr_qb_codex_bot_followup.py` (7 cases)
- `siglume-api-sdk-ts/test/pr_qb_codex_bot_followup.test.ts` (5 cases)

## Verification
- pytest: **211 → 218 passed** (0 regressions)
- vitest: **254 → 259 passed** (0 regressions)
- ruff check: clean
- npm run lint / build / typecheck: clean
- contract-sync: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)