### PR TITLE
docs: clarify AIWorks extension audience (fix auto-translation ambiguity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,12 +349,12 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 
 ### AIWorks extension (`siglume_api_sdk_aiworks`)
 
-Separate module for AIWorks job fulfillment. Import only if your app participates in AIWorks.
+Separate module for AIWorks job fulfillment. Import this when your API (or capability listed on the Agent API Store) may be invoked by an agent that is fulfilling an AIWorks job — the platform passes a `JobExecutionContext` into your capability's execution, and this module gives you the typed parser for it. If you do not expect agents to call your API from inside AIWorks jobs, you do not need this module.
 
 | Component | What it does |
 |---|---|
-| `JobExecutionContext` | Context provided when fulfilling an AIWorks job |
-| `FulfillmentReceipt` | Structured receipt for job completion |
+| `JobExecutionContext` | The context the platform passes to your capability when it runs inside an AIWorks job |
+| `FulfillmentReceipt` | Structured receipt you return to confirm the work was completed |
 | `DeliverableSpec` | What the buyer expects the agent to produce |
 | `BudgetSnapshot` | Budget information from the order |
 

--- a/siglume_api_sdk_aiworks.py
+++ b/siglume_api_sdk_aiworks.py
@@ -1,11 +1,15 @@
 """Siglume Agent API SDK — AIWorks extension.
 
-Types for agents fulfilling jobs on AIWorks.
-This module is intentionally separate from the core SDK: AIWorks-specific
-concepts (need_id, order_id, deliverable_spec) do not belong in the
-general-purpose Agent API Store SDK.
+Types for APIs / capabilities that may be invoked by agents fulfilling
+jobs on AIWorks. This module is intentionally separate from the core
+SDK: AIWorks-specific concepts (need_id, order_id, deliverable_spec)
+do not belong in the general-purpose Agent API Store SDK.
 
-Import from here only if your app participates in AIWorks fulfillment.
+Import from here when your capability (listed on the Agent API Store)
+may be called by an agent inside an AIWorks job — the platform passes
+a JobExecutionContext into execution.metadata, and this module is the
+typed parser for it. If your API is never expected to run inside an
+AIWorks job, you do not need this module.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
Fixes the ambiguous wording on the AIWorks extension section of the README.

### Problem
The original text read:
> Separate module for AIWorks job fulfillment. Import only if your app participates in AIWorks.

Auto-translated into Japanese this becomes:
> AIWorksの仕事の達成のための別モジュールがあります。アプリがAIWorksに参加している場合のみインポートしてください。

Which implies the SDK user themselves is an AIWorks participant — wrong. The actual audience is API / capability developers on the Agent API Store whose listing may be invoked by an AIWorks-fulfilling agent. Those agents pass a `JobExecutionContext` into `execution.metadata`; this module is the typed parser for it.

### Fix
- `README.md` — expand the one-liner into a paragraph that names the real use case ("your capability may be invoked by an agent fulfilling an AIWorks job") and tells readers who don't fit to skip the module.
- `siglume_api_sdk_aiworks.py` docstring — same clarification so `help()` / IDE hover text matches the README.

No code changes. pytest 215 passed, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)