### PR TITLE
docs: unify concept wording to 'Agent API Store' (replace 'marketplace')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and typed Web3 read/simulate helpers now ship in both Python and TypeScript.
 
 ### Changed
 
-- The public OpenAPI surface now includes the marketplace webhook, refund,
+- The public OpenAPI surface now includes the Agent API Store webhook, refund,
   dispute, metering, and Web3 settlement endpoints the SDK wraps.
 - README and Getting Started now point to the current v0.5.0 release line and
   its new platform-integration surfaces.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` before using the helper or the bundl
 ## Using Siglume from LangChain / Claude Agent SDK
 
 The buyer-side SDK is available as `SiglumeBuyerClient` for framework adapters
-that consume marketplace listings instead of publishing them.
+that consume Agent API Store listings instead of publishing them.
 
 - Python bridge example: [examples/buyer_langchain.py](./examples/buyer_langchain.py)
 - TypeScript bridge example: [examples/buyer_claude_agent_sdk.ts](./examples/buyer_claude_agent_sdk.ts)
@@ -236,7 +236,7 @@ or a blank starter template.
 
 ## Refunds and disputes
 
-Use `RefundClient` when you need to reverse a completed marketplace charge or
+Use `RefundClient` when you need to reverse a completed Agent API Store charge or
 respond to a buyer dispute from seller support tooling.
 
 - Python example: [examples/refund_partial.py](./examples/refund_partial.py)
@@ -268,7 +268,7 @@ quotes.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked marketplace receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked Agent API Store receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 `account_plan_wrapper.py` adds a READ_ONLY account-context example that loads
 typed preferences plus the current plan for personalization.

--- a/RELEASE_NOTES_v0.3.1.md
+++ b/RELEASE_NOTES_v0.3.1.md
@@ -4,7 +4,7 @@
 
 v0.3.1 is a patch release for two P2 issues found by automated review after
 the v0.3.0 cut. The fixes keep the server/client story aligned for preview
-quality scoring across Python, TypeScript, and the public marketplace API.
+quality scoring across Python, TypeScript, and the public Agent API Store API.
 
 ## Fixed
 

--- a/RELEASE_NOTES_v0.4.0.md
+++ b/RELEASE_NOTES_v0.4.0.md
@@ -24,8 +24,8 @@ without leaving the public SDK surface.
 - **Deterministic recording harness**: shared Python/TypeScript cassettes let
   tests replay HTTP flows without live network access.
 - **Buyer-side SDK**: experimental `SiglumeBuyerClient` makes it easier to plug
-  Siglume marketplace capabilities into LangChain-style and Claude-style agent
-  runtimes.
+  Siglume Agent API Store capabilities into LangChain-style and Claude-style
+  agent runtimes.
 - **Example set completed for v0.4**: `crm_sync`, `news_digest`, and
   `wallet_balance` join the earlier examples, with TypeScript counterparts in
   `examples-ts/`.

--- a/announcements/POST_HACKERNEWS.md
+++ b/announcements/POST_HACKERNEWS.md
@@ -8,7 +8,7 @@ Title: Show HN: SDK for publishing APIs that AI agents subscribe to (Python + TS
 
 ---
 
-Siglume (https://siglume.com) is an agent-to-agent marketplace where the customer is the AI, not the human. The SDK I'm releasing — `siglume-api-sdk` v0.4.0 — is for developers who want to publish APIs that autonomous agents discover, subscribe to, and call.
+Siglume (https://siglume.com) is an Agent API Store where the API consumer is the AI, not the human — but the subscription decision (opt-in, budget authorize) is still made by the agent's human owner. The SDK I'm releasing — `siglume-api-sdk` v0.4.0 — is for developers who want to publish APIs that autonomous agents discover, subscribe to, and call at runtime after their owner opts in.
 
 The mental model inverts: instead of humans installing apps, agents subscribe to APIs on behalf of their owner. Each subscription pays the developer 93.4% of the revenue (6.6% platform fee), settled on-chain on Polygon (USD-unified, gas sponsored by the platform, no wallet setup required for free listings). Stripe Connect was the original rail; we cut over to smart-wallet / mandate-based auto-debit in Phase 31 (2026-04-18), verified with real userOp on Polygon Amoy.
 

--- a/docs/buyer-sdk.md
+++ b/docs/buyer-sdk.md
@@ -2,7 +2,7 @@
 
 `SiglumeBuyerClient` is the consumer-side companion to `SiglumeClient`. It is
 meant for agent frameworks that want to discover, subscribe to, and invoke
-Siglume marketplace capabilities.
+Siglume Agent API Store capabilities.
 
 ## Current platform shape
 

--- a/docs/refunds-disputes.md
+++ b/docs/refunds-disputes.md
@@ -1,7 +1,7 @@
 # Refunds and Disputes
 
 Siglume exposes receipt-based refund and dispute APIs so sellers can reverse a
-completed marketplace charge or respond to a buyer dispute without dropping
+completed Agent API Store charge or respond to a buyer dispute without dropping
 into raw HTTP calls.
 
 ## Python

--- a/docs/sdk/v0.6-operation-inventory.md
+++ b/docs/sdk/v0.6-operation-inventory.md
@@ -253,7 +253,7 @@ Priority order for typed wrappers after PR-S1:
 1. `market.needs.list` / `market.needs.get` / `market.needs.create`
 Reason: highest day-to-day owner workflow value, directly adjacent to the publish / buy loop, and a clean namespace for PR-S2a.
 2. `market.proposals.list` / `market.proposals.get` / `market.proposals.accept`
-Reason: complements needs coverage, unlocks the proposal negotiation loop, and still stays inside the same marketplace domain with low cross-namespace dependency.
+Reason: complements needs coverage, unlocks the proposal negotiation loop, and still stays inside the same Agent API Store domain with low cross-namespace dependency.
 3. `works.registration.get` / `works.registration.register`
 Reason: AI Works is a distinct surface with clear CRUD-like semantics, so it is a good low-conflict second namespace after market needs/proposals.
 4. `installed_tools.execution.get` / `installed_tools.receipts.get`
@@ -261,5 +261,5 @@ Reason: pairs naturally with the existing buyer SDK invoke flow, but touches exe
 5. `partner.keys.list` / `partner.keys.create`
 Reason: valuable for external operator tooling, but lower urgency than market / works, and partner billing should stay behind its own narrower PR boundary.
 
-Namespace ordering rationale: `market.*` first for owner marketplace use-case frequency, `works.*` next because it is isolated, `installed_tools.*` after that because it overlaps with approval/execution lifecycle, and `partner.*` / `ads.*` last because billing and campaign surfaces are broader and more likely to conflict with ongoing product work.
+Namespace ordering rationale: `market.*` first for owner Agent API Store use-case frequency, `works.*` next because it is isolated, `installed_tools.*` after that because it overlaps with approval/execution lifecycle, and `partner.*` / `ads.*` last because billing and campaign surfaces are broader and more likely to conflict with ongoing product work.
 

--- a/docs/sdk/v0.6-plan.md
+++ b/docs/sdk/v0.6-plan.md
@@ -8,7 +8,7 @@ Status: deferred from `v0.5` to `v0.6`
 
 Reason:
 - The main platform has multi-capability pitch and validator support, but it
-  does not yet expose a public marketplace registration surface for bundling
+  does not yet expose a public Agent API Store registration surface for bundling
   multiple `ToolManual` objects under one listing.
 - No public `/v1/market/bundles`, `capability-bundles`, or equivalent bundle
   registration/read API is available in the platform presentation layer or the

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,6 +1,6 @@
 # Webhooks
 
-Siglume marketplace webhooks let sellers receive signed lifecycle events for subscriptions, payments, capability listing changes, and executions.
+Siglume Agent API Store webhooks let sellers receive signed lifecycle events for subscriptions, payments, capability listing changes, and executions.
 
 ## Supported Events
 


### PR DESCRIPTION
## Summary
The product's canonical user-facing name is **Agent API Store**. Several docs still used "marketplace" as a descriptor, which violates the naming convention and confused readers when paired with the actual product name (and auto-translated confusingly into Japanese as マーケットプレイス).

### Files updated (user-facing concept wording)
- `README.md` — buyer-SDK intro, refund section, examples summary
- `CHANGELOG.md` — v0.5.0 OpenAPI bullet
- `RELEASE_NOTES_v0.3.1.md`, `RELEASE_NOTES_v0.4.0.md`
- `docs/buyer-sdk.md`, `docs/refunds-disputes.md`, `docs/webhooks.md`
- `docs/sdk/v0.6-plan.md`, `docs/sdk/v0.6-operation-inventory.md`
- `announcements/POST_HACKERNEWS.md` (+ disambiguates buyer vs consumer, consistent with PR #131)

### Kept as-is
- `PAYMENT_MIGRATION.md` references like `marketplace_api.py`, `marketplace_capabilities.py` — literal code file names, not concept descriptors.
- `POST_ZENN.md` "Stripe Marketplace" — proper-noun competitor product reference.

## Test plan
- [x] pytest: 218 passed, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)