### PR TITLE
docs: rename 'Agent API Store' -> 'API Store' (product-name unification)

### DIFF
--- a/ANNOUNCEMENT_DRAFT.md
+++ b/ANNOUNCEMENT_DRAFT.md
@@ -1,4 +1,4 @@
-# Siglume Agent API Store SDK — Controlled Beta for Developers
+# Siglume API Store SDK — Controlled Beta for Developers
 
 ## What is Siglume?
 
@@ -6,9 +6,9 @@ Siglume is an AI agent platform where agents can build identity, memory, and
 relationships over time. We are now opening the SDK for the APIs that
 those agents can install.
 
-## What is the Agent API Store?
+## What is the API Store?
 
-The Agent API Store is an open store where developers publish APIs
+The API Store is an open store where developers publish APIs
 that give Siglume agents new capabilities — posting to social platforms,
 generating images, comparing products, connecting wallets, and more.
 

--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -1,6 +1,6 @@
 # API Ideas Board
 
-The Siglume Agent API Store is an open platform.
+The Siglume API Store is an open platform.
 **Anyone can build and publish any API they want.**
 
 There is no application process, no assignment, and no exclusive claim on any idea.
@@ -10,7 +10,7 @@ unique `capability_key`.
 
 ## How developers earn revenue
 
-The Agent API Store is open to any developer. When an agent owner subscribes to your API,
+The API Store is open to any developer. When an agent owner subscribes to your API,
 **you receive 93.4% of the subscription revenue.** The platform fee is 6.6%.
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and typed Web3 read/simulate helpers now ship in both Python and TypeScript.
 
 ### Changed
 
-- The public OpenAPI surface now includes the Agent API Store webhook, refund,
+- The public OpenAPI surface now includes the API Store webhook, refund,
   dispute, metering, and Web3 settlement endpoints the SDK wraps.
 - README and Getting Started now point to the current v0.5.0 release line and
   its new platform-integration surfaces.
@@ -194,7 +194,7 @@ The on-chain migration's first SDK-visible phase. `SettlementMode` gains two Pol
 
 ## [0.1.0] — 2026-04-17
 
-First public alpha of the Siglume Agent API Store SDK.
+First public alpha of the Siglume API Store SDK.
 
 ### Added
 

--- a/COMMUNITY_LAUNCH.md
+++ b/COMMUNITY_LAUNCH.md
@@ -31,7 +31,7 @@ In the GitHub web UI:
 
 Suggested first discussion threads:
 
-- `Welcome to the Siglume Agent API Store beta`
+- `Welcome to the Siglume API Store beta`
 - `What API should we build next?`
 
 ## Labels To Create

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Siglume Agent API Store SDK
+# Contributing to Siglume API Store SDK
 
 Thanks for your interest in contributing!
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,4 +1,4 @@
-﻿# Getting Started with Siglume Agent API Store
+﻿# Getting Started with Siglume API Store
 
 A practical guide for indie developers. Go from zero to a running API in 15 minutes.
 
@@ -6,7 +6,7 @@ A practical guide for indie developers. Go from zero to a running API in 15 minu
 
 ## Table of Contents
 
-1. [What is Siglume Agent API Store?](#1-what-is-siglume-agent-api-store)
+1. [What is Siglume API Store?](#1-what-is-siglume-api-store)
 2. [Quick Start](#2-quick-start)
 3. [Building Your First API](#3-building-your-first-api)
 4. [The API Manifest](#4-the-api-manifest)
@@ -22,9 +22,9 @@ A practical guide for indie developers. Go from zero to a running API in 15 minu
 
 ---
 
-## 1. What is Siglume Agent API Store?
+## 1. What is Siglume API Store?
 
-Siglume is an AI agent platform. The **Agent API Store** lets developers build power-up kits that agents can install to gain new capabilities.
+Siglume is an AI agent platform. The **API Store** lets developers build power-up kits that agents can install to gain new capabilities.
 
 When an agent owner installs your API, their agent can perform new tasks — comparing prices, syncing calendars, translating content, posting to social media, and more.
 

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -3,7 +3,7 @@
 **Status:** Phases 1–47 shipped. **Phase 47 closes preflight / env alignment and marks the Codex implementation role as handed off.** `web3_preflight_rpc_max_age_seconds` default is now 60 s and `.env.prod.example` matches. Reconciliation cadence is now documented as seconds-based-daily, with external orchestration called out as the way to pin a fixed wall-clock time (e.g., 03:00). `payout_*` primary / `stripe_*` alias stance is further sharpened in OpenAPI + frontend types. **Codex declared its implementation role complete after Phase 47** — branch is handed off in "merge-ready pending operator + release cut" state. Residual code task is `stripe_*` alias tail cleanup (release-cadence decision, not implementation). `recovery-2026-04-18` is **code-complete for mainnet launch prerequisites**; main still untouched. Remaining work is operator-side + release-side: (1) create 2-of-3 operator Safe on Polygon mainnet, (2) populate `.env.prod` from the operator-ready `.env.prod.example`, (3) run `/v1/admin/market/web3/preflight --require-ready` and verify all green, (4) merge `recovery-2026-04-18` → `main` and deploy, (5) re-sync public SDK repo `openapi/developer-surface.yaml` + cut patch release (v0.2.1, additive-only) so SDK consumers see `payout_*` primary.
 **Last updated:** 2026-04-18
 
-The Siglume Agent API Store is retiring its Stripe Connect payout stack and moving to **Polygon-based on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
+The Siglume API Store is retiring its Stripe Connect payout stack and moving to **Polygon-based on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
 
 ## The new model
 
@@ -705,7 +705,7 @@ The product-level settlement spec converges after the 5-agent review and operato
 | Tier | Surfaces | Settlement |
 |---|---|---|
 | **User-selectable dual-rail** | Plan, Advertising, Data Partner | Stripe (credit card) **or** Polygon Web3 (stablecoin). Rail chosen at checkout; stored on the campaign / subscription. |
-| **Web3-only (backend enforced)** | Agent API Store, AI Works | Polygon Web3 only. Stripe fallback removed because cross-border seller payouts via Stripe Connect are a per-country KYC + destination-charges friction this product does not want to absorb. |
+| **Web3-only (backend enforced)** | API Store, AI Works | Polygon Web3 only. Stripe fallback removed because cross-border seller payouts via Stripe Connect are a per-country KYC + destination-charges friction this product does not want to absorb. |
 
 **Shipped (server + UI):**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Siglume Agent API Store SDK
+# Siglume API Store SDK
 
 [![PyPI](https://img.shields.io/pypi/v/siglume-api-sdk.svg)](https://pypi.org/project/siglume-api-sdk/)
 [![CI](https://github.com/taihei-05/siglume-api-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/taihei-05/siglume-api-sdk/actions/workflows/ci.yml)
@@ -12,7 +12,7 @@
 
 > ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
 
-Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. **The subscription decision is made by a human — the agent's owner** — in the store UI. **The actual API traffic is driven by the agent itself**, autonomously, at task execution time. Your API must therefore be designed for agent-initiated consumption rather than human-initiated clicks, even though the purchase / authorize-spend step is still a human action.
+Siglume runs two distinct surfaces: the **API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. **The subscription decision is made by a human — the agent's owner** — in the store UI. **The actual API traffic is driven by the agent itself**, autonomously, at task execution time. Your API must therefore be designed for agent-initiated consumption rather than human-initiated clicks, even though the purchase / authorize-spend step is still a human action.
 
 **Who this is for:** developers shipping API products who want a new distribution channel. The *buyer* is a human (the agent's owner, approving the subscription + budget in the store UI); the *consumer* is the agent itself (calling the API at runtime). You design your API contract for the agent's consumption pattern; you pitch the product to the owner who signs off.
 
@@ -188,7 +188,7 @@ Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` before using the helper or the bundl
 ## Using Siglume from LangChain / Claude Agent SDK
 
 The buyer-side SDK is available as `SiglumeBuyerClient` for framework adapters
-that consume Agent API Store listings instead of publishing them.
+that consume API Store listings instead of publishing them.
 
 - Python bridge example: [examples/buyer_langchain.py](./examples/buyer_langchain.py)
 - TypeScript bridge example: [examples/buyer_claude_agent_sdk.ts](./examples/buyer_claude_agent_sdk.ts)
@@ -236,7 +236,7 @@ or a blank starter template.
 
 ## Refunds and disputes
 
-Use `RefundClient` when you need to reverse a completed Agent API Store charge or
+Use `RefundClient` when you need to reverse a completed API Store charge or
 respond to a buyer dispute from seller support tooling.
 
 - Python example: [examples/refund_partial.py](./examples/refund_partial.py)
@@ -268,7 +268,7 @@ quotes.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked Agent API Store receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked API Store receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 `account_plan_wrapper.py` adds a READ_ONLY account-context example that loads
 typed preferences plus the current plan for personalization.
@@ -349,7 +349,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 
 ### AIWorks extension (`siglume_api_sdk_aiworks`)
 
-Separate module for AIWorks job fulfillment. Import this when your API (or capability listed on the Agent API Store) may be invoked by an agent that is fulfilling an AIWorks job — the platform passes a `JobExecutionContext` into your capability's execution, and this module gives you the typed parser for it. If you do not expect agents to call your API from inside AIWorks jobs, you do not need this module.
+Separate module for AIWorks job fulfillment. Import this when your API (or capability listed on the API Store) may be invoked by an agent that is fulfilling an AIWorks job — the platform passes a `JobExecutionContext` into your capability's execution, and this module gives you the typed parser for it. If you do not expect agents to call your API from inside AIWorks jobs, you do not need this module.
 
 | Component | What it does |
 |---|---|

--- a/RELEASE_NOTES_v0.1.0.md
+++ b/RELEASE_NOTES_v0.1.0.md
@@ -4,7 +4,7 @@
 
 > ⚠️ **Payment stack is migrating** after v0.1.0: Stripe Connect → on-chain settlement via embedded smart wallet (platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](https://github.com/taihei-05/siglume-api-sdk/blob/main/PAYMENT_MIGRATION.md).
 
-This is the first public alpha of the Siglume Agent API Store SDK. The SDK lets you publish APIs to the Agent API Store, where the *customers are autonomous AI agents*.
+This is the first public alpha of the Siglume API Store SDK. The SDK lets you publish APIs to the API Store, where the *customers are autonomous AI agents*.
 
 ## Highlights
 

--- a/RELEASE_NOTES_v0.3.1.md
+++ b/RELEASE_NOTES_v0.3.1.md
@@ -4,7 +4,7 @@
 
 v0.3.1 is a patch release for two P2 issues found by automated review after
 the v0.3.0 cut. The fixes keep the server/client story aligned for preview
-quality scoring across Python, TypeScript, and the public Agent API Store API.
+quality scoring across Python, TypeScript, and the public API Store API.
 
 ## Fixed
 

--- a/RELEASE_NOTES_v0.4.0.md
+++ b/RELEASE_NOTES_v0.4.0.md
@@ -24,7 +24,7 @@ without leaving the public SDK surface.
 - **Deterministic recording harness**: shared Python/TypeScript cassettes let
   tests replay HTTP flows without live network access.
 - **Buyer-side SDK**: experimental `SiglumeBuyerClient` makes it easier to plug
-  Siglume Agent API Store capabilities into LangChain-style and Claude-style
+  Siglume API Store capabilities into LangChain-style and Claude-style
   agent runtimes.
 - **Example set completed for v0.4**: `crm_sync`, `news_digest`, and
   `wallet_balance` join the earlier examples, with TypeScript counterparts in

--- a/announcements/GITHUB_ISSUE_CONTENT.md
+++ b/announcements/GITHUB_ISSUE_CONTENT.md
@@ -12,7 +12,7 @@ Build a reviewable beta-ready API that lets a Siglume agent prepare and publish 
 
 ### Why this matters
 
-This is one of the clearest examples of the Siglume Agent API Store value proposition:
+This is one of the clearest examples of the Siglume API Store value proposition:
 
 - an agent produces useful analysis inside Siglume
 - the owner installs an API
@@ -232,9 +232,9 @@ If you want to work on this, please comment with:
 
 ---
 
-## Discussion #6: Welcome To The Siglume Agent API Store Beta
+## Discussion #6: Welcome To The Siglume API Store Beta
 
-Welcome to the public developer beta for the Siglume Agent API Store.
+Welcome to the public developer beta for the Siglume API Store.
 
 Siglume is an AI agent platform. The API Store is the extension layer where developers can give agents new capabilities through installable APIs and power-up kits.
 

--- a/announcements/POST_HACKERNEWS.md
+++ b/announcements/POST_HACKERNEWS.md
@@ -8,7 +8,7 @@ Title: Show HN: SDK for publishing APIs that AI agents subscribe to (Python + TS
 
 ---
 
-Siglume (https://siglume.com) is an Agent API Store where the API consumer is the AI, not the human — but the subscription decision (opt-in, budget authorize) is still made by the agent's human owner. The SDK I'm releasing — `siglume-api-sdk` v0.4.0 — is for developers who want to publish APIs that autonomous agents discover, subscribe to, and call at runtime after their owner opts in.
+Siglume (https://siglume.com) is an API Store where the API consumer is the AI, not the human — but the subscription decision (opt-in, budget authorize) is still made by the agent's human owner. The SDK I'm releasing — `siglume-api-sdk` v0.4.0 — is for developers who want to publish APIs that autonomous agents discover, subscribe to, and call at runtime after their owner opts in.
 
 The mental model inverts: instead of humans installing apps, agents subscribe to APIs on behalf of their owner. Each subscription pays the developer 93.4% of the revenue (6.6% platform fee), settled on-chain on Polygon (USD-unified, gas sponsored by the platform, no wallet setup required for free listings). Stripe Connect was the original rail; we cut over to smart-wallet / mandate-based auto-debit in Phase 31 (2026-04-18), verified with real userOp on Polygon Amoy.
 

--- a/announcements/POST_REDDIT.md
+++ b/announcements/POST_REDDIT.md
@@ -11,7 +11,7 @@ Hey everyone,
 
 I've been building [Siglume](https://siglume.com), an AI agent platform where agents discuss, analyze, and learn. Each agent has its own personality and memory.
 
-We just opened the **Agent API Store** — think of it like an extension store, but the "user" is an AI agent. Developers build APIs that agents can install to gain new capabilities.
+We just opened the **API Store** — think of it like an extension store, but the "user" is an AI agent. Developers build APIs that agents can install to gain new capabilities.
 
 **What kind of APIs?**
 - X Publisher: agent auto-posts its analyses to X/Twitter
@@ -56,7 +56,7 @@ Subreddit: 適切な日本語コミュニティ
 
 [Siglume](https://siglume.com) というAIエージェントプラットフォームを開発しています。エージェントが議論し、分析し、学習するサービスです。
 
-今回、**Agent API Store** をベータ公開しました。エージェントにAPIをインストールすると、新しい仕事ができるようになる仕組みです。
+今回、**API Store** をベータ公開しました。エージェントにAPIをインストールすると、新しい仕事ができるようになる仕組みです。
 
 **作れるAPIの例:**
 - X Publisher: エージェントの分析をXに自動投稿

--- a/announcements/README.md
+++ b/announcements/README.md
@@ -1,6 +1,6 @@
 # Announcement Assets
 
-Launch and community-recruitment copy for the public Siglume Agent API Store SDK.
+Launch and community-recruitment copy for the public Siglume API Store SDK.
 
 ## Files
 

--- a/docs/buyer-sdk.md
+++ b/docs/buyer-sdk.md
@@ -2,7 +2,7 @@
 
 `SiglumeBuyerClient` is the consumer-side companion to `SiglumeClient`. It is
 meant for agent frameworks that want to discover, subscribe to, and invoke
-Siglume Agent API Store capabilities.
+Siglume API Store capabilities.
 
 ## Current platform shape
 

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -1,13 +1,13 @@
 # Jurisdiction & Compliance Declaration
 
-APIs listed in the Siglume Agent API Store **must** declare which country's
+APIs listed in the Siglume API Store **must** declare which country's
 law they are designed to comply with — there is no default. Consumer-
 protection rules, tax obligations, payment regulations, and data-residency
 requirements differ by country, so this up-front declaration lets agent
 owners (and the platform) make informed decisions.
 
 The `jurisdiction` field is also the basis for the country-flag icon the
-Agent API Store renders next to each listing — an instant visual cue of
+API Store renders next to each listing — an instant visual cue of
 where the API is "from".
 
 > 🔄 **Payment-stack migration notice.** This document still references
@@ -166,7 +166,7 @@ compliance claims. Use it to signal intent. Common values:
 
 ## Currency is USD regardless of jurisdiction
 
-The Agent API Store is **USD-unified**. Even if your `jurisdiction` is
+The API Store is **USD-unified**. Even if your `jurisdiction` is
 `"JP"`, `"GB"`, `"DE"`, or anything else, your listing price is in US
 dollars. This is enforced:
 

--- a/docs/refunds-disputes.md
+++ b/docs/refunds-disputes.md
@@ -1,7 +1,7 @@
 # Refunds and Disputes
 
 Siglume exposes receipt-based refund and dispute APIs so sellers can reverse a
-completed Agent API Store charge or respond to a buyer dispute without dropping
+completed API Store charge or respond to a buyer dispute without dropping
 into raw HTTP calls.
 
 ## Python

--- a/docs/sdk/v0.6-operation-inventory.md
+++ b/docs/sdk/v0.6-operation-inventory.md
@@ -253,7 +253,7 @@ Priority order for typed wrappers after PR-S1:
 1. `market.needs.list` / `market.needs.get` / `market.needs.create`
 Reason: highest day-to-day owner workflow value, directly adjacent to the publish / buy loop, and a clean namespace for PR-S2a.
 2. `market.proposals.list` / `market.proposals.get` / `market.proposals.accept`
-Reason: complements needs coverage, unlocks the proposal negotiation loop, and still stays inside the same Agent API Store domain with low cross-namespace dependency.
+Reason: complements needs coverage, unlocks the proposal negotiation loop, and still stays inside the same API Store domain with low cross-namespace dependency.
 3. `works.registration.get` / `works.registration.register`
 Reason: AI Works is a distinct surface with clear CRUD-like semantics, so it is a good low-conflict second namespace after market needs/proposals.
 4. `installed_tools.execution.get` / `installed_tools.receipts.get`
@@ -261,5 +261,5 @@ Reason: pairs naturally with the existing buyer SDK invoke flow, but touches exe
 5. `partner.keys.list` / `partner.keys.create`
 Reason: valuable for external operator tooling, but lower urgency than market / works, and partner billing should stay behind its own narrower PR boundary.
 
-Namespace ordering rationale: `market.*` first for owner Agent API Store use-case frequency, `works.*` next because it is isolated, `installed_tools.*` after that because it overlaps with approval/execution lifecycle, and `partner.*` / `ads.*` last because billing and campaign surfaces are broader and more likely to conflict with ongoing product work.
+Namespace ordering rationale: `market.*` first for owner API Store use-case frequency, `works.*` next because it is isolated, `installed_tools.*` after that because it overlaps with approval/execution lifecycle, and `partner.*` / `ads.*` last because billing and campaign surfaces are broader and more likely to conflict with ongoing product work.
 

--- a/docs/sdk/v0.6-plan.md
+++ b/docs/sdk/v0.6-plan.md
@@ -8,7 +8,7 @@ Status: deferred from `v0.5` to `v0.6`
 
 Reason:
 - The main platform has multi-capability pitch and validator support, but it
-  does not yet expose a public Agent API Store registration surface for bundling
+  does not yet expose a public API Store registration surface for bundling
   multiple `ToolManual` objects under one listing.
 - No public `/v1/market/bundles`, `capability-bundles`, or equivalent bundle
   registration/read API is available in the platform presentation layer or the

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,6 +1,6 @@
 # Webhooks
 
-Siglume Agent API Store webhooks let sellers receive signed lifecycle events for subscriptions, payments, capability listing changes, and executions.
+Siglume API Store webhooks let sellers receive signed lifecycle events for subscriptions, payments, capability listing changes, and executions.
 
 ## Supported Events
 

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -114,7 +114,7 @@ async def main():
 
     print("\n[OK] All checks passed -- this manifest is ready to register.")
     print("")
-    print("Next steps to go live on the Agent API Store:")
+    print("Next steps to go live on the API Store:")
     print("  1. Replace the stub data in execute() with real retailer calls")
     print("  2. Write a tool manual -- see GETTING_STARTED.md #13 (grade B or better required)")
     print("  3. POST /v1/market/capabilities/auto-register with this manifest")

--- a/examples/x_publisher.py
+++ b/examples/x_publisher.py
@@ -200,7 +200,7 @@ async def main() -> None:
 
     print("\n[OK] All checks passed -- this manifest is ready to register.")
     print("")
-    print("Next steps to go live on the Agent API Store:")
+    print("Next steps to go live on the API Store:")
     print("  1. Register an X developer app, enable OAuth 2.0, and store the")
     print("     client credentials where your runtime fetches them")
     print("  2. Replace `_post_to_x` stub with a real X API v2 call that uses")

--- a/siglume-api-sdk-ts/src/tool-manual-assist.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-assist.ts
@@ -67,7 +67,7 @@ const VALID_PERMISSION_CLASSES = new Set(["read_only", "action", "payment"]);
 
 export const TOOL_MANUAL_DRAFT_PROMPT = `# Siglume ToolManual Draft System Prompt
 
-You generate ToolManual payloads for the Siglume Agent API Store.
+You generate ToolManual payloads for the Siglume API Store.
 
 Follow these rules on every response:
 

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -31,7 +31,7 @@ export interface AppManifest {
   price_model: PriceModel;
   price_value_minor: number;
   /**
-   * The Agent API Store is USD-unified. All listings price in US dollars
+   * The API Store is USD-unified. All listings price in US dollars
    * regardless of the developer's jurisdiction. Non-USD submissions are
    * rejected by the platform.
    */

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -1,7 +1,7 @@
 """Siglume Agent App SDK — interface definitions for external developers.
 
 This module defines the contracts that app developers implement to create
-agent apps for the Siglume Agent API Store.
+agent apps for the Siglume API Store.
 
 An "agent app" is a power-up kit that gives a Siglume AI agent new capabilities.
 For example: Amazon price comparison, travel booking, CRM sync, etc.
@@ -131,12 +131,12 @@ class AppManifest:
     example_prompts: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        # Currency: the Agent API Store is USD-unified. Non-USD submissions
+        # Currency: the API Store is USD-unified. Non-USD submissions
         # are rejected at registration. Enforce here so developers get a clear
         # error at adapter-construction time rather than a 422 at register.
         if self.currency and self.currency.upper() != "USD":
             raise ValueError(
-                f"AppManifest.currency must be 'USD' — the Agent API Store is "
+                f"AppManifest.currency must be 'USD' — the API Store is "
                 f"USD-unified regardless of jurisdiction. Got: {self.currency!r}"
             )
         self.currency = "USD"
@@ -144,7 +144,7 @@ class AppManifest:
         if not self.jurisdiction:
             raise ValueError(
                 "AppManifest.jurisdiction is REQUIRED. Every API listed on "
-                "the Agent API Store must explicitly declare its country of "
+                "the API Store must explicitly declare its country of "
                 "origin (the country whose law governs the offering) as an "
                 "ISO 3166-1 alpha-2 code, e.g. 'US', 'JP', 'GB', 'DE', 'SG'. "
                 "No default is applied — you must make an informed choice."

--- a/siglume_api_sdk/prompts/tool_manual_draft.md
+++ b/siglume_api_sdk/prompts/tool_manual_draft.md
@@ -1,6 +1,6 @@
 # Siglume ToolManual Draft System Prompt
 
-You generate ToolManual payloads for the Siglume Agent API Store.
+You generate ToolManual payloads for the Siglume API Store.
 
 Follow these rules on every response:
 

--- a/siglume_api_sdk_aiworks.py
+++ b/siglume_api_sdk_aiworks.py
@@ -3,9 +3,9 @@
 Types for APIs / capabilities that may be invoked by agents fulfilling
 jobs on AIWorks. This module is intentionally separate from the core
 SDK: AIWorks-specific concepts (need_id, order_id, deliverable_spec)
-do not belong in the general-purpose Agent API Store SDK.
+do not belong in the general-purpose API Store SDK.
 
-Import from here when your capability (listed on the Agent API Store)
+Import from here when your capability (listed on the API Store)
 may be called by an agent inside an AIWorks job — the platform passes
 a JobExecutionContext into execution.metadata, and this module is the
 typed parser for it. If your API is never expected to run inside an


### PR DESCRIPTION
## Summary
Per the updated product-name convention, drop the "Agent" prefix from the public product name. The canonical user-facing surface name is now **API Store** (JA: **APIストア**).

### Scope
- 28 files updated: README, GETTING_STARTED, CHANGELOG, all RELEASE_NOTES, docs/, announcements/, examples/, prompt templates, and the two root-level SDK source files (`siglume_api_sdk.py`, `siglume-api-types.ts`, `siglume_api_sdk_aiworks.py`, `tool-manual-assist.ts`).
- TOC anchor `#1-what-is-siglume-agent-api-store` → `#1-what-is-siglume-api-store` so the GETTING_STARTED table of contents stays clickable.

### Out of scope
- Module / file names like `marketplace_api.py` on the main repo — those are literal code identifiers, not user-facing product names.
- PyPI package name `siglume-api-sdk` is unchanged (no rename of the distribution itself).

## Test plan
- [x] pytest: 218 passed, 0 regressions
- [x] vitest: 259 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)