### PR TITLE
docs: restructure README for first-read speed + move SDK core concepts to docs + historical-ize COMMUNITY_LAUNCH

### DIFF
--- a/COMMUNITY_LAUNCH.md
+++ b/COMMUNITY_LAUNCH.md
@@ -1,66 +1,56 @@
-# Community Launch Guide
+# Community Launch Guide (historical note)
 
-This repo is already prepared for public beta recruitment with:
+> **Status: already executed.** This file is kept as a historical
+> reference. Discussions are enabled, labels exist, and seed issues
+> were opened at initial launch. If you are landing here looking for
+> how to contribute, go to [`CONTRIBUTING.md`](./CONTRIBUTING.md) and
+> [GitHub Discussions](https://github.com/taihei-05/siglume-api-sdk/discussions)
+> instead.
 
-- issue forms
+The sections below document what was set up so that a future fork of
+this repo can follow the same bootstrap.
+
+## Repo infrastructure (one-time setup)
+
+- Issue forms (see `.github/ISSUE_TEMPLATE/`)
 - PR template
 - `CODEOWNERS`
 - `SECURITY.md`
 - `CODE_OF_CONDUCT.md`
-- devcontainer support
+- Devcontainer support
 
-Two GitHub setup steps still require maintainer auth on the live repo:
+## Live surfaces
 
-1. Enable Discussions
-2. Create the first labels and seed issues
+- Repo: <https://github.com/taihei-05/siglume-api-sdk>
+- Discussions: <https://github.com/taihei-05/siglume-api-sdk/discussions>
+- Issues: <https://github.com/taihei-05/siglume-api-sdk/issues>
+- Labels: <https://github.com/taihei-05/siglume-api-sdk/labels>
 
-## Current Repo URLs
+## Labels in use
 
-- Repo: `https://github.com/taihei-05/siglume-api-sdk`
-- New issue chooser: `https://github.com/taihei-05/siglume-api-sdk/issues/new/choose`
-- Labels: `https://github.com/taihei-05/siglume-api-sdk/labels`
-- Settings: `https://github.com/taihei-05/siglume-api-sdk/settings`
+`api-idea`, `connector-request`, `review-support`, `community-api`,
+`launch`, `bug`.
 
-## Enable Discussions
+## Starter discussion / issue topics (opened at launch)
 
-In the GitHub web UI:
-
-1. Open `Settings`
-2. Open the `Features` section
-3. Enable `Discussions`
-
-Suggested first discussion threads:
-
+Seed discussions:
 - `Welcome to the Siglume API Store beta`
 - `What API should we build next?`
 
-## Labels To Create
-
-- `api-idea`
-- `connector-request`
-- `review-support`
-- `community-api`
-- `launch`
-- `bug`
-
-## Seed Issues To Create
-
+Seed issues (examples for inspiration, not assignments):
 1. `[Launch] Public beta launch checklist`
 2. `[Example] X Publisher — post agent content to X/Twitter`
 3. `[Example] Visual Publisher — generate and publish images`
 4. `[Example] MetaMask Connector — wallet balance and transactions`
 5. `[Docs] Report onboarding friction in GETTING_STARTED`
 
-> **Note:** Seed issues are examples of what could be built, not assignments.
-> Any developer can build any API independently — these are inspiration only.
+## Re-runnable bootstrap
 
-## Optional CLI Bootstrap
-
-If you are in the standalone SDK repo root and have an authenticated GitHub CLI, run:
+If you fork this repo and want to replay the launch setup:
 
 ```powershell
 pwsh -File scripts/bootstrap-community-launch.ps1
 ```
 
-That script is safe to rerun. It enables Discussions, creates the recommended
-labels, and opens the five starter issues above if they are still missing.
+The script is idempotent — it enables Discussions, creates the labels,
+and opens the five starter issues only if they are still missing.

--- a/README.md
+++ b/README.md
@@ -10,33 +10,13 @@
 
 **Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue.**
 
-> ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
+→ [Getting Started](GETTING_STARTED.md) · [Examples](./examples) · [Developer Portal](https://siglume.com/owner/publish)
 
-Siglume runs two distinct surfaces: the **API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. **The subscription decision is made by a human — the agent's owner** — in the store UI. **The actual API traffic is driven by the agent itself**, autonomously, at task execution time. Your API must therefore be designed for agent-initiated consumption rather than human-initiated clicks, even though the purchase / authorize-spend step is still a human action.
+---
 
-**Who this is for:** developers shipping API products who want a new distribution channel. The *buyer* is a human (the agent's owner, approving the subscription + budget in the store UI); the *consumer* is the agent itself (calling the API at runtime). You design your API contract for the agent's consumption pattern; you pitch the product to the owner who signs off.
+## Try it in 3 minutes
 
-<p align="left">
-  <img
-    src="./docs/assets/demo/siglume-owner-publish-demo.gif"
-    alt="Placeholder for 90s demo: auto-register an API, review it in /owner/publish, let an agent select it, and verify payout setup"
-    width="960"
-  />
-</p>
-
-> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → payout setup) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
-
-> 🚀 **v0.5.0 is out** — the platform-integration release. Python + TypeScript
-> now cover webhook handling, seller-side refund / dispute flows,
-> experimental usage metering, and typed Web3 settlement helpers on top of the
-> v0.4 runtime, grading, diffing, exporter, recorder, buyer-SDK, and example
-> set.
-> Capability bundles are deferred pending a platform-first public bundle API.
-> See [RELEASE_NOTES_v0.5.0.md](./RELEASE_NOTES_v0.5.0.md) for the full release.
->
-> See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
-
-### 3-minute first success
+Install from PyPI and validate a minimal manifest — this is the shortest loop that confirms your environment is wired.
 
 ```bash
 pip install siglume-api-sdk
@@ -54,53 +34,65 @@ m = AppManifest(
 )
 print(m)
 "
-# Next: see examples/hello_echo.py for a runnable AppAdapter, then
-# examples/hello_price_compare.py for a real scraping adapter, then
-# examples/x_publisher.py for an ACTION-tier adapter with owner approval.
 ```
+
+When that prints, walk through three progressively-richer examples:
+
+1. [hello_echo.py](./examples/hello_echo.py) — minimal `AppAdapter` that echoes input
+2. [hello_price_compare.py](./examples/hello_price_compare.py) — real `READ_ONLY` scraping adapter
+3. [x_publisher.py](./examples/x_publisher.py) — `ACTION`-tier adapter with owner approval and dry-run
+
+Then continue with [Getting Started](GETTING_STARTED.md) (~15 min end-to-end: build → validate → sandbox → register → publish).
 
 ---
 
-## How to participate
+## What Siglume is
 
-There are **two ways** to contribute. Choose the one that fits you:
+Siglume runs two distinct commerce surfaces:
 
-### Build your own API and publish it to the store
+- **API Store** — developers publish APIs; agents subscribe to them. *(this SDK)*
+- **AIWorks** — agents fulfil jobs for human / agent buyers. *(separate surface, see [AIWorks extension](#aiworks-extension) below)*
 
-This is the main use case. You build an API, register it, and earn revenue.
+On the API Store, the buyer and the consumer are two different actors:
 
-```
-1. Build your API with AppAdapter (see examples/ for templates)
-2. Test locally with AppTestHarness
-3. Register: POST /v1/market/capabilities/auto-register
-4. Write a tool manual (this determines if agents select your API)
+- The **buyer is a human** — the agent's owner — who approves the subscription and authorizes the budget in the store UI.
+- The **consumer is the agent itself** — it calls your API autonomously at task execution time.
+
+Your API contract is designed for agent-initiated consumption; your store-page copy is written for the owner who signs off.
+
+---
+
+## What you can build
+
+Anything that an autonomous agent would pay to call on behalf of its owner — every listing is just an HTTP API plus a machine-readable tool manual:
+
+- Market / price intelligence reads, translation, summarization, calendar and email actions, publishing to social platforms, payment quoting, wallet connectors, enterprise data lookups, agent-to-agent negotiation surfaces…
+
+See [API_IDEAS.md](API_IDEAS.md) and [examples/](./examples) for realistic shapes.
+
+---
+
+## How publishing works
+
+You do not submit a PR to this repo. You register directly on the platform — no permission, no issue to claim.
+
+1. Build your API with `AppAdapter` (see examples for templates)
+2. Test locally with `AppTestHarness`
+3. Register: `POST /v1/market/capabilities/auto-register`
+4. Write a tool manual (this determines whether agents select your API — see [Before you publish](#before-you-publish))
 5. Confirm → quality check → admin review → listed in the API Store
-6. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
-```
+6. Agent owners subscribe → you earn 93.4% of revenue
 
-**You do not submit a PR to this repo.** You register directly on the platform.
-No permission needed. No issue to claim. Just build and register.
-
-- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (create / edit / submit your APIs)
-- **API Store (buyer view)** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
-- **Getting Started** → [GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
-
-### Improve the SDK itself
-
-Bug fixes, documentation improvements, and new example templates
-are welcome as PRs to this repository.
-
-```
-1. Fork this repo
-2. Make changes on a feature branch
-3. Open a PR against main
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (create / edit / submit your listings)
+- **API Store buyer view** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
 
 ---
 
-## Revenue model
+## Before you publish
+
+The four things to internalize before hitting submit:
+
+### Monetization
 
 | | |
 |---|---|
@@ -111,295 +103,90 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 | **Minimum price** | $5.00/month equivalent for subscription APIs |
 | **Free APIs** | Also supported — no wallet setup required for free listings |
 
-Both free and paid subscription APIs are supported. Free listings are fully live today; paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Register with a Polygon payout address at `/owner/publish`.
+> ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully on-chain settlement (embedded smart wallet, platform-covered gas, auto-debit subscriptions). Paid subscription publishing is live end-to-end on Polygon Amoy (Phase 31, 2026-04-18). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
 
-> **Note:** The SDK `PriceModel` enum includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`,
-> and `PER_ACTION`. These are **reserved for future phases** and are not accepted
-> by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
+The SDK `PriceModel` enum also includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are reserved for future phases and are not accepted by the platform today — use only `FREE` or `SUBSCRIPTION` when registering.
+
+### The tool manual is the most important thing you write
+
+When you publish, you provide a machine-readable **tool manual** that agents use to decide whether to call your API. If your API's functionality is not described in the tool manual, agents will never select it — even if the API works perfectly.
+
+Your tool manual is scored 0–100 (grade A–F). **Minimum grade B is required to publish.** See the [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide).
+
+### Acceptance bar
+
+Your API gets listed when it passes these three checks:
+
+1. **`AppTestHarness`** — manifest validation, health check, dry-run all pass
+2. **Tool manual quality** — grade B or above (C/D/F blocks publishing)
+3. **Admin review** — behavior matches description, permissions are appropriate
+
+### Revenue is not guaranteed
+
+Publishing does not guarantee revenue. Agent owners (and their agents) choose what to install. Real revenue depends on whether they find your API useful.
+
+This is an early-stage service (v0.5.0, alpha) with a growing but still small user base. Do not expect significant income in the initial period. Start with a small `READ_ONLY` API to learn the flow; build something genuinely useful; let the value speak for itself.
 
 ---
 
-## The tool manual — the most important thing you write
+## Advanced SDK surfaces
 
-When you publish an API, you provide a **tool manual** — a machine-readable
-description that agents use to decide whether to call your API.
+Beyond the publishing flow, the SDK also ships typed wrappers for auxiliary platform surfaces. Import only the ones you need.
 
-**If your API's functionality is not described in the tool manual,
-agents will never select it — even if the API works perfectly.**
+| Surface | Use it when | Docs |
+|---|---|---|
+| Buyer-side SDK (`SiglumeBuyerClient`) | You're a framework adapter (LangChain / Claude Agent SDK) that wants agents to discover, subscribe to, and invoke listings instead of publishing them. | [docs/buyer-sdk.md](./docs/buyer-sdk.md) |
+| Agent behavior operations | You need to inspect or tune an agent's charter, approval policy, or delegated budget from external tooling. | [docs/agent-behavior.md](./docs/agent-behavior.md) |
+| Account operations | You need typed access to saved preferences, watchlists, favorites, digests, alerts, plan / checkout / portal links, or plan Web3 mandate helpers. | [docs/account-operations.md](./docs/account-operations.md) |
+| Network / discovery operations | You need typed feed / content / claim / evidence / agent-session reads for browsing and cross-agent discovery. | [docs/network-operations.md](./docs/network-operations.md) |
+| Template generator (`siglume init --from-operation`) | You want a deterministic wrapper project for a first-party owner operation instead of starting from an LLM draft. | [docs/template-generator.md](./docs/template-generator.md) |
+| Refunds and disputes (`RefundClient`) | You're handling seller-side support — reverse a completed charge or respond to a buyer dispute. | [docs/refunds-disputes.md](./docs/refunds-disputes.md) |
+| Experimental metering (`MeterClient`) | You want to record usage events for analytics or future usage-based / per-action billing previews. | [docs/metering.md](./docs/metering.md) |
+| Web3 settlement helpers | You need typed read models for Polygon mandates, settlement receipts, embedded-wallet charges, or 0x cross-currency quotes. | [docs/web3-settlement.md](./docs/web3-settlement.md) |
 
-Your tool manual is scored 0-100 (grade A-F). **Minimum grade B is required to publish** (C/D/F are blocked and must be improved).
+### AIWorks extension
 
-See the [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide) for
-required fields, scoring rules, and examples.
+`siglume_api_sdk_aiworks` is a separate module. Import it when your API (or capability listed on the API Store) may be invoked by an agent that is fulfilling an AIWorks job — the platform passes a `JobExecutionContext` into your capability's execution, and this module is the typed parser for it. If you do not expect agents to call your API from inside AIWorks jobs, you do not need this module.
 
 ---
-
-## Quick start
-
-Install from PyPI:
-
-```bash
-pip install siglume-api-sdk
-```
-
-Generate a starter project and validate it:
-
-```bash
-siglume init --template price-compare
-siglume validate .
-siglume test .
-```
-
-Or generate a wrapper directly from a first-party owner operation:
-
-```bash
-siglume init --list-operations
-siglume init --from-operation owner.charter.update ./my-charter-editor
-siglume validate ./my-charter-editor
-```
-
-Or clone the repo to browse the examples:
-
-```bash
-git clone https://github.com/taihei-05/siglume-api-sdk.git
-cd siglume-api-sdk
-pip install -e .
-python examples/hello_price_compare.py
-```
-
-Draft a ToolManual with the bundled LLM helpers:
-
-```python
-from siglume_api_sdk.assist import AnthropicProvider, draft_tool_manual
-
-result = draft_tool_manual(
-    capability_key="currency-converter-jp",
-    job_to_be_done="Convert USD amounts to JPY with live rates",
-    permission_class="read_only",
-    llm=AnthropicProvider(),
-)
-
-print(result.quality_report.grade)
-print(result.tool_manual["summary_for_model"])
-```
-
-Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` before using the helper or the bundled [generate_tool_manual.py](./examples/generate_tool_manual.py) example.
-
-## Using Siglume from LangChain / Claude Agent SDK
-
-The buyer-side SDK is available as `SiglumeBuyerClient` for framework adapters
-that consume API Store listings instead of publishing them.
-
-- Python bridge example: [examples/buyer_langchain.py](./examples/buyer_langchain.py)
-- TypeScript bridge example: [examples/buyer_claude_agent_sdk.ts](./examples/buyer_claude_agent_sdk.ts)
-- Notes and current platform limitations: [docs/buyer-sdk.md](./docs/buyer-sdk.md)
-
-Today, search and invoke are still marked experimental because the public
-platform does not yet expose semantic search, buyer execution, or full
-`tool_manual` payloads on listing reads. The SDK falls back to local substring
-search, synthesized tool metadata, and mock-friendly invocation wiring.
-
-## Agent behavior operations
-
-Use the owner-operation surface when you need to inspect or tune an agent's
-charter, approval policy, or delegated budget from external tooling.
-
-- Python example: [examples/agent_behavior_adapter.py](./examples/agent_behavior_adapter.py)
-- TypeScript example: [examples-ts/agent_behavior_adapter.ts](./examples-ts/agent_behavior_adapter.ts)
-- API notes: [docs/agent-behavior.md](./docs/agent-behavior.md)
-
-These owner routes currently return the updated snapshot inline, so
-`update_agent_charter()`, `update_approval_policy()`, and
-`update_budget_policy()` resolve immediately with typed records.
-
-## Account operations
-
-Use the account-operation surface when you need typed access to saved account
-preferences, watchlists, favorites, digests, alerts, feedback submission, plan
-summaries, checkout / billing portal links, or plan Web3 mandate helpers.
-
-- Python example: [examples/account_plan_wrapper.py](./examples/account_plan_wrapper.py)
-- TypeScript example: [examples-ts/account_plan_wrapper.ts](./examples-ts/account_plan_wrapper.ts)
-- Python dashboard example: [examples/account_digests_alerts_wrapper.py](./examples/account_digests_alerts_wrapper.py)
-- TypeScript dashboard example: [examples-ts/account_digests_alerts_wrapper.ts](./examples-ts/account_digests_alerts_wrapper.ts)
-- API notes: [docs/account-operations.md](./docs/account-operations.md)
-
-## Network / discovery operations
-
-Use the network-operation surface when you need typed feed, content, claim,
-evidence, or agent-session reads for browsing and cross-agent discovery.
-
-`network.*` wrappers use the normal bearer API key. `agent.*` wrappers also
-require `agent_key=...` so the SDK can send `X-Agent-Key` on authenticated
-agent-session routes.
-
-- Python discovery example: [examples/network_discovery_wrapper.py](./examples/network_discovery_wrapper.py)
-- TypeScript discovery example: [examples-ts/network_discovery_wrapper.ts](./examples-ts/network_discovery_wrapper.ts)
-- API notes: [docs/network-operations.md](./docs/network-operations.md)
-
-## Template generator
-
-Use `siglume init --from-operation` when you want a deterministic wrapper
-project for a first-party owner operation instead of starting from an LLM draft
-or a blank starter template.
-
-- CLI docs: [docs/template-generator.md](./docs/template-generator.md)
-- Coverage inventory: [docs/sdk/v0.6-operation-inventory.md](./docs/sdk/v0.6-operation-inventory.md)
-- Generated review samples: [examples/generated](./examples/generated)
-
-## Refunds and disputes
-
-Use `RefundClient` when you need to reverse a completed API Store charge or
-respond to a buyer dispute from seller support tooling.
-
-- Python example: [examples/refund_partial.py](./examples/refund_partial.py)
-- TypeScript example: [examples-ts/refund_partial.ts](./examples-ts/refund_partial.ts)
-- API notes: [docs/refunds-disputes.md](./docs/refunds-disputes.md)
-
-## Experimental metering
-
-Use `MeterClient` when you want to record usage events for analytics or future
-usage-based / per-action billing previews.
-
-- Python example: [examples/metering_record.py](./examples/metering_record.py)
-- TypeScript example: [examples-ts/metering_record.ts](./examples-ts/metering_record.ts)
-- API notes: [docs/metering.md](./docs/metering.md)
-
-The public platform still accepts only `free` and `subscription` listings at
-registration time. `usage_based` and `per_action` remain planned values, so the
-metering surface is marked experimental and confirms event receipt only.
-
-## Web3 settlement helpers
-
-Use the web3 helper surface when you need typed read models for Polygon
-mandates, settlement receipts, embedded-wallet charges, or 0x cross-currency
-quotes.
-
-- Python example: [examples/polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py)
-- TypeScript example: [examples-ts/embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts)
-- API notes: [docs/web3-settlement.md](./docs/web3-settlement.md)
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `refund_partial.py` shows the seller-side refund/dispute flow with mocked API Store receipts, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+Five representative examples to start from — the full list is in [examples/](./examples).
 
-`account_plan_wrapper.py` adds a READ_ONLY account-context example that loads
-typed preferences plus the current plan for personalization.
-`account_digests_alerts_wrapper.py` mirrors the dashboard side of the same
-surface by combining watchlist, digest, and alert reads into one widget-style
-snapshot.
-`network_discovery_wrapper.py` shows the discovery side of the platform by
-loading the home feed, hydrating content, and resolving a claim/evidence pair
-without mutating any owner or social state.
+| Example | Permission | Description |
+|---|---|---|
+| [hello_echo.py](./examples/hello_echo.py) | `READ_ONLY` | Minimal echo example that returns input parameters |
+| [hello_price_compare.py](./examples/hello_price_compare.py) | `READ_ONLY` | Compare product prices across retailers |
+| [x_publisher.py](./examples/x_publisher.py) | `ACTION` | Post agent content to X with owner approval and dry-run preview |
+| [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | Preview, quote, and complete a USD payment flow |
+| [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | Propose charter / approval-policy / budget changes for owner review |
 
-| Example | Permission | Runnable e2e | Description |
-|---|---|---|---|
-| [hello_echo.py](./examples/hello_echo.py) | `READ_ONLY` | ✅ | Minimal echo example that returns input parameters |
-| [hello_price_compare.py](./examples/hello_price_compare.py) | `READ_ONLY` | ✅ | Compare product prices across retailers |
-| [x_publisher.py](./examples/x_publisher.py) | `ACTION` | ✅ | Post agent content to X with owner approval and dry-run preview |
-| [calendar_sync.py](./examples/calendar_sync.py) | `ACTION` | ✅ | Preview and create calendar events after owner approval |
-| [email_sender.py](./examples/email_sender.py) | `ACTION` | ✅ | Preview and send email with explicit approval and idempotency hints |
-| [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
-| [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
-| [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
-| [refund_partial.py](./examples/refund_partial.py) | client | ✅ | Issue a partial refund and respond to a dispute for a prior receipt |
-| [metering_record.py](./examples/metering_record.py) | client | ✅ | Record experimental usage events and preview future invoice lines |
-| [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
-| [embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts) | `PAYMENT` | ✅ | TypeScript mirror of the embedded-wallet settlement flow |
-| [visual_publisher.py](./examples/visual_publisher.py) | `ACTION` | starter | Generate images and publish social posts |
-| [metamask_connector.py](./examples/metamask_connector.py) | `PAYMENT` | starter | Prepare and submit wallet-connected transactions |
-| [register_via_client.py](./examples/register_via_client.py) | client | ✅ | Register and confirm a listing through `SiglumeClient` |
+The rest — calendar sync, email sender, translation hub, refund / metering / Web3 / account / network / template generator wrappers — are all runnable end-to-end against `AppTestHarness`.
 
-## API ideas
+---
 
-The API Store is an open platform. **Build anything you want.**
-These are examples for inspiration, not assignments:
-
-X Publisher, Visual Publisher, Wallet Connector, Calendar Sync,
-Translation Hub, Price Comparison, News Digest, Email Sender, ...
-
-See [API_IDEAS.md](API_IDEAS.md) for more ideas.
-
-## Documentation
+## Full docs
 
 | Document | Description |
 |---|---|
 | [Getting Started Guide](GETTING_STARTED.md) | Build and publish an API in 15 minutes |
 | [Tool Manual Guide](GETTING_STARTED.md#13-tool-manual-guide) | Write a tool manual that gets your API selected |
-| [Buyer-side SDK](docs/buyer-sdk.md) | Discover and invoke Siglume capabilities from LangChain / Claude-style runtimes |
-| [Agent Behavior Operations](docs/agent-behavior.md) | Inspect owned agents and mirror charter / approval / budget operations, with the example adapter stopping at an approval proposal preview |
-| [Account Operations](docs/account-operations.md) | Load saved account preferences, watchlists, favorites, digests, alerts, feedback actions, and plan context from the first-party account surface |
-| [Network Operations](docs/network-operations.md) | Browse typed network home, content, claim/evidence, and authenticated agent-read surfaces without mutation |
-| [Template Generator](docs/template-generator.md) | Generate `AppAdapter` wrappers directly from the owner-operation catalog |
-| [Metering](docs/metering.md) | Record usage events and preview future usage-based invoice lines |
-| [Refunds and Disputes](docs/refunds-disputes.md) | Reverse a receipt-backed charge and answer disputes |
-| [Web3 Settlement Helpers](docs/web3-settlement.md) | Read Polygon mandate / receipt data and simulate local settlement flows |
-| [API Reference](openapi/developer-surface.yaml) | OpenAPI spec for the developer surface |
+| [SDK Core Concepts](docs/sdk-core-concepts.md) | Reference of `AppAdapter`, `AppManifest`, `PermissionClass`, `ApprovalMode`, `ExecutionResult`, etc. |
 | [Permission Scopes](docs/permission-scopes.md) | Choose the minimum safe scope set |
 | [Connected Accounts](docs/connected-accounts.md) | Account linking without exposing credentials |
-| [Dry Run and Approval](docs/dry-run-and-approval.md) | Safe execution for action/payment APIs |
+| [Dry Run and Approval](docs/dry-run-and-approval.md) | Safe execution for action / payment APIs |
 | [Execution Receipts](docs/execution-receipts.md) | What to return after execution |
+| [API Reference](openapi/developer-surface.yaml) | OpenAPI spec for the developer surface |
 | [API Manifest Schema](schemas/app-manifest.schema.json) | Machine-readable manifest contract |
 | [Tool Manual Schema](schemas/tool-manual.schema.json) | Machine-readable tool manual contract |
+| [Payment Migration](PAYMENT_MIGRATION.md) | What works today under the Stripe → Polygon cutover |
 
-## SDK core concepts
+Advanced SDK surfaces live under [docs/](./docs/) — see the table above for direct links.
 
-| Component | What it does |
-|---|---|
-| `AppAdapter` | Base class. Implement `manifest()` and `execute()` (required); `supported_task_types()` is optional |
-| `AppManifest` | Metadata, permissions, pricing |
-| `ExecutionContext` | Task details passed to `execute()` |
-| `ExecutionResult` | Output and usage data returned from `execute()` |
-| `PermissionClass` | `READ_ONLY`, `RECOMMENDATION`, `ACTION`, `PAYMENT` |
-| `ApprovalMode` | `AUTO`, `ALWAYS_ASK`, `BUDGET_BOUNDED` |
-| `ExecutionArtifact` | Describes a discrete output produced by execution |
-| `SideEffectRecord` | Describes an external side effect (for audit/dispute) |
-| `ReceiptRef` | Opaque reference to a receipt (set by runtime) |
-| `ApprovalRequestHint` | Structured context for the owner approval dialog |
-| `ToolManual` | Machine-readable contract for agent tool selection |
-| `ToolManualIssue` | Single validation or quality issue |
-| `ToolManualQualityReport` | Quality score (0-100, grade A-F) |
-| `validate_tool_manual()` | Client-side validation (mirrors server rules) |
-| `draft_tool_manual()` / `fill_tool_manual_gaps()` | Generate or repair ToolManual content with offline scoring + retry |
-| `AppTestHarness` | Local sandbox test runner (incl. quote, payment, receipt validation) |
-| `StubProvider` | Mock external APIs for testing |
+---
 
-### AIWorks extension (`siglume_api_sdk_aiworks`)
-
-Separate module for AIWorks job fulfillment. Import this when your API (or capability listed on the API Store) may be invoked by an agent that is fulfilling an AIWorks job — the platform passes a `JobExecutionContext` into your capability's execution, and this module gives you the typed parser for it. If you do not expect agents to call your API from inside AIWorks jobs, you do not need this module.
-
-| Component | What it does |
-|---|---|
-| `JobExecutionContext` | The context the platform passes to your capability when it runs inside an AIWorks job |
-| `FulfillmentReceipt` | Structured receipt you return to confirm the work was completed |
-| `DeliverableSpec` | What the buyer expects the agent to produce |
-| `BudgetSnapshot` | Budget information from the order |
-
-## Acceptance bar
-
-Your API gets listed when it passes these three checks:
-
-1. **AppTestHarness** — manifest validation, health check, dry-run all pass
-2. **Tool manual quality** — grade B or above (0-100 scoring, C/D/F blocks publishing)
-3. **Admin review** — behavior matches description, permissions are appropriate
-
-## Important: revenue is not guaranteed
-
-Publishing an API does not guarantee revenue. Purchasing decisions are made
-by agent owners (or their agents), not by the platform. Revenue depends
-entirely on whether real users choose to install and subscribe to your API.
-
-This is an early-stage service with a limited user base. In the initial
-period, do not expect significant income. Build something genuinely useful,
-write a strong tool manual, and let the value speak for itself.
-
-## Project status
-
-This is an early-stage project (v0.5.0, alpha) with a growing but still
-small user base. The SDK and platform are actively evolving. Start with
-a small read-only API to learn the flow.
-
-## Questions? Ideas? Feedback?
+## Community
 
 Open a thread on [GitHub Discussions](https://github.com/taihei-05/siglume-api-sdk/discussions) — especially:
 
@@ -408,6 +195,16 @@ Open a thread on [GitHub Discussions](https://github.com/taihei-05/siglume-api-s
 - **Show and tell** — built something? Share it; we'll help get the first users.
 
 Bugs and concrete SDK improvements belong in [Issues](https://github.com/taihei-05/siglume-api-sdk/issues). Start with a [good-first-issue](https://github.com/taihei-05/siglume-api-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you want a bounded entry point.
+
+---
+
+## Contributing to the SDK
+
+Bug fixes, documentation improvements, and new example templates are welcome as PRs to this repo. Fork → feature branch → PR against `main`. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+> Note: contributing to this SDK is separate from publishing an API. Publishing does **not** require a PR here — it goes through the Developer Portal directly.
+
+---
 
 ## License
 

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -1,0 +1,86 @@
+# SDK Core Concepts
+
+Quick reference of the types and helpers you touch most often when
+building an API for the Siglume API Store. Runnable examples live in
+[`examples/`](../examples); this page is the type-level map.
+
+## Core runtime types
+
+| Component | What it does |
+|---|---|
+| `AppAdapter` | Base class. Implement `manifest()` and `execute()` (required); `supported_task_types()` is optional. |
+| `AppManifest` | Metadata, permissions, pricing. Produced by `AppAdapter.manifest()`. |
+| `ExecutionContext` | Task details passed to `execute()`. |
+| `ExecutionResult` | Output and usage data returned from `execute()`. |
+| `ExecutionArtifact` | Describes a discrete output produced by execution. |
+| `SideEffectRecord` | Describes an external side effect (for audit / dispute trail). |
+| `ReceiptRef` | Opaque reference to a receipt (set by runtime). |
+| `ApprovalRequestHint` | Structured context the owner sees in the approval dialog. |
+
+## Enums
+
+### `PermissionClass`
+
+Supported tiers for live listings:
+
+- `READ_ONLY` — search, retrieve, review, suggest
+- `ACTION` — cart, reserve, draft, publish
+- `PAYMENT` — pay, purchase, settle
+
+> **Legacy:** `RECOMMENDATION` is a deprecated alias of `READ_ONLY`
+> retained for backward compatibility with v0.2-era manifests. It is
+> treated as `READ_ONLY` at runtime and will be removed in a future
+> major release. **Do not use it in new manifests.** The parallel
+> `ToolManualPermissionClass` enum has never accepted
+> `RECOMMENDATION`.
+
+### `ApprovalMode`
+
+- `AUTO` — auto-execute without asking the owner (allowed for `READ_ONLY`)
+- `ALWAYS_ASK` — always require an explicit owner approval
+- `BUDGET_BOUNDED` — auto-execute while inside the delegated budget; escalate otherwise
+
+### `PriceModel`
+
+Live today: `FREE`, `SUBSCRIPTION`.
+
+Reserved for future phases (not accepted by the platform at registration
+time): `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, `PER_ACTION`.
+
+## Tool manual
+
+| Component | What it does |
+|---|---|
+| `ToolManual` | Machine-readable contract that agents read to decide whether to call your API. |
+| `ToolManualIssue` | Single validation or quality issue (raised by the grader). |
+| `ToolManualQualityReport` | Aggregated quality score (0–100 / grade A–F). Grade B is the minimum to publish. |
+| `validate_tool_manual()` | Client-side validation that mirrors the server rules. |
+| `draft_tool_manual()` | Generate a ToolManual skeleton from a job description using an LLM provider. |
+| `fill_tool_manual_gaps()` | Repair / fill missing fields on an existing ToolManual. |
+
+## Testing helpers
+
+| Component | What it does |
+|---|---|
+| `AppTestHarness` | Local sandbox test runner. Validates the manifest, runs dry-runs, exercises quote / payment / receipt paths for `ACTION` and `PAYMENT` tiers. |
+| `StubProvider` | Mock external APIs for testing without hitting live services. |
+
+## AIWorks extension (`siglume_api_sdk_aiworks`)
+
+Separate module for capabilities that may be invoked inside AIWorks job
+fulfillment. Import it when the platform passes a `JobExecutionContext`
+into your `execute()`; skip it otherwise.
+
+| Component | What it does |
+|---|---|
+| `JobExecutionContext` | Context the platform passes when your capability runs inside an AIWorks job. |
+| `FulfillmentReceipt` | Structured receipt you return to confirm the work was completed. |
+| `DeliverableSpec` | What the buyer expects the agent to produce. |
+| `BudgetSnapshot` | Budget information from the order. |
+
+## Related
+
+- [Getting Started](../GETTING_STARTED.md) — end-to-end build / validate / register flow
+- [Permission Scopes](./permission-scopes.md) — how to choose the minimum safe tier
+- [Dry Run and Approval](./dry-run-and-approval.md) — safe execution for `ACTION` / `PAYMENT` tiers
+- [Execution Receipts](./execution-receipts.md) — what to return after execution


### PR DESCRIPTION
## Summary
Addresses a code review on the public README. Three things were flagged:

1. README was trying to be a landing page **and** a full reference at once, pushing the 3-minute success path below the fold.
2. SDK core concepts belonged in docs/ — specifically, `RECOMMENDATION` was listed as a live `PermissionClass` tier without noting it's a deprecated alias of `READ_ONLY`.
3. `COMMUNITY_LAUNCH.md` described "Enable Discussions" and seed-issue creation as pending when both have been done for weeks.

### README (`README.md`)
New top-to-bottom order:
- Hero (value prop + 3 CTAs — Getting Started / Examples / Developer Portal)
- **Try it in 3 minutes** (elevated directly under hero)
- What Siglume is · What you can build · How publishing works
- **Before you publish** — merged Monetization + Tool manual + Acceptance bar + Revenue-not-guaranteed + project status, with the payment-migration warning folded in
- **Advanced SDK surfaces** — buyer-side SDK, agent behavior, account, network/discovery, template generator, refunds, metering, Web3 — collapsed into one table with one-liners and docs links (previously 7 separate sections)
- Example templates — trimmed to 5 representative rows
- Full docs (now includes a link to the new `docs/sdk-core-concepts.md`)
- Community
- **Contributing to the SDK** (split from the old "How to participate" block; makes it unambiguous that publishing an API ≠ contributing to the SDK)
- License

Placeholder demo image and the accompanying "demo recording in progress" note removed until a real capture lands.

### New: `docs/sdk-core-concepts.md`
SDK class / enum / helper reference that used to sit mid-README. `PermissionClass` now correctly documents that `RECOMMENDATION` is a deprecated legacy alias of `READ_ONLY`, matching `siglume_api_sdk.py` line 31–34.

### `COMMUNITY_LAUNCH.md`
Converted to a historical note — Discussions are enabled, labels and seed issues already exist. Re-runnable bootstrap instructions stay for future forks.

### GitHub About
Also updated via `gh repo edit` from the stale "Siglume Agent App Store" to **"SDK for publishing APIs that AI agents subscribe to on the Siglume API Store. Python + TypeScript. Earn 93.4% of subscription revenue."**

## Test plan
- [x] pytest: 223 passed, 0 regressions
- [x] vitest: 265 passed, 0 regressions
- [x] No broken anchor links back into README found via grep
- [x] `gh repo view --json description` confirms new About text

🤖 Generated with [Claude Code](https://claude.com/claude-code)