### PR TITLE
fix(v0.6): address chatgpt-codex-connector[bot] P1 findings on PR-S2a

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -2881,7 +2881,13 @@ export class SiglumeClient implements SiglumeClientShape {
       return resolvedAgentId;
     }
     const [data] = await this.request("GET", "/me/agent");
-    const agentIdFromMe = stringOrNull(data.agent_id);
+    // `/me/agent` may return the identifier under either `agent_id`
+    // (current contract) or the legacy `id` field. parseAgent already
+    // accepts both; mirror that here so callers that rely on the
+    // omitted-`agent_id` path do not hard-fail against servers still
+    // emitting the legacy shape.
+    const agentIdFromMe =
+      stringOrNull(data.agent_id) ?? stringOrNull(data.id);
     if (agentIdFromMe) {
       return agentIdFromMe;
     }

--- a/siglume-api-sdk-ts/test/pr_s2a_codex_bot_followup.test.ts
+++ b/siglume-api-sdk-ts/test/pr_s2a_codex_bot_followup.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { SiglumeClient, SiglumeClientError } from "../src/index";
+
+function envelope(data: Record<string, unknown>) {
+  return { data, meta: { request_id: "req_test", trace_id: "trc_test" }, error: null };
+}
+
+function urlOf(input: RequestInfo | URL): URL {
+  if (input instanceof Request) return new URL(input.url);
+  if (input instanceof URL) return input;
+  return new URL(String(input));
+}
+
+function buildClient(fetchImpl: typeof globalThis.fetch): SiglumeClient {
+  return new SiglumeClient({
+    api_key: "sig_test_key",
+    base_url: "https://api.example.test/v1",
+    fetch: fetchImpl,
+  });
+}
+
+describe("PR-S2a codex bot follow-up: /me/agent id fallback", () => {
+  it("accepts agent_id field (current shape)", async () => {
+    const paths: string[] = [];
+    const client = buildClient(async (input) => {
+      const url = urlOf(input);
+      paths.push(url.pathname);
+      if (url.pathname === "/v1/me/agent") {
+        return new Response(JSON.stringify(envelope({ agent_id: "agt_current" })), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.pathname === "/v1/owner/agents/agt_current/operations/execute") {
+        return new Response(
+          JSON.stringify(
+            envelope({
+              status: "completed",
+              result: { items: [], next_cursor: null, limit: 20, offset: 0 },
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    const page = await client.list_market_needs();
+    expect(page.items).toEqual([]);
+    expect(paths).toContain("/v1/me/agent");
+    expect(paths).toContain("/v1/owner/agents/agt_current/operations/execute");
+  });
+
+  it("accepts legacy id field (codex-bot P1 case)", async () => {
+    const paths: string[] = [];
+    const client = buildClient(async (input) => {
+      const url = urlOf(input);
+      paths.push(url.pathname);
+      if (url.pathname === "/v1/me/agent") {
+        return new Response(JSON.stringify(envelope({ id: "agt_legacy" })), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.pathname === "/v1/owner/agents/agt_legacy/operations/execute") {
+        return new Response(
+          JSON.stringify(
+            envelope({
+              status: "completed",
+              result: { items: [], next_cursor: null, limit: 20, offset: 0 },
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    const page = await client.list_market_needs();
+    expect(page.items).toEqual([]);
+    expect(paths).toContain("/v1/owner/agents/agt_legacy/operations/execute");
+  });
+
+  it("prefers agent_id over legacy id when both are present", async () => {
+    const paths: string[] = [];
+    const client = buildClient(async (input) => {
+      const url = urlOf(input);
+      paths.push(url.pathname);
+      if (url.pathname === "/v1/me/agent") {
+        return new Response(
+          JSON.stringify(envelope({ agent_id: "agt_new", id: "agt_old" })),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.pathname === "/v1/owner/agents/agt_new/operations/execute") {
+        return new Response(
+          JSON.stringify(
+            envelope({
+              status: "completed",
+              result: { items: [], next_cursor: null, limit: 20, offset: 0 },
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await client.list_market_needs();
+    expect(paths).toContain("/v1/owner/agents/agt_new/operations/execute");
+    expect(paths).not.toContain("/v1/owner/agents/agt_old/operations/execute");
+  });
+
+  it("honors explicit agent_id argument without calling /me/agent", async () => {
+    const client = buildClient(async (input) => {
+      const url = urlOf(input);
+      if (url.pathname === "/v1/me/agent") {
+        throw new Error("must not call /me/agent when agent_id is explicit");
+      }
+      if (url.pathname === "/v1/owner/agents/agt_explicit/operations/execute") {
+        return new Response(
+          JSON.stringify(
+            envelope({
+              status: "completed",
+              result: { items: [], next_cursor: null, limit: 20, offset: 0 },
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await client.list_market_needs({ agent_id: "agt_explicit" });
+  });
+
+  it("raises when /me/agent has neither agent_id nor id", async () => {
+    const client = buildClient(async (input) => {
+      const url = urlOf(input);
+      if (url.pathname === "/v1/me/agent") {
+        return new Response(JSON.stringify(envelope({ something_else: "x" })), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+
+    await expect(client.list_market_needs()).rejects.toThrow(SiglumeClientError);
+  });
+});

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -2513,7 +2513,15 @@ class SiglumeClient:
         if resolved_agent_id:
             return resolved_agent_id
         data, _meta = self._request("GET", "/me/agent")
-        agent_id_from_me = _string_or_none(data.get("agent_id"))
+        # `/me/agent` may return the identifier under either `agent_id`
+        # (current contract) or the legacy `id` field. `_parse_agent`
+        # already accepts both; mirror that here so callers that rely on
+        # the omitted-`agent_id` path do not hard-fail against servers
+        # still emitting the legacy shape.
+        agent_id_from_me = (
+            _string_or_none(data.get("agent_id"))
+            or _string_or_none(data.get("id"))
+        )
         if agent_id_from_me:
             return agent_id_from_me
         raise SiglumeClientError("agent_id is required.")

--- a/tests/test_pr_s2a_codex_bot_followup.py
+++ b/tests/test_pr_s2a_codex_bot_followup.py
@@ -1,0 +1,146 @@
+"""Regression tests for chatgpt-codex-connector[bot] findings on
+PR-S2a (siglume-api-sdk#136).
+
+Pin: `SiglumeClient._resolve_owner_operation_agent_id` must accept
+both the current `agent_id` field and the legacy `id` field from
+`GET /me/agent`. `_parse_agent` already supports both; the resolver
+added in PR-S2a silently dropped the `id` fallback, which broke
+`list_market_needs` / `get_market_need` / `create_market_need` /
+`update_market_need` against servers still emitting the legacy shape
+whenever the caller omitted `agent_id`.
+"""
+from __future__ import annotations
+
+import httpx
+
+from siglume_api_sdk.client import SiglumeClient
+
+
+def envelope(data):
+    return {"data": data, "meta": {"request_id": "req_test", "trace_id": "trc_test"}}
+
+
+def build_client(handler) -> SiglumeClient:
+    return SiglumeClient(
+        api_key="sig_test_key",
+        base_url="https://api.example.test/v1",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _mock_handler_for_market_needs(
+    *, me_agent_payload: dict, expected_agent_id: str
+):
+    """Return an httpx handler that serves `/me/agent` with the given
+    payload and a minimal `list_market_needs` response on
+    `/owner/agents/{expected}/operations/execute`."""
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/v1/me/agent" and request.method == "GET":
+            return httpx.Response(200, json=envelope(me_agent_payload))
+        if (
+            request.url.path
+            == f"/v1/owner/agents/{expected_agent_id}/operations/execute"
+            and request.method == "POST"
+        ):
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "status": "completed",
+                        "result": {
+                            "items": [],
+                            "next_cursor": None,
+                            "limit": 20,
+                            "offset": 0,
+                        },
+                    }
+                ),
+            )
+        raise AssertionError(
+            f"unexpected request: {request.method} {request.url.path}"
+        )
+
+    return handler, seen_paths
+
+
+def test_resolver_accepts_agent_id_field() -> None:
+    """Current shape: /me/agent returns {"agent_id": "..."}."""
+    handler, paths = _mock_handler_for_market_needs(
+        me_agent_payload={"agent_id": "agt_current"},
+        expected_agent_id="agt_current",
+    )
+    with build_client(handler) as client:
+        page = client.list_market_needs()  # no agent_id → resolve via /me/agent
+
+    assert page.items == []
+    assert "/v1/me/agent" in paths
+    assert "/v1/owner/agents/agt_current/operations/execute" in paths
+
+
+def test_resolver_accepts_legacy_id_field() -> None:
+    """Legacy shape: /me/agent returns {"id": "..."} without agent_id.
+    This is the codex-bot P1 case — before the fix, the resolver raised
+    "agent_id is required." even though the server returned a valid id.
+    """
+    handler, paths = _mock_handler_for_market_needs(
+        me_agent_payload={"id": "agt_legacy"},
+        expected_agent_id="agt_legacy",
+    )
+    with build_client(handler) as client:
+        page = client.list_market_needs()
+
+    assert page.items == []
+    assert "/v1/owner/agents/agt_legacy/operations/execute" in paths
+
+
+def test_resolver_prefers_agent_id_over_legacy_id_when_both_present() -> None:
+    """If /me/agent returns both keys, the current-contract one wins."""
+    handler, paths = _mock_handler_for_market_needs(
+        me_agent_payload={"agent_id": "agt_new", "id": "agt_old"},
+        expected_agent_id="agt_new",
+    )
+    with build_client(handler) as client:
+        client.list_market_needs()
+
+    assert "/v1/owner/agents/agt_new/operations/execute" in paths
+    assert "/v1/owner/agents/agt_old/operations/execute" not in paths
+
+
+def test_resolver_honors_explicit_agent_id_arg() -> None:
+    """If the caller passes agent_id, /me/agent must NOT be called."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/me/agent":
+            raise AssertionError("/me/agent must not be called when agent_id is explicit")
+        if request.url.path == "/v1/owner/agents/agt_explicit/operations/execute":
+            return httpx.Response(
+                200,
+                json=envelope(
+                    {
+                        "status": "completed",
+                        "result": {"items": [], "next_cursor": None, "limit": 20, "offset": 0},
+                    }
+                ),
+            )
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with build_client(handler) as client:
+        client.list_market_needs(agent_id="agt_explicit")
+
+
+def test_resolver_raises_when_me_agent_has_neither_field() -> None:
+    import pytest
+
+    from siglume_api_sdk.client import SiglumeClientError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/me/agent":
+            return httpx.Response(200, json=envelope({"something_else": "x"}))
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    with build_client(handler) as client:
+        with pytest.raises(SiglumeClientError, match="agent_id"):
+            client.list_market_needs()


### PR DESCRIPTION
## Summary
Two P1 findings (same bug, Python + TS parity) on PR-S2a (#136).

### Issue
`_resolve_owner_operation_agent_id` only read `data.agent_id` from `GET /me/agent`. `_parse_agent` / `parseAgent` already accept both `agent_id` (current contract) and `id` (legacy). Against servers emitting the legacy shape, any `market.needs.*` call that omitted `agent_id` hard-failed with `"agent_id is required."` even though a valid id was in the response.

### Fix
Both resolvers now fall back to `data.id` when `data.agent_id` is absent. `agent_id` is preferred when both are present so current-contract servers keep working unchanged.

### Regression coverage
- `tests/test_pr_s2a_codex_bot_followup.py` (5 Python cases)
- `siglume-api-sdk-ts/test/pr_s2a_codex_bot_followup.test.ts` (5 TS cases)

Both cover: accepts agent_id, accepts legacy id, prefers agent_id when both present, honors explicit agent_id without calling /me/agent, raises on neither.

## Verification
- pytest: **228 → 233 passed** (+5)
- vitest: **271 → 276 passed** (+5)
- ruff / contract-sync / typecheck / lint / build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)