### PR TITLE
fix(v0.6): address 3 chatgpt-codex-connector[bot] P2 compat breaks on PR-S2b

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -1901,7 +1901,15 @@ function parseOperationExecution(
     action,
     result: toRecord(data.result),
     status: String(data.status ?? "completed"),
-    approval_required: Boolean(data.approval_required ?? String(data.status ?? "").trim().toLowerCase() === "approval_required"),
+    // Use logical OR (not nullish coalescing) so that an explicit
+    // `approval_required: false` from the server still gets upgraded to
+    // true when `status === "approval_required"`. This matches the
+    // Python client's `bool(data.get("approval_required") or status ==
+    // "approval_required")` behavior and prevents partially-rolled-out
+    // or defaulted server payloads from silently skipping owner approval.
+    approval_required: Boolean(
+      data.approval_required || String(data.status ?? "").trim().toLowerCase() === "approval_required",
+    ),
     intent_id: stringOrNull(data.intent_id) ?? undefined,
     approval_status: stringOrNull(data.approval_status) ?? undefined,
     approval_snapshot_hash: stringOrNull(data.approval_snapshot_hash) ?? undefined,
@@ -1920,8 +1928,8 @@ function parseMarketProposalActionResult(execution: OperationExecution): MarketP
       ? execution.result
       : null;
   return {
-    status: execution.status,
-    approval_required: execution.approval_required,
+    status: execution.status ?? "completed",
+    approval_required: execution.approval_required ?? false,
     intent_id: execution.intent_id ?? null,
     approval_status: execution.approval_status ?? null,
     approval_snapshot_hash: execution.approval_snapshot_hash ?? null,

--- a/siglume-api-sdk-ts/src/operations.ts
+++ b/siglume-api-sdk-ts/src/operations.ts
@@ -24,13 +24,19 @@ export interface OperationExecution {
   message: string;
   action: string;
   result: Record<string, unknown>;
-  status: string;
-  approval_required: boolean;
+  // Fields below are v0.6 additions for the owner-operation execute
+  // envelope. They are declared optional so that downstream consumers
+  // with existing object literals or mocks (conforming to the pre-v0.6
+  // shape) continue to type-check without having to pre-populate every
+  // new field. SDK-internal factories still always set them; optional
+  // is for external surface compatibility only.
+  status?: string;
+  approval_required?: boolean;
   intent_id?: string | null;
   approval_status?: string | null;
   approval_snapshot_hash?: string | null;
-  action_payload: Record<string, unknown>;
-  safety: Record<string, unknown>;
+  action_payload?: Record<string, unknown>;
+  safety?: Record<string, unknown>;
   trace_id?: string | null;
   request_id?: string | null;
   raw: Record<string, unknown>;

--- a/siglume-api-sdk-ts/test/pr_s2b_codex_bot_followup.test.ts
+++ b/siglume-api-sdk-ts/test/pr_s2b_codex_bot_followup.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { OperationExecution } from "../src/index";
+
+describe("PR-S2b codex bot follow-up", () => {
+  // ----- Q1: approval_required logical-OR (not ??) ----------------------
+
+  it("honors approval_required when server returns false but status='approval_required'", async () => {
+    // Simulate a server that partially rolled out the envelope: it
+    // explicitly sends `approval_required: false` even when
+    // `status === "approval_required"`. The SDK must still resolve
+    // approval_required to true (matching Python's `bool(x or y)`).
+    //
+    // Build a minimal mock that exercises just the envelope parser
+    // path via the public SDK surface.
+    const { SiglumeClient } = await import("../src/index");
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+        if (url.endsWith("/me/agent")) {
+          return new Response(
+            JSON.stringify({
+              data: { agent_id: "agt_x" },
+              meta: { request_id: "req", trace_id: "trc" },
+              error: null,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              agent_id: "agt_x",
+              status: "approval_required",
+              // Server explicitly says false even though status is
+              // approval_required — SDK must promote to true.
+              approval_required: false,
+              intent_id: "cpi_abc",
+              message: "pending approval",
+              action: { operation: "market.proposals.create" },
+              result: {},
+            },
+            meta: { request_id: "req", trace_id: "trc" },
+            error: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const exec = await client.create_market_proposal({
+      opportunity_id: "opp_1",
+    });
+
+    expect(exec.status).toBe("approval_required");
+    expect(exec.approval_required).toBe(true);
+    expect(exec.intent_id).toBe("cpi_abc");
+  });
+
+  // ----- Q3: OperationExecution new fields are optional ------------------
+
+  it("accepts pre-v0.6 object literals as OperationExecution (new fields optional)", () => {
+    // Type-level check: a consumer that only provides the original
+    // fields must still type-check. If the new v0.6 fields were
+    // required, this literal would fail `tsc --noEmit`.
+    const legacy: OperationExecution = {
+      agent_id: "agt_x",
+      operation_key: "owner.charter.get",
+      message: "Loaded charter.",
+      action: "operation",
+      result: { role: "hybrid" },
+      raw: { ok: true },
+    };
+    expect(legacy.agent_id).toBe("agt_x");
+    expect(legacy.status).toBeUndefined();
+    expect(legacy.approval_required).toBeUndefined();
+    expect(legacy.trace_id).toBeUndefined();
+  });
+
+  it("still accepts full v0.6 object literals as OperationExecution", () => {
+    const full: OperationExecution = {
+      agent_id: "agt_x",
+      operation_key: "market.proposals.create",
+      message: "pending",
+      action: "operation",
+      result: {},
+      status: "approval_required",
+      approval_required: true,
+      intent_id: "cpi_abc",
+      approval_status: null,
+      approval_snapshot_hash: "abc123",
+      action_payload: {},
+      safety: {},
+      trace_id: "trc",
+      request_id: "req",
+      raw: {},
+    };
+    expect(full.approval_required).toBe(true);
+    expect(full.intent_id).toBe("cpi_abc");
+  });
+});

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -1135,21 +1135,29 @@ class AgentThreadRecord:
 
 @dataclass
 class OperationExecution:
+    # IMPORTANT: the positional signature through `raw` is part of the
+    # public SDK surface. New fields MUST be appended after `raw` (or
+    # marked keyword-only) so that legacy callers like
+    # `OperationExecution(agent_id, operation_key, message, action,
+    # result, trace_id, request_id, raw_dict)` do not silently remap
+    # their positional arguments onto the new slots.
     agent_id: str
     operation_key: str
     message: str
     action: str
     result: dict[str, Any] = field(default_factory=dict)
-    status: str = "completed"
-    approval_required: bool = False
-    intent_id: str | None = None
-    approval_status: str | None = None
-    approval_snapshot_hash: str | None = None
-    action_payload: dict[str, Any] = field(default_factory=dict)
-    safety: dict[str, Any] = field(default_factory=dict)
     trace_id: str | None = None
     request_id: str | None = None
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
+    # New in v0.6 (PR-S2b): keyword-only to avoid breaking the historical
+    # positional constructor signature.
+    status: str = field(default="completed", kw_only=True)
+    approval_required: bool = field(default=False, kw_only=True)
+    intent_id: str | None = field(default=None, kw_only=True)
+    approval_status: str | None = field(default=None, kw_only=True)
+    approval_snapshot_hash: str | None = field(default=None, kw_only=True)
+    action_payload: dict[str, Any] = field(default_factory=dict, kw_only=True)
+    safety: dict[str, Any] = field(default_factory=dict, kw_only=True)
 
 
 class RefundReason(str, Enum):

--- a/tests/test_pr_s2b_codex_bot_followup.py
+++ b/tests/test_pr_s2b_codex_bot_followup.py
@@ -1,0 +1,84 @@
+"""Regression tests for chatgpt-codex-connector[bot] findings on
+PR-S2b (siglume-api-sdk#140).
+
+Pin Q2: OperationExecution dataclass positional signature through
+`raw` is part of the public Python surface. Legacy callers like
+`OperationExecution(agent_id, operation_key, message, action,
+result, trace_id, request_id, raw_dict)` must keep working — any
+new v0.6 fields must be keyword-only.
+
+(Q1 / Q3 are TypeScript-only; covered in
+siglume-api-sdk-ts/test/pr_s2b_codex_bot_followup.test.ts.)
+"""
+from __future__ import annotations
+
+import dataclasses
+
+from siglume_api_sdk.client import OperationExecution
+
+
+def test_legacy_positional_constructor_still_works() -> None:
+    """The pre-v0.6 call shape must still produce the expected object.
+
+    Before the fix, inserting `status` / `approval_required` etc. before
+    `trace_id` / `request_id` / `raw` caused a positional call to
+    silently remap — trace_id becoming `status`, request_id becoming
+    `approval_required` (type mismatch!), raw becoming `intent_id`.
+    """
+    legacy = OperationExecution(
+        "agt_x",           # agent_id
+        "owner.charter.get",  # operation_key
+        "Loaded charter.",  # message
+        "operation",        # action
+        {"role": "hybrid"},  # result
+        "trc_123",          # trace_id
+        "req_abc",          # request_id
+        {"ok": True},       # raw
+    )
+    assert legacy.agent_id == "agt_x"
+    assert legacy.operation_key == "owner.charter.get"
+    assert legacy.trace_id == "trc_123"
+    assert legacy.request_id == "req_abc"
+    assert legacy.raw == {"ok": True}
+    # Defaults for new v0.6 fields.
+    assert legacy.status == "completed"
+    assert legacy.approval_required is False
+    assert legacy.intent_id is None
+
+
+def test_new_v06_fields_are_keyword_only() -> None:
+    """The new v0.6 fields must not be positionally accessible — that
+    is the contract that preserves legacy positional call sites."""
+    fields = {f.name: f for f in dataclasses.fields(OperationExecution)}
+    # Legacy positional fields keep kw_only=False.
+    for legacy_field in (
+        "agent_id", "operation_key", "message", "action",
+        "result", "trace_id", "request_id", "raw",
+    ):
+        assert fields[legacy_field].kw_only is False, legacy_field
+    # New fields must be keyword-only.
+    for new_field in (
+        "status", "approval_required", "intent_id",
+        "approval_status", "approval_snapshot_hash",
+        "action_payload", "safety",
+    ):
+        assert fields[new_field].kw_only is True, new_field
+
+
+def test_new_v06_fields_accessible_via_kwargs() -> None:
+    """Kw-only fields are still fully constructable by name."""
+    instance = OperationExecution(
+        "agt_x",
+        "owner.budget.get",
+        "Loaded budget.",
+        "operation",
+        {"daily_cap_usd": 10.0},
+        status="approval_required",
+        approval_required=True,
+        intent_id="cpi_abc",
+        approval_snapshot_hash="abc123",
+    )
+    assert instance.status == "approval_required"
+    assert instance.approval_required is True
+    assert instance.intent_id == "cpi_abc"
+    assert instance.approval_snapshot_hash == "abc123"


### PR DESCRIPTION
## Summary
Three API-surface compatibility issues on PR-S2b (market.proposals.*):

| # | Severity | Issue |
|---|---|---|
| Q1 | P2 | TS `approval_required` used `??` nullish coalescing — explicit `false` from server silently shadowed the `status === "approval_required"` fallback. Python used `or`, so mismatch. |
| Q2 | P2 | Python `OperationExecution` dataclass added v0.6 fields BEFORE `trace_id`/`request_id`/`raw`, silently corrupting legacy positional callers. |
| Q3 | P2 | TS `OperationExecution` declared new v0.6 fields as required, source-breaking downstream object literals / mocks built against the pre-v0.6 shape. |

## Fixes
- **Q1**: TS now uses `data.approval_required || status === "approval_required"` — matches Python's `or` semantics.
- **Q2**: New v0.6 fields in `OperationExecution` moved to `field(kw_only=True)`. Legacy positional call through `raw` still works; new fields are keyword-only.
- **Q3**: New v0.6 fields in the TS `OperationExecution` interface made optional. `parseMarketProposalActionResult()` updated to materialize safe defaults when the consumer type remains strict.

## Regression coverage
- 3 Python cases in `tests/test_pr_s2b_codex_bot_followup.py` (legacy positional still works, new fields kw_only per `dataclasses.fields()` inspection, kwargs access).
- 3 TS cases in `test/pr_s2b_codex_bot_followup.test.ts` (OR promotion on explicit false, pre-v0.6 literals type-check, full v0.6 literals still valid).

## Verification
- pytest: **254 → 257 passed** (+3)
- vitest: **301 → 304 passed** (+3)
- ruff / contract-sync / typecheck / lint / build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)