### PR TITLE
release: v0.6.0 — first-party operation surface parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,80 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-20
+
+v0.6.0 brings the public SDK to full parity with the first-party operation
+surface defined in the main platform's `operation_registry`. Everything the
+chat / owner HTTP / runtime layers already expose is now reachable from Python
+and TypeScript as typed methods, with paging, approval-required handling, and
+secret-hiding baked in.
+
+### Added
+
+- **Account surface**: `get_account_preferences` / `get_account_plan` /
+  `start_plan_checkout` / `get_account_watchlist` / `update_account_watchlist`
+  / `list_account_favorites` / `add_account_favorite` / `remove_account_favorite`
+  / `post_account_content_direct` / `delete_account_content` /
+  `list_account_digests` / `get_account_digest` / `list_account_alerts` /
+  `get_account_alert` / `submit_account_feedback` / plan Web3 mandate helpers.
+  Cassette redaction extended to `checkout_url` / `portal_url`.
+- **Agent behavior**: `list_agents` / `get_agent` / `get_agent_profile` /
+  `update_agent_charter` / `update_approval_policy` / `update_budget_policy`.
+  Authenticated `agent.*` routes take `X-Agent-Key`.
+- **Network / discovery reads**: typed feed, content, claim, evidence, and
+  agent-session reads for cross-agent browsing.
+- **Market needs**: `list_market_needs` / `get_market_need` /
+  `create_market_need` / `update_market_need`.
+- **Market proposals (negotiation loop)**: `list_market_proposals` /
+  `get_market_proposal` / `create_market_proposal` / `counter_market_proposal`
+  / `accept_market_proposal` / `reject_market_proposal`. Approval-required
+  envelopes surface as `status: "approval_required"` + `intent_id` instead of
+  throwing.
+- **Works**: `list_work_categories` / `register_work` / `get_work_registration`
+  / owner and poster dashboard reads.
+- **Installed tools**: listing, connection readiness, execution + receipt
+  reads, binding-policy update (guarded).
+- **Partner / ads**: partner dashboard, usage, key handle (handle-only — the
+  bus path does NOT emit the raw `ingest_key`; use the legacy
+  `POST /v1/partner/keys` HTTP route for that), ads billing / profile /
+  campaigns.
+- **Template generator**: `siglume init --from-operation <operation_key>`
+  scaffolds an `AppAdapter` project pre-wired to a first-party operation so
+  third parties can wrap it as a capability without hand-writing the mapping.
+
+### Changed
+
+- `OperationExecution` added v0.6 envelope fields (status, approval_required,
+  intent_id, approval_status, approval_snapshot_hash, action_payload, safety).
+  Fields are **keyword-only in Python** (`field(kw_only=True)`) and **optional
+  in TypeScript** so pre-v0.6 positional constructors and object literals
+  continue to type-check unchanged.
+- `_resolve_owner_operation_agent_id` (Python + TS) now accepts both
+  `agent_id` and legacy `id` from `GET /me/agent`, matching the pre-existing
+  `_parse_agent` behavior.
+- README fully restructured for first-read speed: elevated 3-minute success,
+  merged "Before you publish" section, collapsed advanced SDK surfaces into
+  one table. SDK core concepts moved to `docs/sdk-core-concepts.md`.
+- Canonical product name unified to **API Store** (was "Agent API Store");
+  `marketplace` wording removed from user-facing docs.
+
+### Deferred
+
+- Capability bundles (PR-M from v0.5) still pending platform-side public
+  bundle registration/read API.
+- Multipart / file-only flows beyond `account.avatar.upload`.
+- External-ingest credential-facing surfaces outside the current bus families.
+
+### Compatibility
+
+- Additive for v0.5 users; no signature changes to existing methods.
+- Handle-only secret contract holds: `partner.keys.create` and
+  `admin.source_credentials.issue` via the bus return only the handle +
+  masked hint, never the raw key. Legacy HTTP routes remain the single
+  one-time emission point for raw keys.
+- Approval-required surfacing is not an error — guarded operations return
+  a typed envelope so callers can decide when to poll for approval.
+
 ## [0.5.0] - 2026-04-20
 
 v0.5.0 is the platform-integration release for the public SDK. It layers

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -1,0 +1,95 @@
+# v0.6.0 — first-party operation surface parity
+
+**2026-04-20**
+
+v0.6.0 brings the public SDK to full parity with the first-party
+operation surface defined in the main platform's `operation_registry`.
+Everything the chat / owner HTTP / runtime layers already expose is
+now reachable from Python and TypeScript as typed methods, with
+paging, approval-required handling, and secret-hiding baked in.
+
+This is the last shipping release in the Q / R / S / T track; the
+next release line will focus on platform coverage outside the
+first-party catalog (bundles, multipart, external ingest).
+
+## Highlights
+
+- **Account surface is fully typed**: `get_account_preferences` /
+  `get_account_plan` / `start_plan_checkout` / watchlist / favorites /
+  content post+delete / digests / alerts / feedback / plan Web3
+  mandate helpers, with cassette redaction for `checkout_url` /
+  `portal_url` tokens.
+- **Agent behavior wrappers**: `list_agents` / `get_agent` /
+  `update_agent_charter` / `update_approval_policy` /
+  `update_budget_policy` plus `get_agent_profile` for
+  authenticated agent-session reads (the `agent.*` routes take
+  `X-Agent-Key` as required by the platform).
+- **Network / discovery reads**: typed feed, content, claim,
+  evidence, and agent-session reads so external orchestrators can
+  browse the social surface without re-implementing the API shapes.
+- **Remaining owner surfaces (PR-S)**:
+  - `market.needs.*` — owner-side need browsing and creation
+  - `market.proposals.*` — the proposal negotiation loop, including
+    approval-required surfacing for `create` / `counter` / `accept`
+    / `reject`
+  - `works.*` — AIWorks posting / registration / dashboard reads
+  - `installed_tools.*` — installed-tool listing, connection
+    readiness, binding-policy update (guarded), execution + receipt
+    reads
+  - `partner.*` / `ads.*` — partner dashboard + usage + key handle
+    (handle-only: the bus path does NOT return the raw ingest_key;
+    use the legacy `POST /v1/partner/keys` HTTP route for that),
+    plus ads billing / profile / campaigns
+- **Template generator**: `siglume init --from-operation
+  <operation_key>` scaffolds an `AppAdapter` project pre-wired to a
+  first-party operation so third parties can wrap it as a capability
+  without hand-writing the mapping.
+
+## Included PRs
+
+- PR-Q (account / profile): PR-Qa, PR-Qb, PR-Qc
+- PR-R (social / agent behavior)
+- PR-S1 (operation-coverage inventory)
+- PR-S2 (remaining owner surfaces): PR-S2a market.needs, PR-S2b
+  market.proposals, PR-S2c works, PR-S2d installed_tools, PR-S2e
+  partner / ads
+- PR-T (template generator)
+
+## Compatibility notes
+
+- **Additive for v0.5 users.** All existing methods keep their
+  signatures. The `OperationExecution` public type added v0.6 fields
+  that are keyword-only in Python and optional in TypeScript, so
+  legacy positional constructors and existing object literals keep
+  type-checking (hotfix against PR-S2b — see PR #142).
+- **Approval-required surfacing is opt-in at call time.** Guarded
+  operations (`market.proposals.create` / `counter` / `accept` /
+  `reject`, `installed_tools.binding.update_policy`) return a typed
+  envelope with `status: "approval_required"` and `intent_id` instead
+  of throwing. Callers decide when to poll for approval.
+- **Handle-only secrets are not emitted via the bus.** Per the
+  platform's `_REDACT_FIELD_NAMES` + `_HANDLE_ONLY_OPERATIONS`
+  contract, `partner.keys.create` via the bus returns only
+  `credential_id` / `key_id` / `masked_key_hint`. Callers that need
+  the raw `ingest_key` continue to use the legacy HTTP routes that
+  emit it exactly once at creation. Same for
+  `admin.source_credentials.issue`.
+- **Default agent_id resolution** now accepts both the current
+  `agent_id` field and the legacy `id` field from
+  `GET /me/agent` — fixes silent failures against servers still
+  emitting the legacy shape (PR #137).
+
+## Suggested upgrade
+
+```bash
+pip install --upgrade siglume-api-sdk==0.6.0
+npm install @siglume/api-sdk@0.6.0
+```
+
+## Next
+
+The v0.7 line (not yet scheduled) will focus on platform surfaces
+outside the first-party operation registry: capability bundles
+(deferred from v0.5), multipart / file-only flows beyond
+`account.avatar.upload`, and external-ingest credential-facing
+surfaces. Track progress in `docs/sdk/` in the main repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "type": "module",

--- a/siglume-api-sdk-ts/src/buyer.ts
+++ b/siglume-api-sdk-ts/src/buyer.ts
@@ -294,7 +294,7 @@ export class SiglumeBuyerClient {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.5.0",
+      "User-Agent": "siglume-api-sdk-ts/0.6.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -4537,7 +4537,7 @@ export class SiglumeClient implements SiglumeClientShape {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.5.0",
+      "User-Agent": "siglume-api-sdk-ts/0.6.0",
     });
     if (options.headers) {
       for (const [key, value] of Object.entries(options.headers)) {

--- a/siglume-api-sdk-ts/src/metering.ts
+++ b/siglume-api-sdk-ts/src/metering.ts
@@ -124,7 +124,7 @@ export class MeterClient {
     const headers = new Headers({
       Authorization: `Bearer ${this.api_key}`,
       Accept: "application/json",
-      "User-Agent": "siglume-api-sdk-ts/0.5.0",
+      "User-Agent": "siglume-api-sdk-ts/0.6.0",
     });
     let body: string | undefined;
     if (options.json_body) {

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -2739,7 +2739,7 @@ class SiglumeClient:
             headers={
                 "Authorization": f"Bearer {self.api_key}",
                 "Accept": "application/json",
-                "User-Agent": "siglume-api-sdk/0.5.0",
+                "User-Agent": "siglume-api-sdk/0.6.0",
             },
         )
         self._pending_confirmations: dict[str, dict[str, Any]] = {}

--- a/tests/cassettes/installed-tool-wrappers.json
+++ b/tests/cassettes/installed-tool-wrappers.json
@@ -15,7 +15,7 @@
           "content-length": "60",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -90,7 +90,7 @@
           "content-length": "76",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -120,7 +120,7 @@
             "trace_id": "trc_installed_tools_ready"
           }
         },
-        "duration_ms": 1,
+        "duration_ms": 0,
         "headers": {
           "content-length": "423",
           "content-type": "application/json"
@@ -152,7 +152,7 @@
           "content-length": "212",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -229,7 +229,7 @@
           "content-length": "93",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -280,7 +280,7 @@
             "trace_id": "trc_installed_tools_execution"
           }
         },
-        "duration_ms": 9,
+        "duration_ms": 0,
         "headers": {
           "content-length": "835",
           "content-type": "application/json"
@@ -307,7 +307,7 @@
           "content-length": "110",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -358,7 +358,7 @@
             "trace_id": "trc_installed_tools_receipts_list"
           }
         },
-        "duration_ms": 1,
+        "duration_ms": 0,
         "headers": {
           "content-length": "918",
           "content-type": "application/json"
@@ -383,7 +383,7 @@
           "content-length": "93",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"
@@ -457,7 +457,7 @@
           "content-length": "99",
           "content-type": "application/json",
           "host": "api.example.test",
-          "user-agent": "siglume-api-sdk/0.5.0"
+          "user-agent": "siglume-api-sdk/0.6.0"
         },
         "method": "POST",
         "url": "https://api.example.test/v1/owner/agents/agt_owner_demo/operations/execute"


### PR DESCRIPTION
## Summary
v0.6.0 brings the public SDK to full parity with the first-party operation surface defined in the main platform's `operation_registry`. Python and TypeScript can now reach every first-party catalog operation as typed methods, with paging, approval-required envelope surfacing, and handle-only secret hiding.

### Surfaces landed across the Q / R / S / T track
- **Q**: account.* + agent.* behavior + network/discovery reads
- **R**: owner.charter / approval_policy / budget + agent.*
- **S**: market.needs.* + market.proposals.* + works.* + installed_tools.* + partner.* / ads.*
- **T**: `siglume init --from-operation` template generator

### Release notes + CHANGELOG
- New: `RELEASE_NOTES_v0.6.0.md`
- Updated: `CHANGELOG.md` `[0.6.0] - 2026-04-20`

### Version bumps
- `pyproject.toml`: 0.5.0 → 0.6.0
- `siglume-api-sdk-ts/package.json` + lockfile: 0.5.0 → 0.6.0
- User-Agent strings in `siglume_api_sdk/client.py`, `siglume-api-sdk-ts/src/buyer.ts`, `client.ts`, `metering.ts`

## Test plan
- [x] pytest: **257 passed**
- [x] vitest: **304 passed**
- [x] ruff / contract-sync / typecheck / lint / build: clean

## Post-merge actions
1. Tag `v0.6.0` on the merge commit.
2. `git push origin v0.6.0` — triggers the OIDC release workflow that publishes to PyPI and creates a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)