### PR TITLE
docs: add ROADMAP.md + fix dangling references after internal-purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Runnable templates for `PAYMENT` (payment quote / polygon mandate / embedded wal
 | [API Manifest Schema](schemas/app-manifest.schema.json) | Machine-readable manifest contract |
 | [Tool Manual Schema](schemas/tool-manual.schema.json) | Machine-readable tool manual contract |
 | [Payment Migration](PAYMENT_MIGRATION.md) | What works today under the Stripe → Polygon cutover |
+| [Roadmap](ROADMAP.md) | Shipped releases, v0.7 scope (capability bundles / multipart / external-ingest credentials), and what is not planned |
 
 Advanced SDK surfaces live under [docs/](./docs/) — see the table above for direct links.
 

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -88,8 +88,7 @@ npm install @siglume/api-sdk@0.6.0
 
 ## Next
 
-The v0.7 line (not yet scheduled) will focus on platform surfaces
-outside the first-party operation registry: capability bundles
+See [ROADMAP.md](./ROADMAP.md) for the v0.7 scope — capability bundles
 (deferred from v0.5), multipart / file-only flows beyond
 `account.avatar.upload`, and external-ingest credential-facing
-surfaces. Track progress in `docs/sdk/` in the main repo.
+surfaces.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,129 @@
+# Roadmap
+
+What is shipped today on the public SDK, what is scheduled next, and
+what is explicitly out of scope. For the per-release changelog, see
+[CHANGELOG.md](./CHANGELOG.md).
+
+## Shipped
+
+### v0.6.0 — first-party operation surface parity
+
+Every first-party operation on the Siglume platform is reachable
+from Python and TypeScript as a typed method, with paging,
+approval-required handling, and handle-only secret hiding. See
+[RELEASE_NOTES_v0.6.0.md](./RELEASE_NOTES_v0.6.0.md).
+
+### v0.5.0 — platform-integration release
+
+Webhook handling, refund / dispute flow, experimental usage
+metering, Web3 settlement helpers. See
+[RELEASE_NOTES_v0.5.0.md](./RELEASE_NOTES_v0.5.0.md).
+
+### v0.4.0 — multi-runtime + quality + ecosystem
+
+Python + TypeScript parity, offline ToolManual grader, LLM-assisted
+drafting, manifest / tool-manual diff, tool-schema exporter
+(Anthropic / OpenAI / MCP), recording harness, buyer-side SDK
+(experimental), seven starter examples. See
+[RELEASE_NOTES_v0.4.0.md](./RELEASE_NOTES_v0.4.0.md).
+
+## Next — v0.7 (not yet scheduled)
+
+v0.7 focuses on surfaces **outside** the first-party operation
+registry that v0.6 already covers. Each of the three tracks below is
+blocked on platform-side contract work before the SDK can wrap it.
+
+### Capability bundles
+
+Publish one listing that exposes multiple `ToolManual` entries (one
+per sub-capability) and is sold as a single subscription.
+
+What the SDK will add once the platform ships the bundle contract:
+
+- `AppAdapter.list_tools()` convention for declaring multiple tools
+  on one adapter.
+- Bundle-level registration helpers on `SiglumeClient`.
+- Bundle-aware quality grading in `AppTestHarness`.
+
+Platform prerequisites:
+
+- A public `/v1/market/bundles` (or equivalent) registration and
+  read API.
+- Stable bundle-level identity that maps cleanly onto listing keys,
+  release ids, and per-tool quality validation.
+
+### Multipart / file-only flows
+
+Today, the owner-operation contract carries JSON only, and
+`account.avatar.upload` is the only multipart operation wired
+through the bus. File attachments (images, PDFs, audio, archive
+bundles) on posts / notifications / messaging need a handle-based
+upload contract.
+
+The intended shape:
+
+1. A dedicated upload endpoint accepts the bytes and returns a
+   stable `upload_handle_id`.
+2. Regular operation params reference the handle via JSON, e.g.
+   `attachments: [{"handle_id": "...", "filename": "..."}]`.
+3. The runtime resolves handles to bytes at execution time and
+   honors the same safety contract (size caps, mime allow-list,
+   handle TTL, owner-scope checks).
+
+What the SDK will add once the platform ships the upload contract:
+
+- `SiglumeClient.upload_attachment(path | bytes)` returning a
+  typed `UploadHandle`.
+- Attachment-aware variants of content and messaging operations.
+- `AppTestHarness` helpers to simulate upload + handle resolution
+  locally.
+
+Platform prerequisites:
+
+- A public upload endpoint with a documented mime allow-list, size
+  cap, and handle TTL.
+- Handle-aware dispatch in the runtime so approved intents continue
+  to carry only the handle id, never the raw bytes, into persisted
+  artifacts.
+
+### External-ingest credential-facing surfaces
+
+Beyond today's `partner.keys.create` and
+`admin.source_credentials.issue` (both handle-only via the bus),
+several external-ingest integrations need their own credential
+contracts — provider-specific auth refresh, scope rotation, and
+operational telemetry for partner-run data feeds.
+
+What the SDK will add once the platform ships the contract:
+
+- Typed wrappers for each supported provider family.
+- Structured refresh / rotate / revoke flows that preserve the
+  handle-only contract (the bus never emits the raw secret,
+  even at creation — sellers see it once on the user-facing HTTP
+  route).
+
+Platform prerequisites:
+
+- A stable provider-family contract in `operation_registry` for
+  external credential issuance.
+- Decision on per-provider redaction and audit requirements.
+
+## Not planned
+
+- A separate `SiglumeBuyerClient` ecosystem (experimental today;
+  the buyer-side contract will continue to go through the existing
+  execute endpoint).
+- Platform-admin operations. `admin.api_store.*` internal
+  transport routes are intentionally excluded from the bus — they
+  stay HTTP-only.
+- Rewriting the operation contract. `operation_registry` is
+  authoritative; the SDK mirrors whatever that surface exposes.
+
+## How to track
+
+- SDK progress: this file + [CHANGELOG.md](./CHANGELOG.md).
+- Platform-side prerequisites (the blockers above): follow
+  [Siglume Discussions](https://github.com/taihei-05/siglume-api-sdk/discussions)
+  where platform updates relevant to SDK consumers are announced.
+- Bugs / small asks on the current surface: open an
+  [issue](https://github.com/taihei-05/siglume-api-sdk/issues).

--- a/docs/partner-ads-operations.md
+++ b/docs/partner-ads-operations.md
@@ -70,13 +70,12 @@ presentation route.
 - The SDK does not model `ingest_key` on this wrapper and defensively scrubs
   `ingest_key` / `full_key` from the parsed raw payload as well.
 - Partners who need to reveal the raw secret once at creation time must use the
-  legacy user-facing HTTP route `POST /v1/partner/keys`
-  (`presentation/partner_api.py` in the main repo). The shared owner-operation
-  bus path is handle-only by design.
+  legacy user-facing HTTP route `POST /v1/partner/keys`. The shared
+  owner-operation bus path is handle-only by design.
 
-This mirrors the platform contract established in the main repo's
-owner-operation implementation and regression tests. Do not write client code
-that assumes `partner.keys.create()` will ever return `ingest_key`.
+This matches the platform's handle-only contract for credential issuance. Do
+not write client code that assumes `partner.keys.create()` will ever return
+`ingest_key`.
 
 ## Ads Billing Settle Note
 


### PR DESCRIPTION
## Summary
Follow-up to PR #146.

### Added
- **`ROADMAP.md`** — single canonical "what's next" doc. Covers shipped releases (v0.4 → v0.6) and names the three v0.7 blockers (capability bundles, multipart / file-only flows, external-ingest credential-facing surfaces). Each track states what the SDK will add and what the platform needs to ship first.
- README.md Full docs table entry linking to ROADMAP.md.

### Fixed dangling references
- `RELEASE_NOTES_v0.6.0.md` "Next" section: previously said "Track progress in `docs/sdk/` in the main repo" — broken path (deleted in #146) + leaks private repo existence. Replaced with link to ROADMAP.md.
- `docs/partner-ads-operations.md` (lines 74, 77): "main repo" references removed; the contract is now described on its own terms.

## Test plan
- [x] pytest: 257 passed
- [x] contract-sync: clean
- [x] Repo-wide grep for `main repo | private repo | packages/shared-python | apps/api | apps/web | c:/develop | owner_agent_operation_program` across all `*.md`: **zero hits**

🤖 Generated with [Claude Code](https://claude.com/claude-code)