### PR TITLE
docs: align Developer Portal wording + purge lingering 'agent app' terminology

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -24,7 +24,7 @@ A practical guide for indie developers. Go from zero to a running API in 15 minu
 
 ## 1. What is Siglume API Store?
 
-Siglume is an AI agent platform. The **API Store** lets developers build power-up kits that agents can install to gain new capabilities.
+Siglume is an AI agent platform. The **API Store** lets developers publish APIs that agents subscribe to and call at runtime to gain new capabilities.
 
 When an agent owner installs your API, their agent can perform new tasks — comparing prices, syncing calendars, translating content, posting to social media, and more.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You do not submit a PR to this repo. You register directly on the platform — n
 5. Confirm → quality check → admin review → listed in the API Store
 6. Agent owners subscribe → you earn 93.4% of revenue
 
-- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (create / edit / submit your listings)
+- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review, edit, and submit your listings after creation; new listings are always created through the `auto-register` endpoint — see [Getting Started §11](GETTING_STARTED.md#11-auto-register-list-your-api-with-your-ai))
 - **API Store buyer view** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
 
 ---

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -1,6 +1,7 @@
 /**
- * Siglume Agent App SDK — TypeScript type definitions
- * For app developers building frontend components or client-side integrations.
+ * Siglume API Store SDK — TypeScript type definitions
+ * For developers building frontend components or client-side integrations
+ * that interact with Siglume API Store listings.
  */
 
 export type PermissionClass = "read-only" | "recommendation" | "action" | "payment";

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -1,10 +1,11 @@
-"""Siglume Agent App SDK — interface definitions for external developers.
+"""Siglume API Store SDK — interface definitions for external developers.
 
-This module defines the contracts that app developers implement to create
-agent apps for the Siglume API Store.
+This module defines the contracts that developers implement to publish
+APIs on the Siglume API Store.
 
-An "agent app" is a power-up kit that gives a Siglume AI agent new capabilities.
-For example: Amazon price comparison, travel booking, CRM sync, etc.
+A listing is an HTTP API plus a machine-readable tool manual that
+Siglume agents can subscribe to and invoke at runtime. Examples:
+Amazon price comparison, travel booking, CRM sync.
 
 Developers implement the AppAdapter protocol and register it with Siglume.
 """
@@ -798,10 +799,11 @@ class HealthCheckResult:
 # ── App Adapter Protocol ──
 
 class AppAdapter(abc.ABC):
-    """Base class for Siglume agent app adapters.
+    """Base class for Siglume API Store capability adapters.
 
-    External developers subclass this to create new agent apps.
-    Siglume's CapabilityGateway calls these methods at runtime.
+    External developers subclass this to publish a capability on the
+    Siglume API Store. Siglume's CapabilityGateway calls these methods
+    at runtime when a subscribing agent invokes the capability.
     """
 
     @abc.abstractmethod


### PR DESCRIPTION
## Summary
Two reviewer items after PR #147.

### 1. Developer Portal vs auto-register wording
README said "Developer Portal → create / edit / submit your listings" but `GETTING_STARTED.md` said "the only way to create a new listing is via the auto-register endpoint; there is no manual form or developer portal for listing creation". Same reality, different framings. Unified on: **creation always goes through auto-register; the Portal handles review / edit / submit after creation**. Links straight into Getting Started §11 so the sequence is explicit.

### 2. Old terminology in module docstrings
Public surface has said "API Store SDK" since the April rename, but top-of-file docstrings still read "Siglume Agent App SDK" / "agent apps" / "power-up kit":
- `siglume_api_sdk.py` module + `AppAdapter` base-class docstrings
- `siglume-api-types.ts` module header
- `GETTING_STARTED.md §1` ("power-up kits")

Reworded each to the current "Siglume API Store SDK" / "capability adapter" / "API listing" framing. No public identifier / type / behavior change — prose cleanup in the spots developers read first when opening the module.

## Test plan
- [x] pytest: **257 passed**, 0 regressions
- [x] `grep "Agent App SDK | agent apps | power-up kit | Agent App Store"` across `.py`/`.ts`/`.md`: **zero hits**

### Not addressed (reviewer explicitly said "skip")
- Adding a real GIF / screenshot to README hero — the reviewer rated this as a "growth point, not a defect" and the user confirmed it can be skipped for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)