### PR TITLE
fix(client): support SIGLUME_API_KEY env var fallback (PR #144 P2)

### DIFF
--- a/siglume-api-sdk-ts/src/buyer.ts
+++ b/siglume-api-sdk-ts/src/buyer.ts
@@ -83,7 +83,7 @@ export class SiglumeBuyerClient {
 
   constructor(options: SiglumeBuyerClientOptions) {
     this.client = new SiglumeClient(options);
-    this.api_key = options.api_key;
+    this.api_key = this.client.api_key;
     this.base_url = (options.base_url ?? DEFAULT_SIGLUME_API_BASE).replace(/\/+$/, "");
     this.timeout_ms = Math.max(1, options.timeout_ms ?? 15_000);
     this.max_retries = Math.max(1, Math.trunc(options.max_retries ?? 3));

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -130,7 +130,10 @@ type RequestOptions = {
 };
 
 export interface SiglumeClientOptions {
-  api_key: string;
+  /**
+   * Bearer key. Falls back to `process.env.SIGLUME_API_KEY` (Node) when omitted.
+   */
+  api_key?: string;
   agent_key?: string;
   base_url?: string;
   timeout_ms?: number;
@@ -2081,11 +2084,18 @@ export class SiglumeClient implements SiglumeClientShape {
   private readonly fetchImpl: FetchLike;
   private readonly pendingConfirmations = new Map<string, PendingConfirmation>();
 
-  constructor(options: SiglumeClientOptions) {
-    if (!options.api_key) {
-      throw new SiglumeClientError("SIGLUME_API_KEY is required.");
+  constructor(options: SiglumeClientOptions = {}) {
+    const envKey =
+      typeof process !== "undefined" && process.env
+        ? (process.env.SIGLUME_API_KEY ?? "").trim()
+        : "";
+    const resolvedKey = (options.api_key ?? "").trim() || envKey;
+    if (!resolvedKey) {
+      throw new SiglumeClientError(
+        "SIGLUME_API_KEY is required. Pass it as the api_key option or set the SIGLUME_API_KEY env var.",
+      );
     }
-    this.api_key = options.api_key;
+    this.api_key = resolvedKey;
     this.agent_key = options.agent_key?.trim() || undefined;
     this.base_url = (options.base_url ?? DEFAULT_SIGLUME_API_BASE).replace(/\/+$/, "");
     this.timeout_ms = Math.max(1, options.timeout_ms ?? 15_000);

--- a/siglume-api-sdk-ts/src/metering.ts
+++ b/siglume-api-sdk-ts/src/metering.ts
@@ -64,7 +64,7 @@ export class MeterClient {
 
   constructor(options: MeterClientOptions) {
     this.client = new SiglumeClient(options);
-    this.api_key = options.api_key;
+    this.api_key = this.client.api_key;
     this.base_url = (options.base_url ?? DEFAULT_SIGLUME_API_BASE).replace(/\/+$/, "");
     this.timeout_ms = Math.max(1, options.timeout_ms ?? 15_000);
     this.max_retries = Math.max(1, Math.trunc(options.max_retries ?? 3));

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -2786,7 +2786,7 @@ class SiglumeClient:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         *,
         agent_key: str | None = None,
         base_url: str | None = None,
@@ -2794,9 +2794,12 @@ class SiglumeClient:
         max_retries: int = 3,
         transport: httpx.BaseTransport | None = None,
     ) -> None:
-        if not api_key:
-            raise SiglumeClientError("SIGLUME_API_KEY is required.")
-        self.api_key = api_key
+        resolved_key = (api_key or os.environ.get("SIGLUME_API_KEY") or "").strip()
+        if not resolved_key:
+            raise SiglumeClientError(
+                "SIGLUME_API_KEY is required. Pass it as api_key=... or set the SIGLUME_API_KEY env var."
+            )
+        self.api_key = resolved_key
         self.agent_key = str(agent_key or "").strip() or None
         self.base_url = (base_url or os.environ.get("SIGLUME_API_BASE") or DEFAULT_SIGLUME_API_BASE).rstrip("/")
         self.max_retries = max(1, int(max_retries))


### PR DESCRIPTION
## Summary

- Closes the only unresolved chatgpt-codex-connector[bot] P2 review comment from PR #144 ([link](https://github.com/taihei-05/siglume-api-sdk/pull/144))
- `GETTING_STARTED.md:471` has been claiming **\"SiglumeClient reads the SIGLUME_API_KEY environment variable by default\"** since Phase 4, but the constructor required an explicit `api_key` argument with no env fallback
- Aligns SDK with documented behavior (and with the de-facto pattern of `openai` / `anthropic` / `stripe` SDKs)

## Changes

### Python — [siglume_api_sdk/client.py](https://github.com/taihei-05/siglume-api-sdk/blob/fix/sdk-env-api-key-fallback/siglume_api_sdk/client.py)
- `api_key` parameter is now optional. When omitted, reads `os.environ.get(\"SIGLUME_API_KEY\")`
- Mirrors the existing `base_url` / `SIGLUME_API_BASE` pattern

### TypeScript — [siglume-api-sdk-ts/src/client.ts](https://github.com/taihei-05/siglume-api-sdk/blob/fix/sdk-env-api-key-fallback/siglume-api-sdk-ts/src/client.ts)
- `api_key` option is now optional. When omitted, reads `process.env.SIGLUME_API_KEY`
- Guarded by `typeof process !== \"undefined\"` so browser builds without `process` still throw cleanly
- `buyer.ts` and `metering.ts` now read the resolved `api_key` from the wrapped `SiglumeClient` instance, so they inherit env fallback transparently

### Error messages
Both messages still start with `\"SIGLUME_API_KEY is required.\"` so the existing `client-extra.test.ts` continues to pass unchanged. Extended hint follows: `\"Pass it as the api_key option / api_key=... or set the SIGLUME_API_KEY env var.\"`

## Test plan
- [x] Python: manual REPL — raises when both unset, env fallback works, explicit arg overrides env
- [x] TypeScript: \`npx tsc --noEmit\` clean
- [x] TypeScript: \`npx vitest run test/client-extra.test.ts\` — all 5 tests pass (including \"requires an api key at construction time\")

## Background

The 5 other recent chatgpt-codex bot review comments (PR #136 ×2, PR #140 ×3, PR #146 ×1) were verified as already-addressed in subsequent commits. This PR closes the last outstanding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)