### PR TITLE
feat(v0.7): TypeScript SDK wrap for connected-accounts

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -24,6 +24,9 @@ import type {
   ApprovalPolicy,
   BundleListingRecord,
   BundleMember,
+  ConnectedAccountLifecycleResult,
+  ConnectedAccountOAuthStart,
+  ConnectedAccountProvider,
   AutoRegistrationReceipt,
   BillingPortalLink,
   BudgetPolicy,
@@ -198,6 +201,18 @@ export interface SiglumeClientShape {
   add_bundle_capability(bundle_id: string, input: { capability_listing_id: string; position?: number }): Promise<BundleListingRecord>;
   remove_bundle_capability(bundle_id: string, capability_listing_id: string): Promise<BundleListingRecord>;
   submit_bundle_for_review(bundle_id: string): Promise<BundleListingRecord>;
+
+  // Connected accounts (v0.7 track 3)
+  list_connected_account_providers(): Promise<ConnectedAccountProvider[]>;
+  start_connected_account_oauth(input: {
+    provider_key: string;
+    redirect_uri: string;
+    scopes?: string[];
+    account_role?: string;
+  }): Promise<ConnectedAccountOAuthStart>;
+  complete_connected_account_oauth(input: { state: string; code: string }): Promise<Record<string, unknown>>;
+  refresh_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult>;
+  revoke_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult>;
 
   get_developer_portal(): Promise<DeveloperPortalSummary>;
   create_sandbox_session(options: { agent_id: string; capability_key: string }): Promise<SandboxSession>;
@@ -819,6 +834,39 @@ function parseBundleMember(data: Record<string, unknown>): BundleMember {
     status: stringOrNull(data.status),
     added_at: stringOrNull(data.added_at),
     link_id: stringOrNull(data.link_id),
+  };
+}
+
+function parseConnectedAccountProvider(data: Record<string, unknown>): ConnectedAccountProvider {
+  return {
+    provider_key: String(data.provider_key ?? ""),
+    display_name: String(data.display_name ?? ""),
+    auth_type: String(data.auth_type ?? "oauth2"),
+    refresh_supported: Boolean(data.refresh_supported ?? false),
+    pkce_required: Boolean(data.pkce_required ?? false),
+    default_scopes: Array.isArray(data.default_scopes)
+      ? data.default_scopes.filter((s): s is string => typeof s === "string")
+      : [],
+    available_scopes: Array.isArray(data.available_scopes)
+      ? data.available_scopes.filter((s): s is string => typeof s === "string")
+      : [],
+    scope_separator: String(data.scope_separator ?? " "),
+    notes: stringOrNull(data.notes),
+  };
+}
+
+function parseConnectedAccountLifecycle(data: Record<string, unknown>): ConnectedAccountLifecycleResult {
+  return {
+    connected_account_id: String(data.connected_account_id ?? ""),
+    provider_key: String(data.provider_key ?? ""),
+    expires_at: stringOrNull(data.expires_at),
+    scopes: Array.isArray(data.scopes)
+      ? data.scopes.filter((s): s is string => typeof s === "string")
+      : [],
+    refreshed_at: stringOrNull(data.refreshed_at),
+    connection_status: stringOrNull(data.connection_status),
+    provider_revoked: typeof data.provider_revoked === "boolean" ? data.provider_revoked : null,
+    revoked_at: stringOrNull(data.revoked_at),
   };
 }
 
@@ -2316,6 +2364,62 @@ export class SiglumeClient implements SiglumeClientShape {
   }
 
   // ----- end bundles -------------------------------------------------------
+
+  // ----- Connected accounts (v0.7 track 3) ---------------------------------
+  // `resolve()` is intentionally NOT wrapped: runtime-only, never over the wire.
+
+  async list_connected_account_providers(): Promise<ConnectedAccountProvider[]> {
+    const [data] = await this.request("GET", "/me/connected-accounts/providers");
+    const items = Array.isArray(data.items) ? data.items : [];
+    return items
+      .filter((item: unknown): item is Record<string, unknown> => isRecord(item))
+      .map(parseConnectedAccountProvider);
+  }
+
+  async start_connected_account_oauth(input: {
+    provider_key: string;
+    redirect_uri: string;
+    scopes?: string[];
+    account_role?: string;
+  }): Promise<ConnectedAccountOAuthStart> {
+    const body: Record<string, unknown> = {
+      provider_key: input.provider_key,
+      redirect_uri: input.redirect_uri,
+    };
+    if (input.scopes !== undefined) body.scopes = input.scopes;
+    if (input.account_role !== undefined) body.account_role = input.account_role;
+    const [data] = await this.request("POST", "/me/connected-accounts/oauth/authorize", {
+      json_body: body,
+    });
+    return {
+      authorize_url: String(data.authorize_url ?? ""),
+      state: String(data.state ?? ""),
+      provider_key: String(data.provider_key ?? input.provider_key),
+      scopes: Array.isArray(data.scopes)
+        ? data.scopes.filter((s: unknown): s is string => typeof s === "string")
+        : [],
+      pkce_method: stringOrNull(data.pkce_method),
+    };
+  }
+
+  async complete_connected_account_oauth(input: { state: string; code: string }): Promise<Record<string, unknown>> {
+    const [data] = await this.request("POST", "/me/connected-accounts/oauth/callback", {
+      json_body: { state: input.state, code: input.code },
+    });
+    return { ...data };
+  }
+
+  async refresh_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult> {
+    const [data] = await this.request("POST", `/me/connected-accounts/${account_id}/refresh`);
+    return parseConnectedAccountLifecycle(data);
+  }
+
+  async revoke_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult> {
+    const [data] = await this.request("POST", `/me/connected-accounts/${account_id}/revoke`);
+    return parseConnectedAccountLifecycle(data);
+  }
+
+  // ----- end connected accounts --------------------------------------------
 
   async get_developer_portal(): Promise<DeveloperPortalSummary> {
     const [data, meta] = await this.request("GET", "/market/developer/portal");

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -283,6 +283,37 @@ export interface AppListingRecord {
   raw: Record<string, unknown>;
 }
 
+export interface ConnectedAccountProvider {
+  provider_key: string;
+  display_name: string;
+  auth_type: string;
+  refresh_supported: boolean;
+  pkce_required: boolean;
+  default_scopes: string[];
+  available_scopes: string[];
+  scope_separator: string;
+  notes?: string | null;
+}
+
+export interface ConnectedAccountOAuthStart {
+  authorize_url: string;
+  state: string;
+  provider_key: string;
+  scopes: string[];
+  pkce_method?: string | null;
+}
+
+export interface ConnectedAccountLifecycleResult {
+  connected_account_id: string;
+  provider_key: string;
+  expires_at?: string | null;
+  scopes: string[];
+  refreshed_at?: string | null;
+  connection_status?: string | null;
+  provider_revoked?: boolean | null;
+  revoked_at?: string | null;
+}
+
 export interface BundleMember {
   capability_listing_id: string;
   capability_key?: string | null;

--- a/siglume-api-sdk-ts/test/connected-accounts.test.ts
+++ b/siglume-api-sdk-ts/test/connected-accounts.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { SiglumeClient } from "../src/index";
+
+function buildClient(handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  return new SiglumeClient({
+    api_key: "sig_test",
+    base_url: "https://api.example.test/v1",
+    fetch: handler,
+  });
+}
+
+function envelope(data: unknown) {
+  return { data, meta: { request_id: "req", trace_id: "trc" }, error: null };
+}
+
+describe("Connected accounts SDK wrap (v0.7 track 3)", () => {
+  it("lists providers from the registry endpoint", async () => {
+    const calls: string[] = [];
+    const client = buildClient(async (input) => {
+      const url = new URL(String(typeof input === "string" ? input : input instanceof URL ? input : input.url));
+      calls.push(url.pathname);
+      return new Response(
+        JSON.stringify(
+          envelope({
+            items: [
+              {
+                provider_key: "slack",
+                display_name: "Slack",
+                auth_type: "oauth2",
+                refresh_supported: true,
+                pkce_required: false,
+                default_scopes: ["chat:write"],
+                available_scopes: ["chat:write", "channels:read"],
+                scope_separator: ",",
+              },
+            ],
+          }),
+        ),
+        { status: 200 },
+      );
+    });
+    const providers = await client.list_connected_account_providers();
+    client.close();
+    expect(calls[0]).toBe("/v1/me/connected-accounts/providers");
+    expect(providers).toHaveLength(1);
+    expect(providers[0].provider_key).toBe("slack");
+    expect(providers[0].refresh_supported).toBe(true);
+  });
+
+  it("starts OAuth and never sends client_secret in the body", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    const client = buildClient(async (input, init) => {
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify(
+          envelope({
+            authorize_url: "https://slack.com/oauth/v2/authorize?...",
+            state: "s-abc",
+            provider_key: "slack",
+            scopes: ["chat:write"],
+            pkce_method: null,
+          }),
+        ),
+        { status: 201 },
+      );
+    });
+    const result = await client.start_connected_account_oauth({
+      provider_key: "slack",
+      redirect_uri: "https://siglume.example/cb",
+      scopes: ["chat:write"],
+    });
+    client.close();
+    expect(result.state).toBe("s-abc");
+    expect(capturedBody.client_secret).toBeUndefined();
+    expect(capturedBody.client_id).toBeUndefined();
+  });
+
+  it("completes OAuth with state + code", async () => {
+    let path = "";
+    let body: Record<string, unknown> = {};
+    const client = buildClient(async (input, init) => {
+      path = new URL(String(typeof input === "string" ? input : input instanceof URL ? input : input.url)).pathname;
+      body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify(
+          envelope({
+            connected_account_id: "ca-001",
+            provider_key: "slack",
+            connection_status: "connected",
+            scopes: ["chat:write"],
+          }),
+        ),
+        { status: 200 },
+      );
+    });
+    const result = await client.complete_connected_account_oauth({ state: "s", code: "c" });
+    client.close();
+    expect(path).toBe("/v1/me/connected-accounts/oauth/callback");
+    expect(body).toEqual({ state: "s", code: "c" });
+    expect(result.connected_account_id).toBe("ca-001");
+  });
+
+  it("refresh + revoke return typed lifecycle results", async () => {
+    const paths: string[] = [];
+    const client = buildClient(async (input) => {
+      const url = new URL(String(typeof input === "string" ? input : input instanceof URL ? input : input.url));
+      paths.push(url.pathname);
+      if (url.pathname.endsWith("/refresh")) {
+        return new Response(
+          JSON.stringify(
+            envelope({
+              connected_account_id: "ca-001",
+              provider_key: "slack",
+              expires_at: "2026-04-21T01:00:00Z",
+              scopes: ["chat:write"],
+              refreshed_at: "2026-04-21T00:00:00Z",
+            }),
+          ),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify(
+          envelope({
+            connected_account_id: "ca-001",
+            provider_key: "slack",
+            connection_status: "revoked",
+            provider_revoked: true,
+            revoked_at: "2026-04-21T00:00:00Z",
+          }),
+        ),
+        { status: 200 },
+      );
+    });
+    const refreshed = await client.refresh_connected_account("ca-001");
+    const revoked = await client.revoke_connected_account("ca-001");
+    client.close();
+    expect(paths).toEqual([
+      "/v1/me/connected-accounts/ca-001/refresh",
+      "/v1/me/connected-accounts/ca-001/revoke",
+    ]);
+    expect(refreshed.expires_at).toBe("2026-04-21T01:00:00Z");
+    expect(revoked.connection_status).toBe("revoked");
+    expect(revoked.provider_revoked).toBe(true);
+  });
+
+  it("does not expose resolve on the wire (regression)", () => {
+    const client = new SiglumeClient({
+      api_key: "x",
+      base_url: "https://x/v1",
+    });
+    expect((client as unknown as Record<string, unknown>).resolve_connected_account).toBeUndefined();
+    client.close();
+  });
+});


### PR DESCRIPTION
Mirrors the Python wrap (PR #151). Closes the TS parity gap identified in the launch-readiness roadmap.