### PR TITLE
feat(v0.7.1): seller-owned OAuth — SDK responsibility correction

### DIFF
--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -205,11 +205,21 @@ export interface SiglumeClientShape {
   // Connected accounts (v0.7 track 3)
   list_connected_account_providers(): Promise<ConnectedAccountProvider[]>;
   start_connected_account_oauth(input: {
-    provider_key: string;
+    listing_id: string;
     redirect_uri: string;
     scopes?: string[];
     account_role?: string;
   }): Promise<ConnectedAccountOAuthStart>;
+  set_listing_oauth_credentials(
+    listing_id: string,
+    input: {
+      provider_key: string;
+      client_id: string;
+      client_secret: string;
+      required_scopes?: string[];
+    },
+  ): Promise<Record<string, unknown>>;
+  get_listing_oauth_credentials_status(listing_id: string): Promise<Record<string, unknown>>;
   complete_connected_account_oauth(input: { state: string; code: string }): Promise<Record<string, unknown>>;
   refresh_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult>;
   revoke_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult>;
@@ -2377,13 +2387,13 @@ export class SiglumeClient implements SiglumeClientShape {
   }
 
   async start_connected_account_oauth(input: {
-    provider_key: string;
+    listing_id: string;
     redirect_uri: string;
     scopes?: string[];
     account_role?: string;
   }): Promise<ConnectedAccountOAuthStart> {
     const body: Record<string, unknown> = {
-      provider_key: input.provider_key,
+      listing_id: input.listing_id,
       redirect_uri: input.redirect_uri,
     };
     if (input.scopes !== undefined) body.scopes = input.scopes;
@@ -2394,7 +2404,7 @@ export class SiglumeClient implements SiglumeClientShape {
     return {
       authorize_url: String(data.authorize_url ?? ""),
       state: String(data.state ?? ""),
-      provider_key: String(data.provider_key ?? input.provider_key),
+      provider_key: String(data.provider_key ?? ""),
       scopes: Array.isArray(data.scopes)
         ? data.scopes.filter((s: unknown): s is string => typeof s === "string")
         : [],
@@ -2417,6 +2427,32 @@ export class SiglumeClient implements SiglumeClientShape {
   async revoke_connected_account(account_id: string): Promise<ConnectedAccountLifecycleResult> {
     const [data] = await this.request("POST", `/me/connected-accounts/${account_id}/revoke`);
     return parseConnectedAccountLifecycle(data);
+  }
+
+  async set_listing_oauth_credentials(
+    listing_id: string,
+    input: {
+      provider_key: string;
+      client_id: string;
+      client_secret: string;
+      required_scopes?: string[];
+    },
+  ): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {
+      provider_key: input.provider_key,
+      client_id: input.client_id,
+      client_secret: input.client_secret,
+    };
+    if (input.required_scopes !== undefined) body.required_scopes = input.required_scopes;
+    const [data] = await this.request("PUT", `/market/capabilities/${listing_id}/oauth-credentials`, {
+      json_body: body,
+    });
+    return { ...data };
+  }
+
+  async get_listing_oauth_credentials_status(listing_id: string): Promise<Record<string, unknown>> {
+    const [data] = await this.request("GET", `/market/capabilities/${listing_id}/oauth-credentials`);
+    return { ...data };
   }
 
   // ----- end connected accounts --------------------------------------------

--- a/siglume-api-sdk-ts/test/connected-accounts.test.ts
+++ b/siglume-api-sdk-ts/test/connected-accounts.test.ts
@@ -44,8 +44,8 @@ describe("Connected accounts SDK wrap (v0.7 track 3)", () => {
     client.close();
     expect(calls[0]).toBe("/v1/me/connected-accounts/providers");
     expect(providers).toHaveLength(1);
-    expect(providers[0].provider_key).toBe("slack");
-    expect(providers[0].refresh_supported).toBe(true);
+    expect(providers[0]!.provider_key).toBe("slack");
+    expect(providers[0]!.refresh_supported).toBe(true);
   });
 
   it("starts OAuth and never sends client_secret in the body", async () => {
@@ -66,7 +66,7 @@ describe("Connected accounts SDK wrap (v0.7 track 3)", () => {
       );
     });
     const result = await client.start_connected_account_oauth({
-      provider_key: "slack",
+      listing_id: "lst_abc",
       redirect_uri: "https://siglume.example/cb",
       scopes: ["chat:write"],
     });

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3185,18 +3185,21 @@ class SiglumeClient:
     def start_connected_account_oauth(
         self,
         *,
-        provider_key: str,
+        listing_id: str,
         redirect_uri: str,
         scopes: list[str] | None = None,
         account_role: str | None = None,
     ) -> ConnectedAccountOAuthStart:
-        """Begin the OAuth dance. Point the owner's browser at the
-        returned ``authorize_url`` and expect the provider to redirect
-        back to ``redirect_uri`` with ``code`` + ``state`` query
-        params. Those values are passed to
-        ``complete_connected_account_oauth``."""
+        """Begin the OAuth dance for a specific listing.
+
+        v0.7.1 responsibility-correction: OAuth client credentials
+        live on the LISTING (the seller registered their own app
+        with the provider). The SDK caller passes the ``listing_id``
+        they're connecting for; the platform resolves the provider
+        + client credentials from that listing.
+        """
         body: dict[str, Any] = {
-            "provider_key": provider_key,
+            "listing_id": listing_id,
             "redirect_uri": redirect_uri,
         }
         if scopes is not None:
@@ -3240,6 +3243,41 @@ class SiglumeClient:
             "POST", f"/me/connected-accounts/{account_id}/revoke",
         )
         return _parse_connected_account_lifecycle(data)
+
+    def set_listing_oauth_credentials(
+        self,
+        listing_id: str,
+        *,
+        provider_key: str,
+        client_id: str,
+        client_secret: str,
+        required_scopes: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Seller-side: register the OAuth client credentials for
+        your listing. v0.7.1 responsibility-correction — the seller
+        is the OAuth party, not the platform. ``client_secret`` is
+        stored encrypted server-side and is never returned on reads.
+        """
+        body: dict[str, Any] = {
+            "provider_key": provider_key,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+        if required_scopes is not None:
+            body["required_scopes"] = list(required_scopes)
+        data, _meta = self._request(
+            "PUT", f"/market/capabilities/{listing_id}/oauth-credentials",
+            json_body=body,
+        )
+        return dict(data)
+
+    def get_listing_oauth_credentials_status(self, listing_id: str) -> dict[str, Any]:
+        """Read-only: is OAuth configured on this listing? Never
+        returns the secret values themselves."""
+        data, _meta = self._request(
+            "GET", f"/market/capabilities/{listing_id}/oauth-credentials",
+        )
+        return dict(data)
 
     # ----- end connected accounts ----------------------------------------
 

--- a/tests/test_connected_accounts_client.py
+++ b/tests/test_connected_accounts_client.py
@@ -62,7 +62,7 @@ def test_list_providers_parses_registry() -> None:
     assert providers[1].pkce_required is True
 
 
-def test_start_oauth_posts_and_returns_authorize_url() -> None:
+def test_start_oauth_posts_listing_id_and_returns_authorize_url() -> None:
     captured: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -70,7 +70,7 @@ def test_start_oauth_posts_and_returns_authorize_url() -> None:
         captured["path"] = request.url.path
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(201, json=envelope({
-            "authorize_url": "https://slack.com/oauth/v2/authorize?state=s&client_id=...",
+            "authorize_url": "https://slack.com/oauth/v2/authorize?state=s&client_id=sato-cid",
             "state": "s-abc",
             "provider_key": "slack",
             "scopes": ["chat:write"],
@@ -78,7 +78,7 @@ def test_start_oauth_posts_and_returns_authorize_url() -> None:
         }))
 
     start = _build(handler).start_connected_account_oauth(
-        provider_key="slack",
+        listing_id="lst_abc",
         redirect_uri="https://siglume.example/cb",
         scopes=["chat:write"],
         account_role="bot",
@@ -86,17 +86,18 @@ def test_start_oauth_posts_and_returns_authorize_url() -> None:
     assert captured["method"] == "POST"
     assert captured["path"] == "/v1/me/connected-accounts/oauth/authorize"
     body = captured["body"]
-    assert body["provider_key"] == "slack"
+    # Responsibility-correction: callers pass listing_id, not provider_key.
+    # Platform derives provider_key from the listing's seller-registered creds.
+    assert body["listing_id"] == "lst_abc"
+    assert "provider_key" not in body
     assert body["scopes"] == ["chat:write"]
-    assert body["account_role"] == "bot"
     assert isinstance(start, ConnectedAccountOAuthStart)
     assert start.state == "s-abc"
 
 
 def test_start_oauth_never_sends_client_secret() -> None:
-    """Regression: the SDK must not surface client_secret in its API.
-    Client secrets are server-side credentials and belong in platform
-    settings, not in SDK call sites."""
+    """Regression: client_secret is a server-side credential and
+    must never appear in SDK request bodies."""
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content.decode("utf-8"))
         assert "client_secret" not in body
@@ -108,9 +109,50 @@ def test_start_oauth_never_sends_client_secret() -> None:
         }))
 
     _build(handler).start_connected_account_oauth(
-        provider_key="slack",
+        listing_id="lst_abc",
         redirect_uri="https://siglume.example/cb",
     )
+
+
+def test_seller_can_set_and_read_listing_oauth_credentials() -> None:
+    """Seller registers their Slack app credentials against their
+    listing. The read path never returns the secret."""
+    calls: list[tuple[str, str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        calls.append((request.method, request.url.path, body))
+        if request.method == "PUT":
+            return httpx.Response(200, json=envelope({
+                "listing_id": "lst_abc",
+                "provider_key": "slack",
+                "required_scopes": ["chat:write"],
+                "configured": True,
+            }))
+        return httpx.Response(200, json=envelope({
+            "listing_id": "lst_abc",
+            "provider_key": "slack",
+            "configured": True,
+            "required_scopes": ["chat:write"],
+        }))
+
+    client = _build(handler)
+    result = client.set_listing_oauth_credentials(
+        "lst_abc",
+        provider_key="slack",
+        client_id="sato-cid",
+        client_secret="sato-secret",
+        required_scopes=["chat:write"],
+    )
+    assert result["configured"] is True
+    assert calls[0][0] == "PUT"
+    assert calls[0][1] == "/v1/market/capabilities/lst_abc/oauth-credentials"
+    assert calls[0][2]["client_secret"] == "sato-secret"
+
+    status = client.get_listing_oauth_credentials_status("lst_abc")
+    assert status["configured"] is True
+    assert "client_secret" not in status
+    assert "client_id" not in status
 
 
 def test_complete_oauth_returns_account_summary() -> None:


### PR DESCRIPTION
Mirror of platform PR #143. Breaks v0.7.0 start_oauth signature (provider_key → listing_id). Requires platform PR #143 deployed.