### PR TITLE
[codex] fix(connected-accounts): harden OAuth flow and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,25 @@ jobs:
             exit 1
           fi
 
+      - name: Verify TS package version matches tag
+        env:
+          RESOLVED_TAG: ${{ steps.resolve.outputs.resolved-tag }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${RESOLVED_TAG#v}"
+          PACKAGE_VERSION=$(python - <<'PY'
+          import json
+          with open("siglume-api-sdk-ts/package.json", "r", encoding="utf-8") as fh:
+              print(json.load(fh)["version"])
+          PY
+          )
+          echo "Tag version:        $TAG_VERSION"
+          echo "package.json ver.:  $PACKAGE_VERSION"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match siglume-api-sdk-ts/package.json version '$PACKAGE_VERSION'"
+            exit 1
+          fi
+
       - name: Build sdist and wheel
         run: python -m build
 
@@ -194,6 +213,8 @@ jobs:
       url: https://www.npmjs.com/package/@siglume/api-sdk
     permissions:
       contents: read
+      # Required for `npm publish --provenance` on GitHub-hosted runners.
+      id-token: write
     steps:
       - name: Check out the tag
         uses: actions/checkout@v4

--- a/docs/connected-accounts.md
+++ b/docs/connected-accounts.md
@@ -1,12 +1,87 @@
 # Connected Accounts Guide
 
-Siglume APIs can depend on user-linked external accounts such as X, OpenAI, or MetaMask.
+Siglume APIs can depend on user-linked external accounts such as
+Slack, X, Google, Notion, OpenAI, or MetaMask.
+
+The SDK exposes two distinct concerns:
+
+1. Seller-side OAuth setup on the listing
+2. Buyer-side OAuth authorization for that listing
+
+Your API runtime never receives raw long-lived credentials.
 
 ## Design Rule
 
-Your API must never receive raw long-lived credentials directly.
+OAuth client credentials belong to the seller's listing, not to
+the platform. In v0.7.1 the buyer starts OAuth with a
+`listing_id`, and the platform resolves the provider plus the
+seller-registered `client_id` / `client_secret` from that
+listing.
 
-At runtime, Siglume provides an opaque `ConnectedAccountRef`:
+## Seller Setup
+
+After registering your OAuth app with the upstream provider,
+store those credentials against your listing:
+
+```python
+client.set_listing_oauth_credentials(
+    "lst_abc",
+    provider_key="slack",
+    client_id="1234567890.9876543210",
+    client_secret="sato-slack-app-secret",
+    required_scopes=["chat:write"],
+)
+
+status = client.get_listing_oauth_credentials_status("lst_abc")
+assert status["configured"] is True
+```
+
+`client_secret` is encrypted server-side and is never returned by
+the read path.
+
+## Buyer OAuth Flow
+
+The buyer starts OAuth for a specific listing:
+
+```python
+start = client.start_connected_account_oauth(
+    listing_id="lst_abc",
+    redirect_uri="https://siglume.example/owner/connected-accounts/callback",
+    scopes=["chat:write"],
+    account_role="bot",
+)
+# redirect the browser to start.authorize_url
+```
+
+When the provider redirects back with `code` + `state`, complete
+the connection:
+
+```python
+client.complete_connected_account_oauth(
+    state=start.state,
+    code=code_from_provider,
+)
+```
+
+Later, the owner surface can refresh or revoke the connected
+account without exposing the provider token:
+
+```python
+client.refresh_connected_account("ca_123")
+client.revoke_connected_account("ca_123")
+```
+
+## What To Declare In Your App
+
+List required providers in `required_connected_accounts`:
+
+```python
+required_connected_accounts=["slack", "openai"]
+```
+
+## What Your Runtime Receives
+
+At execution time, Siglume provides an opaque `ConnectedAccountRef`:
 
 ```python
 ConnectedAccountRef(
@@ -17,17 +92,7 @@ ConnectedAccountRef(
 )
 ```
 
-## What To Declare
-
-List required providers in `required_connected_accounts`:
-
-```python
-required_connected_accounts=["x-twitter", "openai"]
-```
-
-## What To Expect At Runtime
-
-- `provider_key` identifies the provider
+- `provider_key` identifies the provider family
 - `session_token` is short-lived and Siglume-managed
 - `scopes` describe what the owner granted
 - `environment` tells you whether the execution is sandbox or live
@@ -40,6 +105,7 @@ required_connected_accounts=["x-twitter", "openai"]
 ## Good Practices
 
 - Fail closed when a required provider is missing
-- Return a clear error message such as `"X account not connected"`
+- Return a clear error message such as `"Slack account not connected"`
 - Keep provider-specific logic behind small helper methods
 - Do not log session tokens
+- Expect OAuth to be listing-scoped: buyers may authorize the same provider separately for different sellers

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -978,6 +978,130 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConnectedAccountEnvelope'
 
+  /me/connected-accounts/providers:
+    get:
+      operationId: listConnectedAccountProviders
+      summary: List the connected-account provider registry
+      responses:
+        '200':
+          description: Provider registry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectedAccountProviderListEnvelope'
+
+  /me/connected-accounts/oauth/authorize:
+    post:
+      operationId: startConnectedAccountOAuth
+      summary: Begin the buyer OAuth flow for a specific listing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectedAccountOAuthAuthorizeRequest'
+      responses:
+        '201':
+          description: Authorization URL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectedAccountOAuthStartEnvelope'
+
+  /me/connected-accounts/oauth/callback:
+    post:
+      operationId: completeConnectedAccountOAuth
+      summary: Complete the buyer OAuth flow with provider callback params
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConnectedAccountOAuthCallbackRequest'
+      responses:
+        '200':
+          description: Connected-account lifecycle summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectedAccountLifecycleEnvelope'
+
+  /me/connected-accounts/{accountId}/refresh:
+    post:
+      operationId: refreshConnectedAccount
+      summary: Refresh a connected account without exposing provider tokens
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Refreshed connected-account lifecycle summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectedAccountLifecycleEnvelope'
+
+  /me/connected-accounts/{accountId}/revoke:
+    post:
+      operationId: revokeConnectedAccount
+      summary: Revoke a connected account and return lifecycle metadata
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Revoked connected-account lifecycle summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectedAccountLifecycleEnvelope'
+
+  /market/capabilities/{listingId}/oauth-credentials:
+    get:
+      operationId: getListingOAuthCredentialsStatus
+      summary: Read whether a listing has OAuth credentials configured
+      parameters:
+        - name: listingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Listing OAuth credential status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListingOAuthCredentialsStatusEnvelope'
+    put:
+      operationId: setListingOAuthCredentials
+      summary: Store seller-owned OAuth client credentials for a listing
+      parameters:
+        - name: listingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListingOAuthCredentialsRequest'
+      responses:
+        '200':
+          description: Listing OAuth credential status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListingOAuthCredentialsStatusEnvelope'
+
   /market/sandbox/sessions:
     post:
       operationId: createSandboxSession
@@ -1685,6 +1809,147 @@ components:
         metadata: { type: object }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+
+    ConnectedAccountProvider:
+      type: object
+      properties:
+        provider_key: { type: string }
+        display_name: { type: string }
+        auth_type: { type: string, default: oauth2 }
+        refresh_supported: { type: boolean, default: false }
+        pkce_required: { type: boolean, default: false }
+        default_scopes:
+          type: array
+          items: { type: string }
+        available_scopes:
+          type: array
+          items: { type: string }
+        scope_separator: { type: string, default: ' ' }
+        notes: { type: string, nullable: true }
+
+    ConnectedAccountProviderList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectedAccountProvider'
+
+    ConnectedAccountOAuthAuthorizeRequest:
+      type: object
+      required: [listing_id, redirect_uri]
+      properties:
+        listing_id: { type: string }
+        redirect_uri: { type: string, format: uri }
+        scopes:
+          type: array
+          items: { type: string }
+        account_role: { type: string, nullable: true }
+
+    ConnectedAccountOAuthStart:
+      type: object
+      properties:
+        authorize_url: { type: string, format: uri }
+        state: { type: string }
+        provider_key: { type: string }
+        scopes:
+          type: array
+          items: { type: string }
+        pkce_method: { type: string, nullable: true }
+
+    ConnectedAccountLifecycle:
+      type: object
+      properties:
+        connected_account_id: { type: string }
+        provider_key: { type: string }
+        expires_at: { type: string, format: date-time, nullable: true }
+        scopes:
+          type: array
+          items: { type: string }
+        refreshed_at: { type: string, format: date-time, nullable: true }
+        connection_status: { type: string, nullable: true }
+        provider_revoked: { type: boolean, nullable: true }
+        revoked_at: { type: string, format: date-time, nullable: true }
+
+    ConnectedAccountProviderListEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/ConnectedAccountProviderList'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    ConnectedAccountOAuthStartEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/ConnectedAccountOAuthStart'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    ConnectedAccountOAuthCallbackRequest:
+      type: object
+      required: [state, code]
+      properties:
+        state: { type: string }
+        code: { type: string }
+
+    ConnectedAccountLifecycleEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/ConnectedAccountLifecycle'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    ListingOAuthCredentialsRequest:
+      type: object
+      required: [provider_key, client_id, client_secret]
+      properties:
+        provider_key: { type: string }
+        client_id: { type: string }
+        client_secret: { type: string }
+        required_scopes:
+          type: array
+          items: { type: string }
+
+    ListingOAuthCredentialsStatus:
+      type: object
+      properties:
+        listing_id: { type: string }
+        provider_key: { type: string }
+        configured: { type: boolean }
+        required_scopes:
+          type: array
+          items: { type: string }
+
+    ListingOAuthCredentialsStatusEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/ListingOAuthCredentialsStatus'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
 
     ConnectedAccountPage:
       type: object

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3212,7 +3212,7 @@ class SiglumeClient:
         return ConnectedAccountOAuthStart(
             authorize_url=str(data.get("authorize_url") or ""),
             state=str(data.get("state") or ""),
-            provider_key=str(data.get("provider_key") or provider_key),
+            provider_key=str(data.get("provider_key") or ""),
             scopes=[str(s) for s in (data.get("scopes") or []) if isinstance(s, str)],
             pkce_method=_string_or_none(data.get("pkce_method")),
         )

--- a/tests/test_connected_accounts_client.py
+++ b/tests/test_connected_accounts_client.py
@@ -114,6 +114,27 @@ def test_start_oauth_never_sends_client_secret() -> None:
     )
 
 
+def test_start_oauth_tolerates_missing_provider_key_in_response() -> None:
+    """Regression: v0.7.1 switched the input to listing_id, so the
+    response parser must not reference the removed provider_key arg."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/me/connected-accounts/oauth/authorize"
+        return httpx.Response(201, json=envelope({
+            "authorize_url": "https://slack.com/oauth/v2/authorize",
+            "state": "s-abc",
+            "scopes": ["chat:write"],
+            "pkce_method": None,
+        }))
+
+    start = _build(handler).start_connected_account_oauth(
+        listing_id="lst_abc",
+        redirect_uri="https://siglume.example/cb",
+    )
+    assert start.state == "s-abc"
+    assert start.provider_key == ""
+
+
 def test_seller_can_set_and_read_listing_oauth_credentials() -> None:
     """Seller registers their Slack app credentials against their
     listing. The read path never returns the secret."""


### PR DESCRIPTION
## What changed
- fix the Python `start_connected_account_oauth(...)` parser so it no longer references the removed `provider_key` argument after the v0.7.1 `listing_id` migration
- add a regression test that proves the Python client tolerates OAuth authorize responses without `provider_key`
- harden the release workflow by checking the TypeScript package version against the pushed tag and by granting `id-token: write` to the npm provenance publish job
- update `docs/connected-accounts.md` to document the current seller-owned OAuth credential flow (`set_listing_oauth_credentials(...)` + listing-scoped buyer OAuth)
- extend `openapi/developer-surface.yaml` with the v0.7.1 connected-account OAuth endpoints and listing OAuth credential endpoints

## Why this changed
Two clear regressions were present on `main`:

1. The Python SDK still had a fallback reference to `provider_key` inside `start_connected_account_oauth(...)` even though the method signature was changed to `listing_id` in v0.7.1. That could raise `NameError` at runtime when the server response omitted `provider_key`.
2. The new npm publish workflow used `npm publish --provenance` without `id-token: write`, which npm provenance requires on GitHub-hosted runners.

Separately, the public connected-accounts docs and OpenAPI spec had drifted behind the v0.7.1 seller-owned OAuth flow.

## Validation
- `py -3.11 -m pytest tests/test_connected_accounts_client.py -q`
- `py -3.11 -m pytest tests/test_client.py -q`
- `npm test`
- YAML parse check for `.github/workflows/release.yml` and `openapi/developer-surface.yaml`