### PR TITLE
docs: clarify SDK entrypoints and publish path

### DIFF
--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -81,5 +81,5 @@ attract users over time.
 ## Resources
 
 - [Getting Started Guide](GETTING_STARTED.md) — build and publish in 15 minutes
-- [SDK Reference](siglume_api_sdk.py)
+- [SDK Core Concepts](docs/sdk-core-concepts.md)
 - [API Spec](openapi/developer-surface.yaml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,15 @@ source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -e .
 ```
 
+## Repository layout
+
+Treat `import siglume_api_sdk` as the canonical public entrypoint.
+
+- `siglume_api_sdk/` is the canonical package entrypoint and the home for new runtime surfaces such as `client`, `cli`, `buyer`, `webhooks`, and testing helpers.
+- `siglume_api_sdk.py` is the legacy compatibility layer that preserves the pre-package flat-module API and still carries some shared core contracts during the migration.
+- `siglume_api_sdk_aiworks.py` is a separate optional module for AIWorks-specific runtime types.
+- New docs and examples should point at the package entrypoint. If you move or refactor legacy-exported symbols, preserve `from siglume_api_sdk import ...` for downstream users.
+
 ## Dev Container (optional)
 
 This repository includes a `.devcontainer/` configuration.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -51,6 +51,15 @@ siglume validate .
 siglume test .
 ```
 
+For the shortest publish-ready loop, continue in the same project with:
+
+```bash
+siglume score . --remote
+siglume register . --confirm
+```
+
+`validate` and `test` are fully local. `score --remote` and `register --confirm` require `SIGLUME_API_KEY` plus a tool manual you are ready to submit; the full auth and confirmation flow is covered in [Section 11](#11-auto-register-list-your-api-with-your-ai) and [Section 13](#13-tool-manual-guide).
+
 Or clone the repo to browse the examples:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ Then continue with [Getting Started](GETTING_STARTED.md) (~15 min end-to-end: bu
 
 ---
 
+## Fast path to publish
+
+If you want the shortest copy-paste path from an empty directory to a publish-ready draft, start with the CLI scaffold:
+
+```bash
+mkdir hello-echo
+cd hello-echo
+pip install siglume-api-sdk
+siglume init --template echo
+siglume validate .
+siglume test .
+siglume score . --remote
+siglume register . --confirm
+```
+
+`validate` and `test` are fully local. `score --remote` and `register --confirm` require your Siglume developer API key (`SIGLUME_API_KEY`) plus a reviewed `tool_manual.json`; see [Getting Started](GETTING_STARTED.md) sections 11 and 13 for the full auth and confirmation flow.
+
+---
+
 ## What Siglume is
 
 Siglume runs two distinct commerce surfaces:
@@ -85,6 +104,17 @@ You do not submit a PR to this repo. You register directly on the platform — n
 
 - **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review, edit, and submit your listings after creation; new listings are always created through the `auto-register` endpoint — see [Getting Started §11](GETTING_STARTED.md#11-auto-register-list-your-api-with-your-ai))
 - **API Store buyer view** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
+
+---
+
+## Repository layout
+
+If you are using the SDK, treat `import siglume_api_sdk` as the canonical entrypoint.
+
+- `siglume_api_sdk/` is the canonical package entrypoint and the home for new runtime surfaces such as `client`, `cli`, `buyer`, `webhooks`, and the testing helpers.
+- `siglume_api_sdk.py` is a shipped compatibility layer for pre-package flat-module consumers and still holds some core contract definitions while the transition remains in progress.
+- New docs, examples, and imports should point at the package entrypoint. When you touch symbols that originated in the flat module, preserve the package-level `from siglume_api_sdk import ...` experience.
+- `siglume_api_sdk_aiworks.py` remains a separate optional module for AIWorks-specific execution context.
 
 ---
 
@@ -129,7 +159,9 @@ This is an early-stage service (v0.5.0, alpha) with a growing but still small us
 
 ---
 
-## Advanced SDK surfaces
+## Expanded platform SDK
+
+If your goal is to publish one API to the store, you can stop after the sections above. The surfaces below are optional platform-wide wrappers that sit beyond the core publish flow.
 
 Beyond the publishing flow, the SDK also ships typed wrappers for auxiliary platform surfaces. Import only the ones you need — each page below shows the full method signatures and realistic flows.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ Before cutting a version tag:
 - [ ] Version in `pyproject.toml` (`[project].version`) matches the tag you're about to cut
 - [ ] `RELEASE_NOTES_vX.Y.Z.md` exists at the repo root, written as the GitHub Release body (highlights, revenue model, quick start, what's next, honest note)
 - [ ] `examples/hello_price_compare.py` and `examples/x_publisher.py` still run end-to-end against `AppTestHarness`
-- [ ] `docs/` and `README.md` are coherent with the shipped `siglume_api_sdk.py` surface (no references to removed symbols)
+- [ ] `docs/` and `README.md` are coherent with the shipped `siglume_api_sdk` public surface (package entrypoint plus legacy compatibility exports; no references to removed symbols)
 - [ ] There is **no** stale `siglume_app_sdk` / `siglume-app-sdk` / `siglume-app-types` reference (`grep -rn` expects zero matches)
 
 ## Build artifacts


### PR DESCRIPTION
## Summary

This PR improves the SDK's first-read experience without changing runtime behavior.

- adds a top-level `Fast path to publish` section in `README.md` with the shortest scaffold -> validate -> test -> score -> register flow
- documents the repository layout in `README.md` and `CONTRIBUTING.md`, clarifying that `import siglume_api_sdk` is the canonical public entrypoint while `siglume_api_sdk.py` remains a legacy compatibility layer
- renames the advanced surface section in `README.md` to better separate the core publish SDK from the wider platform wrappers
- aligns `GETTING_STARTED.md` quick start with the publish-ready CLI flow
- updates `API_IDEAS.md` and `RELEASING.md` so internal references point at the public package surface rather than the flat module file

## Why

The repository already has strong runtime and CLI coverage, but first-time readers can still stumble on two things:

- the shortest path to a publish-ready draft is not obvious from the top of the README
- the coexistence of `siglume_api_sdk/` and `siglume_api_sdk.py` makes the canonical implementation entrypoint unclear for contributors

These doc changes reduce that confusion while keeping packaging and behavior unchanged.

## Validation

- reviewed the staged diff for the five touched docs
- ran `git diff --check`
- no code tests run because this is a docs-only change
