### PR TITLE
Release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-04-23
+
+v0.7.2 aligns the public SDK and developer docs with the production
+auto-register and runtime-validation contract enforced by the Siglume
+server.
+
+### Added
+
+- Complete paid Action API publishing example with subscription pricing,
+  ToolManual schemas, runtime validation, and Polygon payout preflight.
+- Runtime validation contract docs covering healthcheck, invoke method,
+  review auth header, sample request payload, and expected response fields.
+- CLI preflight checks that block registration when generated
+  `runtime_validation.json` placeholders or publisher identity fields are
+  still missing.
+
+### Changed
+
+- Python and TypeScript `auto_register()` payloads now include manifest,
+  ToolManual, publisher identity, runtime validation, validation report
+  parsing, and `legal.jurisdiction` aliases expected by the live server.
+- Example manifests now include `docs_url` and `support_contact` so
+  `siglume init` output is production-registration ready after runtime
+  placeholder replacement.
+
+### Fixed
+
+- `register_via_client.py` now demonstrates the full runtime validation
+  payload instead of calling production auto-register with an incomplete
+  request.
+- OpenAPI now documents the runtime validation and legal/publisher identity
+  fields that the server validates.
+
 ## [0.7.1] - 2026-04-21
 
 v0.7.1 is a responsibility-correction release over v0.7.0.

--- a/RELEASE_NOTES_v0.7.2.md
+++ b/RELEASE_NOTES_v0.7.2.md
@@ -1,0 +1,62 @@
+# siglume-api-sdk v0.7.2 - Production Auto-Register Alignment
+
+Released: 2026-04-23
+
+## TL;DR
+
+v0.7.2 makes the public SDK match the current Siglume server validation rules
+for production auto-register. It closes the gap that caused paid Action API
+registration to fail late with missing jurisdiction, publisher identity,
+runtime validation, and payout-readiness details.
+
+## Highlights
+
+- Python and TypeScript `auto_register()` now send the production payload shape:
+  manifest, ToolManual, publisher identity aliases, `legal.jurisdiction`,
+  runtime validation, and validation-report parsing.
+- `siglume register` now fails locally when generated runtime placeholders are
+  still present, including `https://api.example.com`, localhost URLs, missing
+  request payloads, missing expected response fields, or placeholder review
+  secrets.
+- The examples now include publisher identity fields by default, and
+  `examples/register_via_client.py` shows a complete runtime validation payload
+  sourced from explicit environment variables.
+- `GETTING_STARTED.md` and the OpenAPI schema now document the server-required
+  fields for paid Action API publishing, including Polygon payout preflight and
+  runtime invocation expectations.
+
+## Why this matters
+
+Developers should not have to discover hidden registration requirements one
+422 error at a time. This release moves the current production contract into
+the SDK, CLI, OpenAPI, and examples so the failure mode is local, specific, and
+actionable before Siglume calls the live runtime.
+
+## Quick Start
+
+```bash
+pip install --upgrade siglume-api-sdk==0.7.2
+```
+
+For TypeScript projects, use the package from the GitHub release or npm once
+the package is available:
+
+```bash
+npm install @siglume/api-sdk@0.7.2
+```
+
+## Validation
+
+- Python: `273 passed`
+- TypeScript: `310 passed`
+- `ruff check .`
+- `npm run typecheck`
+- OpenAPI YAML and JSON fixtures parse successfully
+- Main CI and Contract Sync are green for the auto-register alignment changes
+
+## Honest Note
+
+This release aligns the public SDK with the current server contract. If the
+server tightens production registration again, the SDK should treat the server
+as source of truth and move those checks into the local CLI/OpenAPI surface
+before users hit remote validation failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.7.1"
+version = "0.7.2"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.6.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.6.0",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Prepare siglume-api-sdk v0.7.2 release for the production auto-register/runtime-validation alignment.\n\nIncludes:\n- Python and TypeScript version bump to 0.7.2\n- CHANGELOG entry\n- RELEASE_NOTES_v0.7.2.md\n\nValidation already run locally:\n- Python pytest: 273 passed\n- TS vitest: 310 passed\n- ruff check .\n- npm run typecheck\n- Python build + twine check\n- npm run build and npm pack check