### PR TITLE
Fix final registration onboarding gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2026-04-23
+
+v0.7.4 tightens the last onboarding edge cases found after v0.7.3.
+
+### Changed
+
+- `siglume register` preflight now treats Tool Manual warning-severity issues
+  as advisory instead of fatal in both Python and TypeScript.
+- Getting Started now states that production `auto-register` must include the
+  Tool Manual; `confirm-auto-register` is no longer documented as the place to
+  first provide it.
+- Generated Python and TypeScript starter READMEs now tell developers to replace
+  `docs_url`, `support_contact`, runtime URLs, and review-key placeholders
+  before registration.
+- `siglume init --from-operation` generated manifests now include publisher
+  identity placeholders so the required fields are visible in the project.
+- OpenAPI wording now clarifies that `legal.jurisdiction` is a validation
+  report path, not an input namespace.
+
 ## [0.7.3] - 2026-04-23
 
 v0.7.3 closes the remaining production-facing review findings after the

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -330,18 +330,35 @@ asyncio.run(main())
 
 All checks must pass: manifest validation, health check, dry run succeeds.
 
-### Step 2: Register via auto-register
+### Step 2: Prepare the production registration contract
+
+Before any production registration call, make sure your project has the full
+contract the server validates:
+
+- `manifest` with `docs_url`, `support_contact`, and `jurisdiction`
+- `tool_manual` with `input_schema` and `output_schema`
+- `runtime_validation` with public healthcheck/invoke URLs, review auth, sample request payload, and expected response fields
+- `source_code` or `source_url`
+
+The easiest path is:
+
+```bash
+siglume validate .
+siglume test .
+siglume score . --remote
+```
+
+See [Section 11](#11-auto-register-list-your-api-with-your-ai) for the full payload shape.
+
+### Step 3: Register via auto-register and confirm
 
 The **only** way to create a new API listing is via the auto-register endpoint.
-There is no manual form or developer portal for listing creation.
+There is no manual form or developer portal for listing creation. Production
+`auto-register` must include `tool_manual`; do not wait until
+`confirm-auto-register` to provide it.
 
-See [Section 11](#11-auto-register-list-your-api-with-your-ai) for the full flow.
-
-### Step 3: Write your tool manual and confirm
-
-Include your tool manual in the `confirm-auto-register` call.
-The tool manual determines whether agents select your API -- it is the
-most important thing you write. See [Section 13](#13-tool-manual-guide).
+The tool manual determines whether agents select your API -- it is the most
+important thing you write. See [Section 13](#13-tool-manual-guide).
 
 A quality check runs automatically at confirmation time:
 - Grade B or above (A/B): your API proceeds to admin review

--- a/RELEASE_NOTES_v0.7.4.md
+++ b/RELEASE_NOTES_v0.7.4.md
@@ -1,0 +1,27 @@
+# Siglume API SDK v0.7.4
+
+This release fixes the final onboarding review findings after v0.7.3.
+
+## Highlights
+
+- Registration preflight now blocks only Tool Manual error-severity validation
+  issues. Warning-severity issues remain visible in the preflight report but do
+  not stop `siglume register`.
+- Getting Started no longer describes the old source-only registration flow.
+  The Tool Manual is documented as required at `auto-register` time.
+- Generated Python and TypeScript project READMEs now tell developers to replace
+  `docs_url`, `support_contact`, runtime URL, and review-key placeholders before
+  registering.
+- `siglume init --from-operation` generated manifests now include publisher
+  identity placeholders so required registration fields are visible immediately.
+- OpenAPI wording now makes clear that `legal.jurisdiction` is a validation
+  report path, not an accepted input location.
+
+## Validation
+
+- `py -3.11 -m pytest -q`
+- `py -3.11 -m ruff check .`
+- `npm run typecheck`
+- `npm run test -- --coverage.enabled=false`
+- `npm run build`
+- `npm run pack:check`

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -139,8 +139,8 @@ paths:
         should include `manifest`, `tool_manual`, `runtime_validation`,
         `docs_url`, `support_contact`, and `jurisdiction`.
 
-        The validation path `legal.jurisdiction` maps to the listing
-        jurisdiction, which may be supplied as top-level `jurisdiction` or
+        If jurisdiction is missing, validation reports `legal.jurisdiction`;
+        fix it by supplying top-level `jurisdiction` or
         `manifest.jurisdiction`. The validation path
         `legal.publisher_identity` maps to `docs_url` plus `support_contact`;
         those fields may be top-level, inside `manifest`, or supplied as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.7.3"
+version = "0.7.4"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "type": "module",

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -433,9 +433,10 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
   const manifestIssues = await projectValidationIssues(project);
   const [toolManualValid, toolManualIssues] = validate_tool_manual(project.tool_manual);
   const remoteQuality = await client.preview_quality_score(project.tool_manual);
+  const blockingToolManualIssues = toolManualIssues.filter((issue) => issue.severity === "error");
   const errors = [
     ...manifestIssues.map((issue) => String(issue)),
-    ...toolManualIssues.map((issue) => issue.message),
+    ...blockingToolManualIssues.map((issue) => issue.message),
   ];
   if (!toolManualValid) {
     errors.push("tool_manual.json is not valid for production registration");
@@ -765,6 +766,8 @@ function buildOperationManifest(
     price_model: PriceModel.FREE,
     jurisdiction: "US",
     short_description: operation.summary,
+    docs_url: "https://example.com/docs",
+    support_contact: "support@example.com",
     example_prompts: [`Run ${operation.operation_key} for my owned agent.`],
   };
 }
@@ -857,6 +860,8 @@ function operationAdapterSource(operation: OperationMetadata, manifest: AppManif
     "      price_model: PriceModel.FREE,",
     `      jurisdiction: ${JSON.stringify(manifest.jurisdiction)},`,
     `      short_description: ${JSON.stringify(manifest.short_description ?? "")},`,
+    `      support_contact: ${JSON.stringify(manifest.support_contact ?? "")},`,
+    `      docs_url: ${JSON.stringify(manifest.docs_url ?? "")},`,
     `      example_prompts: ${examplePrompts},`,
     "    };",
     "  }",
@@ -1038,14 +1043,17 @@ function operationReadmeTemplate(
     "- `runtime_validation.json`: public endpoint and review-key checks used by auto-register",
     "- `tests/test_adapter.ts`: smoke test for `AppTestHarness`",
     "",
-    "Before registering, edit `runtime_validation.json` and replace the generated public URL and review-key placeholders.",
+    "Before registering, replace all generated placeholders:",
+    "- In `adapter.ts` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
+    "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
     "",
     "## Commands",
     "",
     "```bash",
     "siglume validate .",
     "siglume test .",
-    "siglume register .",
+    "siglume score . --remote",
+    "siglume register . --confirm",
     "npm test -- tests/test_adapter.ts",
     "```",
     "",
@@ -1537,14 +1545,16 @@ function readmeTemplate(template: TemplateName): string {
     "- `tool_manual.json`: editable ToolManual draft for validation and registration",
     "- `runtime_validation.json`: live API smoke-test contract used during registration",
     "",
-    "Before registering, edit `runtime_validation.json` and replace the generated public URL and review-key placeholders.",
+    "Before registering, replace all generated placeholders:",
+    "- In `adapter.ts` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
+    "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
     "",
     "Suggested workflow:",
     "",
     "```bash",
     "siglume validate .",
     "siglume test .",
-    "siglume score . --offline",
+    "siglume score . --remote",
     "siglume register . --confirm",
     "```",
     "",

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -419,7 +419,15 @@ describe("siglume CLI", () => {
     expect((listPayload.operations as Array<Record<string, unknown>>)[0]?.operation_key).toBe("owner.charter.update");
     expect(initPayload.mode).toBe("from-operation");
     expect((initPayload.operation as Record<string, unknown>).operation_key).toBe("owner.charter.update");
-    expect(await readFile(join(projectDir, "adapter.ts"), "utf8")).toContain("execute_owner_operation");
+    const manifest = JSON.parse(await readFile(join(projectDir, "manifest.json"), "utf8")) as Record<string, unknown>;
+    const adapterText = await readFile(join(projectDir, "adapter.ts"), "utf8");
+    const readmeText = await readFile(join(projectDir, "README.md"), "utf8");
+    expect(manifest.docs_url).toBe("https://example.com/docs");
+    expect(manifest.support_contact).toBe("support@example.com");
+    expect(adapterText).toContain("execute_owner_operation");
+    expect(adapterText).toContain("support_contact: \"support@example.com\"");
+    expect(adapterText).toContain("docs_url: \"https://example.com/docs\"");
+    expect(readmeText).toContain("replace `docs_url` and `support_contact`");
     expect(await readFile(join(projectDir, "tool_manual.json"), "utf8")).toContain("\"owner_charter_update\"");
     expect(await readFile(join(projectDir, "runtime_validation.json"), "utf8")).toContain("\"expected_response_fields\"");
   });

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -312,6 +312,38 @@ describe("cli project helpers", () => {
     expect(autoRegisterCalled).toBe(false);
   });
 
+  it("allows Tool Manual warnings during registration preflight", async () => {
+    const toolManual = manualBase();
+    (toolManual.input_schema.properties as Record<string, unknown>).trace_id = {
+      type: "string",
+      description: "Platform-injected trace identifier.",
+    };
+    const projectDir = await createObjectProject({ toolManual });
+    let autoRegisterCalled = false;
+
+    const report = await runRegistration(
+      projectDir,
+      {},
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async preview_quality_score() {
+              return publishableQualityReport();
+            },
+            async auto_register() {
+              autoRegisterCalled = true;
+              return { listing_id: "lst_warning", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    expect((report.receipt as { listing_id: string }).listing_id).toBe("lst_warning");
+    expect((report.registration_preflight as { ok: boolean }).ok).toBe(true);
+    expect(autoRegisterCalled).toBe(true);
+  });
+
   it("covers registration, support, and usage helper branches", async () => {
     const projectDir = await createObjectProject();
     const usageCapture = { api_key: undefined as string | undefined, usage_calls: 0 };

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -512,6 +512,8 @@ def build_operation_manifest(
         price_model=PriceModel.FREE,
         jurisdiction="US",
         short_description=operation.summary,
+        docs_url="https://example.com/docs",
+        support_contact="support@example.com",
         example_prompts=[f"Run {operation.operation_key} for my owned agent."],
     )
 
@@ -638,6 +640,8 @@ def _operation_adapter_source(operation: OperationMetadata, manifest: AppManifes
                     price_model=PriceModel.FREE,
                     jurisdiction="{manifest.jurisdiction}",
                     short_description="{manifest.short_description}",
+                    support_contact="{manifest.support_contact}",
+                    docs_url="{manifest.docs_url}",
                     example_prompts={json.dumps(list(manifest.example_prompts or []))},
                 )
 
@@ -830,14 +834,17 @@ def _operation_readme_template(operation: OperationMetadata, manifest: AppManife
             "- `runtime_validation.json`: public endpoint and review-key checks used by auto-register",
             "- `tests/test_adapter.py`: smoke test for `AppTestHarness`",
             "",
-            "Before registering, edit `runtime_validation.json` and replace the generated public URL and review-key placeholders.",
+            "Before registering, replace all generated placeholders:",
+            "- In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
+            "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
             "",
             "## Commands",
             "",
             "```bash",
             "siglume validate .",
             "siglume test .",
-            "siglume register .",
+            "siglume score . --remote",
+            "siglume register . --confirm",
             "pytest tests/test_adapter.py",
             "```",
             "",
@@ -1145,7 +1152,12 @@ def _registration_preflight(project: LoadedProject, client: SiglumeClient) -> di
     remote_quality = client.preview_quality_score(project.tool_manual)
     errors: list[str] = []
     errors.extend(str(issue) for issue in manifest_issues)
-    errors.extend(str(issue.message) for issue in manual_issues)
+    blocking_manual_issues = [
+        issue
+        for issue in manual_issues
+        if str(getattr(issue, "severity", "error") or "error").lower() == "error"
+    ]
+    errors.extend(str(issue.message) for issue in blocking_manual_issues)
     if not manual_valid:
         errors.append("tool_manual.json is not valid for production registration")
     if not _remote_quality_ok(remote_quality):
@@ -1522,7 +1534,9 @@ def _readme_template(template: str) -> str:
         - `tool_manual.json`: editable ToolManual draft for validation and registration
         - `runtime_validation.json`: live API smoke-test contract used during registration
 
-        Before registering, edit `runtime_validation.json` and replace the generated public URL and review-key placeholders.
+        Before registering, replace all generated placeholders:
+        - In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.
+        - In `runtime_validation.json`, replace the public URL and review-key placeholders.
 
         Suggested workflow:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,57 @@ def test_register_blocks_non_publishable_remote_quality(monkeypatch, tmp_path) -
     assert FakeClient.auto_register_called is False
 
 
+def test_register_preflight_allows_tool_manual_warnings(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "warning-allowed"
+    _write_register_project(project_dir)
+    manual = json.loads((project_dir / "tool_manual.json").read_text(encoding="utf-8"))
+    manual["input_schema"]["properties"]["trace_id"] = {
+        "type": "string",
+        "description": "Platform-injected trace identifier.",
+    }
+    (project_dir / "tool_manual.json").write_text(json.dumps(manual), encoding="utf-8")
+
+    class FakeClient:
+        auto_register_called = False
+
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def preview_quality_score(self, manual):
+            from siglume_api_sdk import ToolManualQualityReport
+
+            return ToolManualQualityReport(
+                overall_score=90,
+                grade="A",
+                issues=[],
+                keyword_coverage_estimate=70,
+                improvement_suggestions=[],
+                publishable=True,
+                validation_ok=True,
+            )
+
+        def auto_register(self, manifest, tool_manual, **kwargs):
+            FakeClient.auto_register_called = True
+            return SimpleNamespace(listing_id="lst_warning", status="draft")
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+    monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
+
+    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"listing_id": "lst_warning"' in result.output
+    assert '"registration_preflight"' in result.output
+    assert FakeClient.auto_register_called is True
+
+
 def test_register_human_output_includes_review_and_trace_metadata(monkeypatch, tmp_path) -> None:
     runner = CliRunner()
     project_dir = tmp_path / "human-output"
@@ -357,11 +408,19 @@ def test_init_command_generates_operation_wrapper_with_grade_b_or_better(monkeyp
         assert Path("stubs.py").exists()
         assert Path("runtime_validation.json").exists()
         assert Path("tests/test_adapter.py").exists()
+        manifest = json.loads(Path("manifest.json").read_text(encoding="utf-8"))
+        assert manifest["docs_url"] == "https://example.com/docs"
+        assert manifest["support_contact"] == "support@example.com"
         manual = json.loads(Path("tool_manual.json").read_text(encoding="utf-8"))
         valid, issues = validate_tool_manual(manual)
         assert valid, issues
         assert payload["report"]["quality"]["grade"] in {"A", "B"}
-        assert "execute_owner_operation" in Path("adapter.py").read_text(encoding="utf-8")
+        adapter_text = Path("adapter.py").read_text(encoding="utf-8")
+        readme_text = Path("README.md").read_text(encoding="utf-8")
+        assert "execute_owner_operation" in adapter_text
+        assert 'support_contact="support@example.com"' in adapter_text
+        assert 'docs_url="https://example.com/docs"' in adapter_text
+        assert "replace `docs_url` and `support_contact`" in readme_text
 
 
 def test_build_tool_manual_template_tolerates_missing_job_to_be_done() -> None:


### PR DESCRIPTION
## Summary
- Require the current production contract in Getting Started by documenting Tool Manual at auto-register time, not first during confirm.
- Add docs_url/support_contact placeholders and README replacement guidance to Python/TypeScript generated projects, including --from-operation output.
- Treat Tool Manual warning-severity issues as advisory in Python/TypeScript register preflight, while keeping error issues blocking.
- Clarify OpenAPI wording that legal.jurisdiction is a validation report path, not an input namespace.

## Validation
- py -3.11 -m pytest -q
- py -3.11 -m ruff check .
- npm run typecheck
- npm run test -- --coverage.enabled=false
- npm run build
- npm run pack:check
- py -3.11 -m build
- py -3.11 -m twine check dist/siglume_api_sdk-0.7.4*
- git diff --check