### PR TITLE
Fix npm provenance and onboarding docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Check for NPM_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5] - 2026-04-23
+
+v0.7.5 fixes npm provenance publishing for the TypeScript SDK and tightens the
+last onboarding docs gaps.
+
+### Changed
+
+- TypeScript package metadata now declares the GitHub repository so npm can
+  verify `npm publish --provenance` against the GitHub Actions source.
+- The release workflow now uses Node.js 24 for npm publishing.
+- Quick Start now starts with a local-only loop, then explicitly introduces
+  `SIGLUME_API_KEY` before server-aligned validation.
+- Publishing docs now present `siglume register . --confirm` as the standard
+  SDK route and raw HTTP as the automation route.
+- Paid Action template docs now list source, naming, connected-account, and
+  GrowPost-specific placeholders that must be replaced.
+- Confirm-auto-register docs now frame Tool Manual overrides as post-draft
+  corrections only.
+
 ## [0.7.4] - 2026-04-23
 
 v0.7.4 tightens the last onboarding edge cases found after v0.7.3.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -38,6 +38,7 @@ You build APIs by subclassing `AppAdapter`. The SDK handles manifest validation,
 
 - Python 3.11+
 - pip
+- A Siglume API key for server-aligned validation and registration
 
 ### Install and run
 
@@ -45,17 +46,23 @@ You build APIs by subclassing `AppAdapter`. The SDK handles manifest validation,
 # Install from PyPI
 pip install siglume-api-sdk
 
-# Generate a starter and validate it
+# Generate a starter and run the local loop
 siglume init --template price-compare
-siglume validate .
 siglume test .
+siglume score . --offline
 ```
 
-When you are ready to publish, edit the generated `tool_manual.json`,
-`runtime_validation.json`, and manifest publisher fields, then run the same
-production path the server will enforce:
+When you are ready to use server-aligned validation, export your API key and
+run the same production path the server will enforce:
 
 ```bash
+export SIGLUME_API_KEY="sig_..."   # macOS / Linux
+# or on Windows PowerShell:
+$env:SIGLUME_API_KEY = "sig_..."
+
+# First replace placeholders in tool_manual.json, runtime_validation.json,
+# and the manifest publisher fields.
+siglume validate .
 siglume score . --remote
 siglume register . --confirm
 ```
@@ -79,12 +86,16 @@ python examples/hello_price_compare.py
 
 ```
 my-awesome-app/
-├── my_app.py          # Your API (subclasses AppAdapter)
-├── stubs.py           # Mock external APIs for testing
-├── tests/
-│   └── test_app.py    # Tests
-└── requirements.txt
+├── adapter.py              # Your AppAdapter implementation
+├── manifest.json           # AppManifest snapshot, including publisher identity
+├── tool_manual.json        # Agent-facing Tool Manual used at registration time
+├── runtime_validation.json # Public HTTP validation contract
+└── README.md               # Generated next steps for this project
 ```
+
+`siglume init --from-operation ...` also generates `stubs.py` and
+`tests/test_adapter.py` / `tests/test_adapter.ts` for the operation-wrapper
+route.
 
 ---
 
@@ -301,9 +312,9 @@ Does your API write to anything external?
 
 ```
 1. Build and test locally (AppTestHarness)
-2. Register via auto-register endpoint
-3. Write your tool manual (CRITICAL - see Section 13)
-4. Confirm with tool manual - quality check runs automatically
+2. Write your Tool Manual and runtime validation contract
+3. Validate with the same server checks used by production registration
+4. Register with `siglume register . --confirm`
 5. Admin reviews (3-5 business days)
 6. Published to the API Store
 ```
@@ -343,19 +354,31 @@ contract the server validates:
 The easiest path is:
 
 ```bash
-siglume validate .
 siglume test .
+siglume validate .
 siglume score . --remote
 ```
 
+`siglume validate .` and `siglume score . --remote` require
+`SIGLUME_API_KEY`; use `siglume test .` and `siglume score . --offline` for a
+local-only loop before you have a key.
+
 See [Section 11](#11-auto-register-list-your-api-with-your-ai) for the full payload shape.
 
-### Step 3: Register via auto-register and confirm
+### Step 3: Register with the CLI and confirm
 
 The **only** way to create a new API listing is via the auto-register endpoint.
-There is no manual form or developer portal for listing creation. Production
-`auto-register` must include `tool_manual`; do not wait until
-`confirm-auto-register` to provide it.
+There is no manual form or developer portal for listing creation. The standard
+SDK route is the CLI; it calls `auto-register` with your `manifest`,
+`tool_manual`, `runtime_validation`, publisher identity, and source provenance.
+
+```bash
+siglume register . --confirm
+```
+
+Production `auto-register` must include `tool_manual`; do not wait until
+`confirm-auto-register` to provide it. Use the raw REST endpoint only when you
+are building custom automation around the same complete contract.
 
 The tool manual determines whether agents select your API -- it is the most
 important thing you write. See [Section 13](#13-tool-manual-guide).
@@ -586,8 +609,10 @@ You don't need to fill any forms. Give your AI this guide and your source code �
 ### How it works
 
 1. Your AI reads your source code
-2. Your AI generates the listing manifest, including English + Japanese descriptions
-3. Your AI calls the auto-register endpoint
+2. Your AI generates the complete registration contract: manifest, Tool Manual,
+   runtime validation, publisher identity, source provenance, and English +
+   Japanese descriptions
+3. Your AI calls the auto-register endpoint with that complete contract
 4. You review the draft and confirm
 
 Siglume does NOT translate for you. Your AI generates both languages.
@@ -988,7 +1013,9 @@ agents will NEVER select it — even if the API works perfectly.**
 | `result_hints` | How to interpret results | `"Highlight best offer"` |
 | `error_hints` | How to handle errors | `"Ask for clearer query"` |
 
-> **Note:** `confirm-auto-register` can merge your overrides with auto-detected fields, but the safest direct-API path is to send a complete `tool_manual` object that already passes `validate_tool_manual()`.
+> **Note:** Treat `confirm-auto-register` overrides as a post-draft correction
+> path only. Production `auto-register` should already include a complete
+> `tool_manual` object that passes `validate_tool_manual()`.
 
 ### Quality scoring
 
@@ -1039,8 +1066,8 @@ with SiglumeClient(api_key="YOUR_TOKEN") as client:
     print(report.grade, report.overall_score)
 ```
 
-For end-to-end draft registration, the server still returns the quality score as
-part of `confirm-auto-register`:
+If you need to correct a draft after `auto-register`, the server still returns
+the quality score as part of `confirm-auto-register`:
 
 ```bash
 curl -X POST https://siglume.com/v1/market/capabilities/LISTING_ID/confirm-auto-register \
@@ -1049,7 +1076,7 @@ curl -X POST https://siglume.com/v1/market/capabilities/LISTING_ID/confirm-auto-
   -d @confirm-request.json
 ```
 
-Example request payload:
+Optional correction payload:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -84,9 +84,14 @@ You do not submit a PR to this repo. You register directly on the platform — n
 1. Build your API with `AppAdapter` (see examples for templates)
 2. Test locally with `AppTestHarness`
 3. Write the Tool Manual and runtime validation contract
-4. Register: `POST /v1/market/capabilities/auto-register` with `manifest`, `tool_manual`, `runtime_validation`, publisher identity, and source provenance
+4. Register with the CLI: `siglume register . --confirm`
 5. Confirm → quality check → admin review → listed in the API Store
 6. Agent owners subscribe → you earn 93.4% of revenue
+
+The CLI calls the same production `POST /v1/market/capabilities/auto-register`
+endpoint with `manifest`, `tool_manual`, `runtime_validation`, publisher
+identity, and source provenance. Use raw HTTP only when you are building your
+own automation around that contract.
 
 - **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review, edit, and submit your listings after creation; new listings are always created through the `auto-register` endpoint — see [Getting Started §11](GETTING_STARTED.md#11-auto-register-list-your-api-with-your-ai))
 - **API Store buyer view** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)

--- a/RELEASE_NOTES_v0.7.5.md
+++ b/RELEASE_NOTES_v0.7.5.md
@@ -1,0 +1,26 @@
+# Siglume API SDK v0.7.5
+
+This release fixes TypeScript SDK publishing to npm and closes the final
+onboarding documentation review items.
+
+## Highlights
+
+- Added repository metadata to `@siglume/api-sdk` so npm provenance can verify
+  the package source against GitHub Actions.
+- Updated the release workflow to use Node.js 24 for npm publishing.
+- Quick Start now starts with local-only commands, then introduces
+  `SIGLUME_API_KEY` before server-backed validation.
+- Publishing docs now make `siglume register . --confirm` the standard SDK path.
+- Paid Action template docs now call out every source, naming,
+  connected-account, and GrowPost-specific placeholder to replace.
+- Confirm-auto-register docs now describe Tool Manual overrides as a
+  post-draft correction path only.
+
+## Validation
+
+- `npm run typecheck`
+- `npm run test -- --coverage.enabled=false`
+- `npm run build`
+- `npm run pack:check`
+- `py -3.11 -m build`
+- `py -3.11 -m twine check dist/siglume_api_sdk-0.7.5*`

--- a/examples/paid_action_subscription/README.md
+++ b/examples/paid_action_subscription/README.md
@@ -23,6 +23,12 @@ Before you run the registration curl, replace every placeholder in
 
 | JSON path | Replace with |
 |---|---|
+| `source_url`, `source_context.repository_url`, `source_context.source_paths`, `source_context.doc_paths` | Your public source repository URL, branch/ref, and file paths for the API runtime and docs. |
+| `capability_key`, `manifest.capability_key` | Your stable listing key, using lowercase letters, numbers, and hyphens. |
+| `name`, `manifest.name` | Your API's public listing name. |
+| `job_to_be_done`, `short_description`, `manifest.job_to_be_done`, `manifest.short_description` | Your API's actual use case. Remove the GrowPost-specific wording unless you are publishing GrowPost. |
+| `required_connected_accounts`, `manifest.required_connected_accounts`, `tool_manual.requires_connected_accounts` | The provider keys your API really needs, or `[]` if none. Keep all three lists consistent. |
+| `tool_manual.tool_name` | Your stable agent-facing tool name, using lowercase letters, numbers, and underscores. |
 | `docs_url`, `documentation_url`, `legal.publisher_identity.documentation_url`, `manifest.docs_url` | Your public API docs URL. |
 | `support_contact`, `legal.publisher_identity.support_contact`, `manifest.support_contact` | Your real support email or support URL. |
 | `runtime_validation.public_base_url` | Your public production API base URL. Do not use localhost, private IPs, or `example.com`. |
@@ -34,7 +40,10 @@ Before you run the registration curl, replace every placeholder in
 
 Do not run the curl while `https://api.example.com`,
 `https://docs.example.com`, `support@example.com`, or
-`replace-with-dedicated-review-key` are still present.
+`replace-with-dedicated-review-key` are still present. Also replace the
+example GitHub URLs, `growpost-*` keys, `GrowPost` copy, and `["growpost"]`
+connected-account placeholders unless this API really is a GrowPost
+integration.
 
 Register after those replacements:
 

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -446,10 +446,11 @@ paths:
       description: |
         Confirms the auto-registered listing, runs quality check on the tool manual,
         creates a CapabilityRelease, and submits for admin review.
-        This is the canonical publish gate for the final agent contract.
-        Include tool_manual in overrides for best quality score and explicit
-        input_schema / output_schema control. If input_form_spec was already
-        seeded during auto-register, confirm reuses it unless you override it here.
+        This is the canonical publish gate for a draft that was already created
+        by production auto-register. Production auto-register should already
+        include a complete tool_manual; use confirm overrides only to correct a
+        draft after creation. If input_form_spec was already seeded during
+        auto-register, confirm reuses it unless you override it here.
       tags: [Capabilities]
       parameters:
         - name: listingId
@@ -470,7 +471,7 @@ paths:
                   description: Must be true to confirm
                 overrides:
                   type: object
-                  description: Override auto-detected fields including tool_manual
+                  description: Optional post-draft corrections, including tool_manual only when it changed after auto-register
                   properties:
                     tool_manual:
                       $ref: '#/components/schemas/ToolManual'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.7.4"
+version = "0.7.5"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taihei-05/siglume-api-sdk",
+    "directory": "siglume-api-sdk-ts"
+  },
   "type": "module",
   "engines": {
     "node": ">=18"

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -1052,9 +1052,9 @@ function operationReadmeTemplate(
     "```bash",
     "siglume validate .",
     "siglume test .",
+    "npm test -- tests/test_adapter.ts",
     "siglume score . --remote",
     "siglume register . --confirm",
-    "npm test -- tests/test_adapter.ts",
     "```",
     "",
   ].join("\n");

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -428,6 +428,9 @@ describe("siglume CLI", () => {
     expect(adapterText).toContain("support_contact: \"support@example.com\"");
     expect(adapterText).toContain("docs_url: \"https://example.com/docs\"");
     expect(readmeText).toContain("replace `docs_url` and `support_contact`");
+    expect(readmeText.indexOf("npm test -- tests/test_adapter.ts")).toBeLessThan(
+      readmeText.indexOf("siglume register . --confirm"),
+    );
     expect(await readFile(join(projectDir, "tool_manual.json"), "utf8")).toContain("\"owner_charter_update\"");
     expect(await readFile(join(projectDir, "runtime_validation.json"), "utf8")).toContain("\"expected_response_fields\"");
   });

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -843,9 +843,9 @@ def _operation_readme_template(operation: OperationMetadata, manifest: AppManife
             "```bash",
             "siglume validate .",
             "siglume test .",
+            "pytest tests/test_adapter.py",
             "siglume score . --remote",
             "siglume register . --confirm",
-            "pytest tests/test_adapter.py",
             "```",
             "",
         ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,6 +421,7 @@ def test_init_command_generates_operation_wrapper_with_grade_b_or_better(monkeyp
         assert 'support_contact="support@example.com"' in adapter_text
         assert 'docs_url="https://example.com/docs"' in adapter_text
         assert "replace `docs_url` and `support_contact`" in readme_text
+        assert readme_text.index("pytest tests/test_adapter.py") < readme_text.index("siglume register . --confirm")
 
 
 def test_build_tool_manual_template_tolerates_missing_job_to_be_done() -> None:


### PR DESCRIPTION
## Summary
- Fix npm provenance publishing by adding repository metadata to the TypeScript package and moving the npm publish job to Node 24.
- Make Quick Start local-first, then introduce SIGLUME_API_KEY before server-backed validation.
- Present `siglume register . --confirm` as the standard SDK registration path and raw HTTP as the automation path.
- Expand the paid Action template placeholder checklist and soften confirm-auto-register Tool Manual overrides to post-draft corrections.
- Move generated operation-wrapper tests before registration in Python/TypeScript READMEs.

## Validation
- py -3.11 -m pytest tests/test_cli.py tests/test_client.py tests/test_contract_sync.py -q
- py -3.11 -m ruff check .
- npm run typecheck
- npm run test -- --coverage.enabled=false
- npm run build
- npm run pack:check
- OpenAPI YAML + paid Action JSON parse
- py -3.11 -m build
- py -3.11 -m twine check dist/siglume_api_sdk-0.7.5*
- git diff --check