### PR TITLE
Align AI prompt README inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you want to scaffold quickly with an AI coding agent, give it:
 
 Recommended prompt:
 
-> Read this repository, especially `README.md` and `GETTING_STARTED.md`, and build a Siglume API that follows the documented CLI-first flow.
+> Read this repository, especially `README.md` and `GETTING_STARTED.md`, use the API idea and external API docs I provide, and build a Siglume API that follows the documented CLI-first flow.
 
 ---
 


### PR DESCRIPTION
## Summary

Fix the short AI-agent README prompt so it actually reflects the four inputs listed just above it.

- keep the section minimal
- preserve the documented CLI-first guidance
- explicitly mention the user's API idea and external API docs in the recommended prompt

## Validation

- Read-only reviewer subagent: no blocking issues
- `git diff --cached --check`