### PR TITLE
[codex] Align docs with current SDK implementation

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -333,10 +333,11 @@ Use this flow from CLI / SDK / automation:
   - `tool_manual.json`
   - `runtime_validation.json`
   - optional `oauth_credentials.json` for seller-side OAuth app credentials
-  - optional `input_form_spec.json`
-  - GitHub provenance from your local git checkout when available
 - `siglume register` runs manifest validation and remote Tool Manual quality
-  preview before draft creation by default
+  preview before draft creation
+- `input_form_spec`, `source_context`, and GitHub provenance are supported by
+  the lower-level `auto-register` payload, but the current CLI does not load
+  separate files for them
 - This route requires `SIGLUME_API_KEY` or `~/.siglume/credentials.toml`
   because there is no browser session
 - This is the recommended registration path for CLI users, coding engines, and automation
@@ -356,11 +357,11 @@ siglume register .                 # preflight + draft only
 siglume register . --confirm      # confirm + publish
 ```
 
-Useful flags:
+Supported register flags:
 
-- `--no-preflight`: skip the CLI preflight and attempt registration directly
-- `--force-draft`: attempt draft creation even after a failed preflight
-- `--allow-generated-manual`: allow registration with the CLI-generated fallback `tool_manual`
+- `--confirm`: confirm and publish the staged draft if final checks pass
+- `--submit-review`: submit the resulting listing for the review path
+- `--json`: print machine-readable output
 
 If the listing is already live, re-run the same `capability_key` to stage an
 upgrade. `siglume register . --confirm` then publishes the next release

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ No permission needed. No issue to claim. Just build and register.
 
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
-| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, optional `input_form_spec.json`, optional `oauth_credentials.json`, and GitHub provenance when available, runs preflight by default, then calls `auto-register`. Re-run the same `capability_key` to stage an upgrade. |
+| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and optional `oauth_credentials.json`, runs preflight, then calls `auto-register`. Re-run the same `capability_key` to stage an upgrade. |
 | Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Wallet claim and payout-token changes live in `/owner/credits` under the `Payouts` sub-menu. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
@@ -127,8 +127,8 @@ No permission needed. No issue to claim. Just build and register.
   - Siglume runs an LLM review for applicable-law compliance in the declared jurisdiction.
   - Siglume runs an LLM review for public-order / morals compliance.
   - If the LLM legal review cannot produce a valid pass decision, publish is blocked.
-- `source_url` and optional `source_context` let a CLI / coding engine register
-  directly from GitHub provenance.
+- `source_url` and optional `source_context` let SDK callers or coding engines
+  register directly from GitHub provenance.
 - Callers can send the full `tool_manual` during `auto-register` or
   `confirm-auto-register`, and can optionally seed `input_form_spec`.
 
@@ -147,11 +147,10 @@ siglume register .                 # preflight + draft only
 siglume register . --confirm      # confirm + publish
 ```
 
-`siglume register` now runs manifest validation and remote Tool Manual quality
-preview before draft creation. Use `--no-preflight` only when you explicitly
-want to skip that check, `--force-draft` when you still want to attempt draft
-creation after a failed preflight, and `--allow-generated-manual` only when you
-intend to register with the CLI-generated `tool_manual` template.
+`siglume register` runs manifest validation and remote Tool Manual quality
+preview before draft creation. The supported register flags are `--confirm`,
+`--submit-review`, and `--json`; there is no current flag to skip this
+preflight.
 
 For upgrades, run the same commands again with the same `capability_key`.
 `siglume register` stages the upgrade, and `siglume register . --confirm`

--- a/docs/account-operations.md
+++ b/docs/account-operations.md
@@ -1,7 +1,8 @@
 # Account Operations
 
-`SiglumeClient` exposes typed wrappers for the first-party `account.*`
-surface that is currently present in the platform operation registry.
+`SiglumeClient` exposes typed wrappers for the public account REST surface.
+Some of these routes are also mirrored in the platform owner-operation
+registry, but the SDK methods on this page call the REST routes directly.
 
 Covered today:
 
@@ -48,9 +49,8 @@ Current `AccountWatchlist` fields:
 
 - `symbols`
 
-The operation registry currently exposes `account.watchlist.get` and
-`account.watchlist.update`. There is no separate add/remove operation yet, so
-the SDK mirrors the platform and treats watchlist writes as full replacement.
+There is no separate add/remove REST method for the watchlist yet, so the SDK
+treats watchlist writes as full replacement.
 
 ## Favorites
 
@@ -105,8 +105,8 @@ Methods:
 - `post_account_content_direct(text, lang=...)`
 - `delete_account_content(content_id)`
 
-The current registry key is `account.content.post_direct`, not a generic
-`create` or `update` operation. The SDK follows that exact platform shape.
+The current REST write is `post_account_content_direct()`, not a generic
+`create` or `update` helper. The SDK follows that platform shape.
 
 `post_account_content_direct()` returns:
 
@@ -207,7 +207,6 @@ print(alerts.items[0].title if alerts.items else "no alerts")
 
 ## Secret-like fields and recorder behavior
 
-PR-Qa already added automatic recorder redaction for short-lived checkout and
-billing-portal URLs. The additional Qb families do not introduce new token-like
-or credential-like fields, so the recorder redaction rules are unchanged in
-this PR.
+Recorder redaction already covers short-lived checkout and billing-portal URLs.
+The account wrappers on this page do not introduce new token-like or
+credential-like fields, so the existing recorder redaction rules apply.

--- a/docs/buyer-sdk.md
+++ b/docs/buyer-sdk.md
@@ -6,7 +6,7 @@ Siglume API Store capabilities.
 
 ## Current platform shape
 
-As of 2026-04-19, the public platform exposes:
+The public platform exposes:
 
 - `GET /v1/market/capabilities`
 - `GET /v1/market/capabilities/{listing_id}`
@@ -19,7 +19,7 @@ The public platform does **not** currently expose:
 - a public buyer execution endpoint
 - the full `tool_manual` payload on listing reads
 
-Because of those gaps, PR-N ships with explicit experimental fallbacks:
+Because of those gaps, the buyer SDK uses explicit experimental fallbacks:
 
 - `search_capabilities()` uses SDK-side substring scoring over `list_capabilities()`
 - `get_listing()` synthesizes a minimal `tool_manual` from listing metadata

--- a/docs/execution-receipts.md
+++ b/docs/execution-receipts.md
@@ -92,7 +92,7 @@ Describes what external state changed.
 | `action` | yes | e.g. "tweet_created", "email_sent", "payment_charged" |
 | `provider` | yes | e.g. "x-twitter", "stripe" |
 | `external_id` | no | Provider-side reference |
-| `reversible` | yes | Can this be undone? |
+| `reversible` | yes in the serialized contract | Can this be undone? Python defaults to `False`; TypeScript callers should set it explicitly for wire parity. |
 | `reversal_hint` | no | How to undo (e.g. "DELETE /tweets/{id}") |
 | `timestamp_iso` | no | When the side effect occurred |
 | `metadata` | no | Extra data |
@@ -138,13 +138,13 @@ result = ExecutionResult(
 | `currency` | no | ISO currency code |
 | `side_effects` | no | Plain-text list of what will change |
 | `preview` | no | Structured preview payload |
-| `reversible` | yes | Can the action be undone? |
+| `reversible` | yes in the serialized contract | Can the action be undone? Python defaults to `False`; TypeScript callers should set it explicitly for wire parity. |
 
 ## Good Practices
 
 - Keep receipts structured, not prose-only
 - Do not include secrets or raw tokens
 - Include identifiers that help support investigate problems
-- When the API is in `dry_run`, return a preview receipt instead of a fake live one
+- When the API is in `dry_run`, return preview data in `ExecutionResult.output`, `receipt_summary`, or structured artifacts / side effects; leave `receipt_ref` unset because the runtime owns receipt references
 - Use `SideEffectRecord.reversible` honestly — it affects dispute resolution
 - Always include `external_id` when the provider returns one

--- a/docs/installed-tools-operations.md
+++ b/docs/installed-tools-operations.md
@@ -55,10 +55,18 @@ contains:
 
 - `status`
 - `approval_required`
+- `operation_key`
 - `intent_id`
+- `approval_status`
 - `approval_snapshot_hash`
+- `message`
+- `action`
+- `safety`
 - `preview`
 - `policy`
+- `agent_id`
+- `trace_id`
+- `request_id`
 
 When the platform returns `status="approval_required"`, the SDK does **not**
 raise. Instead:

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -10,23 +10,18 @@ The `jurisdiction` field is also the basis for the country-flag icon the
 API Store renders next to each listing — an instant visual cue of
 where the API is "from".
 
-> 🔄 **Payment-stack migration notice.** This document still references
-> Stripe Connect in several places. The platform is transitioning to
-> on-chain embedded-wallet settlement; the compliance surface there
-> differs (e.g. country-scoped payout rails are replaced by wallet-based
-> settlement). See [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for
-> the current cutover state. The **jurisdiction declaration requirement
-> itself is unchanged** — consumer-protection, tax, and data-residency
-> obligations continue to apply regardless of the settlement mechanism.
+> **Settlement note.** Paid listings settle through the platform's embedded
+> wallet / on-chain payment path. The **jurisdiction declaration requirement
+> itself is unchanged**: consumer-protection, tax, and data-residency
+> obligations continue to apply regardless of the settlement mechanism. See
+> [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for operational settlement
+> history and rollout details.
 
 ## Why this is required
 
-- **Payments**: the legacy Stripe Connect payout rails had per-country
-  destination-charge and refund rules (a US-jurisdiction API settled
-  under US Card-Act-style rules, a JP-jurisdiction API under 資金決済法).
-  On-chain settlement shifts the mechanics, but cross-border consumer
-  protection, chargeback equivalents, and refund-note obligations still
-  track the declared jurisdiction.
+- **Payments**: on-chain settlement changes the payout mechanics, but
+  cross-border consumer protection, chargeback-equivalent handling, refund
+  notes, and tax posture still track the declared jurisdiction.
 - **Consumer protection**: CA residents get CCPA, EU residents get GDPR,
   JP residents get 特定商取引法. The platform surfaces this so owners can
   evaluate risk before subscribing.
@@ -109,9 +104,8 @@ Accepted formats:
 ### ToolManual (required for `action` and `payment` tiers)
 
 Payment tools and state-changing action tools must also declare jurisdiction
-at the tool level. This allows different tools in the same app to opt into
-different legal scopes (e.g. an action tool that's US-only plus a read-only
-tool usable worldwide).
+at the tool level. This keeps the machine-readable tool contract explicit even
+when an app exposes multiple tools.
 
 ```python
 from siglume_api_sdk import ToolManual, ToolManualPermissionClass, SettlementMode
@@ -126,7 +120,7 @@ manual = ToolManual(
     side_effect_summary="Debits the owner's connected wallet via the platform's payment adapter.",
     quote_schema={...},
     currency="USD",
-    settlement_mode=SettlementMode.STRIPE_PAYMENT_INTENT,
+    settlement_mode=SettlementMode.POLYGON_MANDATE,
     refund_or_cancellation_note="Full refund within 7 days per platform policy.",
     jurisdiction="US",  # required for action/payment
     legal_notes="Refunds follow US FTC Rule 16 CFR 429. Not offered to EU users.",
@@ -144,12 +138,9 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
   time.
 - **JSON schemas** (`schemas/app-manifest.schema.json`,
   `schemas/tool-manual.schema.json`) enforce `pattern: ^[A-Z]{2}(-[A-Z0-9]{1,3})?$`.
-- **Platform-side**: the review step checks the declared jurisdiction for
-  consistency with the developer's payout setup (historically the Stripe
-  Connect onboarding country; during the on-chain migration this will move
-  to a wallet/account-level declaration — see
-  [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md)). Mismatches surface as a
-  quality-report warning.
+- **Platform-side**: the review step checks the declared jurisdiction against
+  the submitted registration contract and platform account state. Mismatches
+  surface as quality-report warnings or publish blockers depending on severity.
 
 ## Applicable regulations
 
@@ -170,14 +161,15 @@ The API Store is **USD-unified**. Even if your `jurisdiction` is
 `"JP"`, `"GB"`, `"DE"`, or anything else, your listing price is in US
 dollars. This is enforced:
 
-- `AppManifest.currency` is typed as `"USD"` (literal in TS, validated in Python `__post_init__`, `const` in JSON Schema).
-- `ToolManual.currency` (payment tier) is `const "USD"`.
-- The platform's registration endpoint rejects non-USD payloads with a 422
-  (`CURRENCY_NOT_SUPPORTED`).
+- `AppManifest.currency` is typed as `"USD"` in TypeScript, validated in Python
+  `__post_init__`, and constrained by `schemas/app-manifest.schema.json`.
+- `ToolManual.currency` is constrained to `"USD"` by the SDK validators and
+  `schemas/tool-manual.schema.json`.
+- Registration should be treated as USD-only. Non-USD registration payloads are
+  invalid even if a lower-level HTTP schema describes `currency` as a string.
 
-Why: the payout rail (Stripe Connect today, on-chain embedded wallet after
-cutover), platform-fee accounting, the 93.4% / 6.6% revenue split, and the
-$5.00/month minimum for subscription APIs all
+Why: embedded-wallet settlement, platform-fee accounting, the 93.4% / 6.6%
+revenue split, and the $5.00/month minimum for subscription APIs all
 operate in USD. Mixing currencies would fragment payouts and break the fee
 model.
 
@@ -206,6 +198,4 @@ version (bump `version` in the manifest) and re-submit for review.
 
 **Q: What if I don't know what to put?**
 A: Use the country where you are a legal resident for tax and invoicing
-purposes. That's your jurisdiction. (Historically the answer was tied to
-your Stripe Connect onboarding country; with the on-chain migration this
-becomes a direct self-declaration rather than inferred from payout rails.)
+purposes. That's your jurisdiction.

--- a/docs/market-proposals-operations.md
+++ b/docs/market-proposals-operations.md
@@ -92,6 +92,10 @@ platform:
 - `order`
 - `funds_locked`
 - `escrow_hold`
+- `trace_id`
+- `request_id`
+
+The parsed result also preserves the raw platform payload for debugging.
 
 ## Guarded approval behavior
 

--- a/docs/network-operations.md
+++ b/docs/network-operations.md
@@ -1,8 +1,9 @@
 # Network Operations
 
-`SiglumeClient` exposes typed wrappers for the read-only `network.*` and
-`agent.*` discovery surface that is currently present in the platform
-operation registry.
+`SiglumeClient` exposes typed wrappers for the read-only network and agent
+discovery REST surface. These wrappers do not use the owner-operation execute
+route; they call the public browsing routes and authenticated agent-session
+routes directly.
 
 Authentication note:
 
@@ -32,11 +33,10 @@ Covered today:
 Methods:
 
 - `get_network_home(feed=..., limit=..., query=..., cursor=...)`
-- `list_agents(query=..., limit=..., cursor=...)`
+- `list_agents(query=..., limit=...)`
 - `get_agent(agent_id, ...)`
 
-`network.agents.search` and `network.agents.profile.get` were already covered
-before PR-Qc by the existing high-level wrappers:
+The high-level wrappers map to these platform concepts:
 
 - `list_agents(query=...)` -> `network.agents.search`
 - `get_agent(agent_id, ...)` -> `network.agents.profile.get`
@@ -153,5 +153,5 @@ print(agent_client.list_agent_topics()[0].topic_key)
 ## Recorder behavior
 
 These discovery routes currently return public browsing data plus ordinary
-typed records. PR-Qc did not introduce new secret-like or credential-like
-fields, so the recorder redaction rules are unchanged in this slice.
+typed records. They do not introduce new secret-like or credential-like fields,
+so the existing recorder redaction rules apply.

--- a/docs/partner-ads-operations.md
+++ b/docs/partner-ads-operations.md
@@ -70,7 +70,8 @@ presentation route.
 - The SDK does not model `ingest_key` on this wrapper and defensively scrubs
   `ingest_key` / `full_key` from the parsed raw payload as well.
 - Partners who need to reveal the raw secret once at creation time must use the
-  legacy user-facing HTTP route `POST /v1/partner/keys`. The shared
+  legacy user-facing HTTP route `POST /v1/partner/keys`, which is outside the
+  public SDK wrapper and OpenAPI surface documented here. The shared
   owner-operation bus path is handle-only by design.
 
 This matches the platform's handle-only contract for credential issuance. Do
@@ -82,11 +83,10 @@ not write client code that assumes `partner.keys.create()` will ever return
 - `settle_ads_billing()` exists for parity with the operation registry.
 - The current platform implementation raises a conflict because Ads Web3
   billing auto-settles at month end, so callers should expect a
-  `SiglumeAPIError` in the current production contract rather than a rich
-  success payload.
-- The SDK still ships a typed `AdsBillingSettlement` parser so the surface can
-  stay forward-compatible if the platform later returns structured settlement
-  status instead of only an error.
+  `SiglumeAPIError` from the live production contract.
+- The SDK also ships a typed `AdsBillingSettlement` parser. Mock transports and
+  future platform versions may return structured settlement status such as
+  `status="auto_settles"` and `settles_automatically=true`.
 
 ## Validation Behavior
 

--- a/docs/permission-scopes.md
+++ b/docs/permission-scopes.md
@@ -22,15 +22,18 @@ Typical scopes:
 - `calendar.read`
 - `crm.read`
 
-### `recommendation`
+### Compare or propose without committing
 
-Use this when the API compares, scores, or proposes actions without committing them.
+Use `read-only` when the API compares, scores, quotes, or proposes actions
+without changing external state. `recommendation` is a deprecated
+manifest-only alias of `read-only`; do not use it in new manifests, and do not
+use it in Tool Manual `permission_class`.
 
 Typical scopes:
 
-- `quote.create`
+- `quote.preview`
 - `comparison.run`
-- `draft.create`
+- `draft.preview`
 
 ### `action`
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -95,21 +95,21 @@ By default, the CLI expects:
 - `tool_manual.json`
 - `runtime_validation.json`
 
-It also uses these when present:
+It also uses this when present:
 
 - `oauth_credentials.json` for seller-side OAuth app credentials
-- `input_form_spec.json`
-- `source_context.json`
-- Git metadata from the local checkout to derive `source_url` and `source_context`
+
+`input_form_spec` and `source_context` are supported by the lower-level
+`SiglumeClient.auto_register(...)` API, but the current CLI does not load
+`input_form_spec.json`, `source_context.json`, or Git provenance files.
 
 Before draft creation, `siglume register` runs:
 
 - local manifest validation
 - remote Tool Manual quality preview
 
-Use `--no-preflight` to skip that step, `--force-draft` to continue after a
-failed preflight, and `--allow-generated-manual` only if you intentionally want
-to register with the CLI-generated Tool Manual template.
+The current CLI has no skip flag for this preflight. The supported register
+flags are `--confirm`, `--submit-review`, and `--json`.
 
 ## What is required today
 

--- a/docs/refunds-disputes.md
+++ b/docs/refunds-disputes.md
@@ -31,6 +31,14 @@ dispute = client.respond_to_dispute(
 `issue_full_refund()` is a convenience wrapper that omits `amount_minor` and
 uses a deterministic idempotency key when you do not provide one.
 
+Additional read helpers:
+
+- `list_refunds(receipt_id=..., limit=...)`
+- `get_refund(refund_id)`
+- `get_refunds_for_receipt(receipt_id, limit=...)`
+- `list_disputes(receipt_id=..., limit=...)`
+- `get_dispute(dispute_id)`
+
 ## TypeScript
 
 ```ts

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -53,7 +53,7 @@ time): `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, `PER_ACTION`.
 |---|---|
 | `ToolManual` | Machine-readable contract that agents read to decide whether to call your API. |
 | `ToolManualIssue` | Single validation or quality issue (raised by the grader). |
-| `ToolManualQualityReport` | Aggregated quality score (0–100 / grade A–F). Grade B is the minimum to publish. |
+| `ToolManualQualityReport` | Aggregated quality score (0-100 / grade A-F). Grade B is the minimum to publish. |
 | `validate_tool_manual()` | Client-side validation that mirrors the server rules. |
 | `draft_tool_manual()` | Generate a ToolManual skeleton from a job description using an LLM provider. |
 | `fill_tool_manual_gaps()` | Repair / fill missing fields on an existing ToolManual. |

--- a/docs/template-generator.md
+++ b/docs/template-generator.md
@@ -4,7 +4,8 @@
 first-party Siglume owner operation without using an LLM.
 
 The generator reads the live owner-operation catalog when it is available and
-falls back to the bundled catalog for the current common operations:
+falls back to the bundled catalog. The bundled catalog currently covers owner
+governance operations and market proposal operations, including:
 
 - `owner.charter.get`
 - `owner.charter.update`
@@ -12,6 +13,12 @@ falls back to the bundled catalog for the current common operations:
 - `owner.approval_policy.update`
 - `owner.budget.get`
 - `owner.budget.update`
+- `market.proposals.list`
+- `market.proposals.get`
+- `market.proposals.create`
+- `market.proposals.counter`
+- `market.proposals.accept`
+- `market.proposals.reject`
 
 ## Commands
 
@@ -44,14 +51,18 @@ siglume init \
 
 The Python CLI writes:
 
+- `__init__.py`: package marker
 - `adapter.py`: `AppAdapter` wrapper that previews first and then calls `SiglumeClient.execute_owner_operation()`
 - `stubs.py`: fallback mock provider for local dry runs
 - `manifest.json`: serialized `AppManifest`
 - `tool_manual.json`: machine-generated `ToolManual`
+- `runtime_validation.json`: smoke-test contract used by `siglume register`
 - `README.md`: generated usage notes
+- `tests/__init__.py`: test package marker
 - `tests/test_adapter.py`: harness smoke test
 
 The TypeScript CLI mirrors the same structure with `adapter.ts`, `stubs.ts`,
+`manifest.json`, `tool_manual.json`, `runtime_validation.json`, `README.md`,
 and `tests/test_adapter.ts`.
 
 ## Quality gate

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -20,8 +20,9 @@ What the SDK does **not** do:
 
 The actual settlement flow is owned by the Siglume platform contracts
 (`SubscriptionHub` and related web3 services). Gas is platform-paid. Manifest
-pricing stays USD-only, while settlement tokens may be `JPYC`, `USDC`, or
-other platform-supported Polygon assets.
+pricing stays USD-only. Public swap quotes currently cover `USDC` and `JPYC`;
+mandate and receipt metadata may expose the Polygon token configured by the
+platform for that settlement flow.
 
 ## Client helpers
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -46,7 +46,9 @@ def on_subscription_created(event) -> None:
 
 Lifecycle management is available on `SiglumeClient`:
 
-`event_types` is required when creating a subscription and must contain at least one supported webhook event type.
+`event_types` is required when creating a subscription. The SDK enforces a
+non-empty list; the public OpenAPI enum and server define which event type
+strings are supported.
 
 ```python
 client.create_webhook_subscription(
@@ -55,7 +57,13 @@ client.create_webhook_subscription(
     description="Ops alerts",
 )
 client.list_webhook_subscriptions()
+client.get_webhook_subscription("whsub_123")
+client.rotate_webhook_subscription_secret("whsub_123")
+client.pause_webhook_subscription("whsub_123")
+client.resume_webhook_subscription("whsub_123")
 client.list_webhook_deliveries(limit=20)
+client.redeliver_webhook_delivery("whdel_123")
+client.send_test_webhook_delivery("payment.succeeded", data={"sequence": 1})
 ```
 
 ## TypeScript

--- a/docs/works-operations.md
+++ b/docs/works-operations.md
@@ -88,8 +88,7 @@ execution metadata that matters if the register path ever becomes guarded:
   provide.
 - `register_for_works()` validates `categories` and `capabilities` as string
   arrays before sending the request.
-- As of the operation registry snapshot dated `2026-04-20`,
-  `works.registration.register` executes `direct` rather than `guarded`.
+- `works.registration.register` currently executes as a direct owner operation.
   The wrapper still preserves approval metadata fields so callers do not have
   to change their code if that safety classification flips later.
 

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -66,9 +66,8 @@ siglume register . --confirm # confirm + publish
 ```
 
 `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and
-optional `input_form_spec.json`. If the API uses seller-side OAuth, it also
-reads `oauth_credentials.json`. The CLI runs preflight by default, then calls
-the same `auto-register` route used by SDK / automation clients. Re-run the
+optional `oauth_credentials.json`. The CLI runs preflight, then calls the same
+`auto-register` route used by SDK / automation clients. Re-run the
 same `capability_key` to stage an upgrade. The server-side publish gate
 includes runtime checks, contract checks, seller OAuth checks, pricing / payout
 rules, and a mandatory fail-closed LLM legal review for law compliance plus


### PR DESCRIPTION
## Summary
- align publish, permission, account/network, template, settlement, webhook, refund, installed-tool, and proposal docs with the current SDK implementation
- remove or qualify stale claims about generated files, nonexistent CLI flags, registry-backed REST wrappers, legacy recommendation permissions, and live ads settlement behavior
- add missing documented result metadata and lifecycle helper coverage where the SDK already exposes typed wrappers

## Validation
- `py -3.11 -m pytest -q`
- `py -3.11 scripts/contract_sync.py`
- `npm test` in `siglume-api-sdk-ts`
- `npm run build` in `siglume-api-sdk-ts`
- `py -3.11 -m build`