### PR TITLE
[codex] Restore and align SDK docs

### DIFF
--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -24,15 +24,15 @@ choose to install and subscribe to your API. Better APIs earn more.
 
 > 🔄 **Settlement is migrating.** The platform is moving from Stripe Connect payouts to fully on-chain settlement (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for current status.
 
-Both free and subscription APIs are supported. Use `price_model="free"` to start, or `price_model="subscription"` with `price_value_minor=999` for a $9.99/month API. Paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Register with a Polygon payout address at `/owner/publish`.
+Both free and subscription APIs are supported. Use `price_model="free"` to start, or `price_model="subscription"` with `price_value_minor=999` for a $9.99/month API. Paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Paid revenue settles to the Siglume embedded wallet; change the payout token from `/owner/credits/payout`.
 
 ## How to publish your API
 
 1. Build your API using the SDK (`AppAdapter`)
 2. Test it locally with `AppTestHarness`
 3. Register via `POST /v1/market/capabilities/auto-register`
-4. Confirm with your tool manual → quality check runs automatically
-5. Wait for admin review → published to the API Store
+4. Confirm with your tool manual → quality and legal checks run automatically
+5. Publish immediately when the self-serve checks pass
 
 **There is no PR review process for API listings.** You register directly
 on the platform. See [GETTING_STARTED.md](GETTING_STARTED.md) for the full guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Python and TypeScript `confirm_registration()` now confirm immutable
+  auto-registered drafts with `approved=true` only and no longer send
+  post-draft content overrides.
+- Public onboarding docs now state that submitted API content is read-only in
+  `/owner/publish`; content changes require rerunning `auto-register` /
+  `siglume register` with the same `capability_key`.
+
 ## [0.7.6] - 2026-04-23
 
 v0.7.6 closes the remaining production-onboarding review findings for paid
@@ -42,8 +53,8 @@ last onboarding docs gaps.
   SDK route and raw HTTP as the automation route.
 - Paid Action template docs now list source, naming, connected-account, and
   GrowPost-specific placeholders that must be replaced.
-- Confirm-auto-register docs now frame Tool Manual overrides as post-draft
-  corrections only.
+- Confirm-auto-register docs now frame Tool Manual content as finalized during
+  auto-register instead of first supplied during confirmation.
 
 ## [0.7.4] - 2026-04-23
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -378,8 +378,8 @@ most important thing you write. See [Section 13](#13-tool-manual-guide).
 - Canonical publish gate: `confirm-auto-register`
 - You can send the full `tool_manual` during `auto-register` or
   `confirm-auto-register`
-- `source_url` plus optional `source_context` lets a coding engine register
-  directly from GitHub provenance
+- SDK / HTTP automation can include `source_url` plus optional
+  `source_context` to register directly from GitHub provenance
 - `input_form_spec` can be seeded during `auto-register` and reused at confirm time
 
 A quality check runs automatically at confirmation time:
@@ -518,7 +518,7 @@ Declare the account type in `required_connected_accounts`. The agent owner conne
 Use `price_model="free"` for free APIs. For subscription APIs, use `price_model="subscription"` with `price_value_minor` set to your monthly price in cents (e.g., 999 for $9.99/month). Minimum subscription price is $5.00/month (500 cents). The following pricing models are available:
 
 - **Free** (`price_model="free"`): Anyone can install. You can convert to subscription pricing at any time.
-- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon on-chain embedded-wallet auto-debit (proven end-to-end on Amoy 2026-04-18 — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md)). Revenue settles to your embedded wallet automatically; use `/owner/credits` if you want to change the payout token. Buyers purchase via Web3 mandate, and access grants are automatic.
+- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon on-chain embedded-wallet auto-debit (proven end-to-end on Amoy 2026-04-18 — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md)). Revenue settles to your Siglume embedded wallet automatically; use `/owner/credits/payout` only if you want to change the payout token. Buyers purchase via Web3 mandate, and access grants are automatic.
 
 The SDK enum `PriceModel` also defines `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are **reserved values for future phases** — they are not accepted by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
 
@@ -745,9 +745,9 @@ The response should include:
 }
 ```
 
-If `verified_destination` is false, open `/owner/credits`, complete the wallet
-claim if needed, and confirm the embedded-wallet payout route before
-registering a paid API. Otherwise auto-register blocks with
+If `verified_destination` is false, open `/owner/credits/payout` and confirm
+the embedded-wallet payout token before registering a paid API. External payout
+wallets cannot be specified. Otherwise auto-register blocks with
 `store.payout_destination`.
 
 ### Complete curl: $5/month Action API
@@ -1207,7 +1207,7 @@ You receive:            ~$9.33/month, settled directly to your wallet
 
 ### Wallet payout flow (subscription APIs only)
 
-> ✅ **Payouts now run on Polygon.** Paid subscription publish is **open** — proven end-to-end on Polygon Amoy (2026-04-18). Revenue settles to the embedded wallet automatically; use `/owner/credits` only when you want to change the payout token or finish the wallet claim. Buyers purchase via Web3 mandate, and access grants land automatically. The Stripe Connect onboarding flow shown below is retained only for reference during migration — new publishes use the Polygon path. See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log and real on-chain metrics.
+> ✅ **Payouts now run on Polygon.** Paid subscription publish is **open** — proven end-to-end on Polygon Amoy (2026-04-18). Revenue settles to the Siglume embedded wallet automatically; use `/owner/credits/payout` only when you want to change the payout token. Buyers purchase via Web3 mandate, and access grants land automatically. The Stripe Connect onboarding flow shown below is retained only for reference during migration — new publishes use the Polygon path. See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log and real on-chain metrics.
 
 Historical Stripe-Connect-based flow (retired, kept here for reference only):
 
@@ -1219,7 +1219,7 @@ Historical Stripe-Connect-based flow (retired, kept here for reference only):
 The current on-chain flow (live as of Phase 31 on Polygon Amoy, 2026-04-18):
 
 - Creates an embedded smart wallet attached to the developer's Siglume account (no external wallet app needed).
-- Skips per-country bank-verification steps (the wallet is the payout destination).
+- Uses that embedded wallet as the fixed payout destination; developers can change the payout token, not specify an external payout wallet.
 - Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold the gas token.
 - Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades).
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -384,15 +384,17 @@ See [docs/publish-flow.md](./docs/publish-flow.md) and
 The tool manual determines whether agents select your API -- it is the
 most important thing you write. See [Section 13](#13-tool-manual-guide).
 
-- Portal route: use `/owner/publish` to inspect the CLI / automation result
-- CLI / engine route: call `confirm-auto-register` with your tool manual after the draft is created
+- Portal route: use `/owner/publish` to inspect the immutable CLI /
+  automation result; submitted content is not editable in the portal
+- CLI / engine route: send the final tool manual during `auto-register`, then
+  use `confirm-auto-register` only to approve the immutable draft
 - Canonical schema: `schemas/tool-manual.schema.json`
 - Canonical publish gate: `confirm-auto-register`
-- You can send the full `tool_manual` during `auto-register` or
-  `confirm-auto-register`
+- You must send the full `tool_manual` during `auto-register`
 - SDK / HTTP automation can include `source_url` plus optional
   `source_context` to register directly from GitHub provenance
-- `input_form_spec` can be seeded during `auto-register` and reused at confirm time
+- `input_form_spec` can be seeded during `auto-register` and is reused at
+  confirm time; confirmation does not edit it
 
 A quality check runs automatically at confirmation time:
 - Grade B or above (A/B): your API can be published immediately if the
@@ -423,7 +425,7 @@ A quality check runs automatically at confirmation time:
 - Tool Manual quality grade **B** or above
   - `input_schema` and `output_schema` are part of the canonical contract
   - if you need a stricter contract than the auto-generated seed, send a full
-    `tool_manual` during confirmation
+    `tool_manual` during `auto-register`
 - Mandatory fail-closed LLM legal review during `auto-register`
   - Siglume asks the LLM whether the API is publishable in the declared jurisdiction
   - The review must explicitly pass both applicable-law compliance and
@@ -1074,84 +1076,11 @@ print(f"Listing created: {draft['listing_id']}")
 print(f"Name: {draft['auto_manifest']['name']}")
 print(f"Status: {draft['status']}")
 
-# Confirm and publish — include your tool manual.
-# Note: overrides are merged with auto-detected values.
-# Fields like tool_name, permission_class, summary_for_model etc.
-# are auto-detected from source code; you only need to override
-# what the auto-detection cannot infer (e.g., trigger_conditions).
+# Confirm and publish the immutable draft.
 requests.post(
     f"https://siglume.com/v1/market/capabilities/{listing_id}/confirm-auto-register",
     headers={"Authorization": f"Bearer {YOUR_TOKEN}"},
-    json={
-        "approved": True,
-        "overrides": {
-            "tool_manual": {
-                "tool_name": "slack_digest_publisher",
-                "job_to_be_done": "Summarize recent discussion points and post the digest to a Slack channel the owner controls.",
-                "summary_for_model": "Builds a concise discussion digest and posts it to a specified Slack channel after preview and owner approval.",
-                "trigger_conditions": [
-                    "owner asks to summarize daily discussions and post the result to Slack",
-                    "agent needs to deliver a channel digest to a Slack workspace after reviewing recent messages",
-                    "request is to publish a recurring daily or weekly summary into Slack"
-                ],
-                "do_not_use_when": [
-                    "the owner wants a local summary only and does not want any external post",
-                    "the request targets a Slack workspace or channel the agent cannot access",
-                    "the request is to send email or update a non-Slack destination"
-                ],
-                "permission_class": "action",
-                "dry_run_supported": True,
-                "requires_connected_accounts": ["slack"],
-                "input_schema": {
-                    "type": "object",
-                    "properties": {
-                        "channel": {"type": "string", "description": "Slack channel name or ID where the digest should be posted."},
-                        "period": {"type": "string", "description": "Time window to summarize, such as today, yesterday, or this week.", "default": "today"},
-                        "tone": {"type": "string", "description": "Writing tone for the digest, such as concise, neutral, or executive.", "default": "concise"}
-                    },
-                    "required": ["channel", "period"],
-                    "additionalProperties": False
-                },
-                "output_schema": {
-                    "type": "object",
-                    "properties": {
-                        "summary": {"type": "string", "description": "One-line recap of what was posted to Slack."},
-                        "highlights": {"type": "array", "items": {"type": "string"}},
-                        "posted": {"type": "boolean", "description": "Whether the digest was posted successfully."},
-                        "channel": {"type": "string", "description": "Slack channel that received the digest."}
-                    },
-                    "required": ["summary", "posted", "channel"],
-                    "additionalProperties": False
-                },
-                "usage_hints": [
-                    "Use this tool only after you already know which Slack channel should receive the digest.",
-                    "Prefer a dry run first so the owner can review the summary before it is posted."
-                ],
-                "result_hints": [
-                    "Show the posted channel and the one-line summary so the owner can confirm the destination and content.",
-                    "If highlights are returned, surface them before offering the next follow-up action."
-                ],
-                "error_hints": [
-                    "If the Slack channel is missing or inaccessible, ask the owner to reconnect Slack or provide a valid channel.",
-                    "If posting fails after preview, suggest retrying with the same idempotency key."
-                ],
-                "approval_summary_template": "Post a Slack digest to {channel} for {period}.",
-                "preview_schema": {
-                    "type": "object",
-                    "properties": {
-                        "summary": {"type": "string", "description": "Preview text that will be posted to Slack."},
-                        "channel": {"type": "string", "description": "Slack channel that will receive the digest."},
-                        "estimated_message_count": {"type": "integer", "description": "Approximate number of source messages included in the digest."}
-                    },
-                    "required": ["summary", "channel"],
-                    "additionalProperties": False
-                },
-                "idempotency_support": True,
-                "side_effect_summary": "Posts a discussion digest message into the specified Slack channel.",
-                "jurisdiction": "JP"
-            }
-        }
-    }
+    json={"approved": True}
 )
 # Done.
 ```
@@ -1275,7 +1204,80 @@ agents will NEVER select it — even if the API works perfectly.**
 | `result_hints` | How to interpret results | `"Highlight best offer"` |
 | `error_hints` | How to handle errors | `"Ask for clearer query"` |
 
-> **Note:** `confirm-auto-register` can merge your overrides with auto-detected fields, but the safest direct-API path is to send a complete `tool_manual` object that already passes `validate_tool_manual()`.
+Example final Tool Manual payload to include during `auto-register`:
+
+```json
+{
+  "tool_name": "price_compare_helper",
+  "job_to_be_done": "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
+  "summary_for_model": "Looks up product offers across retailers and returns a structured comparison with the best current deal.",
+  "trigger_conditions": [
+    "owner asks to compare prices for a specific product before deciding where to buy",
+    "agent needs current retailer offers to support a shopping recommendation",
+    "request is to find the cheapest or best-value option for a product query"
+  ],
+  "do_not_use_when": [
+    "the owner already chose a seller and wants to place an order immediately",
+    "the request is to complete checkout or move money instead of comparing offers",
+    "the product query is too vague to search retailer listings reliably"
+  ],
+  "permission_class": "read_only",
+  "dry_run_supported": true,
+  "requires_connected_accounts": [],
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Product name, model number, or search phrase to compare."
+      },
+      "max_results": {
+        "type": "integer",
+        "description": "Maximum number of offers to return in the comparison.",
+        "default": 5
+      }
+    },
+    "required": ["query"],
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "summary": {
+        "type": "string",
+        "description": "One-line overview of the best available deal."
+      },
+      "offers": {
+        "type": "array",
+        "description": "Ranked offers returned by the comparison engine.",
+        "items": {
+          "type": "object"
+        }
+      },
+      "best_offer": {
+        "type": "object",
+        "description": "Top-ranked offer chosen from the returned offers."
+      }
+    },
+    "required": ["summary", "offers", "best_offer"],
+    "additionalProperties": false
+  },
+  "usage_hints": [
+    "Use this tool when the user has named a product and needs evidence-backed price comparison.",
+    "Present the offers in ascending price order and call out important retailer differences."
+  ],
+  "result_hints": [
+    "Highlight the best_offer first, then summarize notable trade-offs such as shipping or stock.",
+    "If multiple offers are close, explain why one is better value instead of only naming the cheapest."
+  ],
+  "error_hints": [
+    "If no offers are found, ask the owner for a clearer product name or model number.",
+    "If retailer coverage is limited, say which sources were searched before suggesting a retry."
+  ]
+}
+```
+
+> **Note:** The submitted contract is immutable after `auto-register`. Send a complete `tool_manual` object that already passes `validate_tool_manual()` before you confirm the draft.
 
 ### Quality scoring
 
@@ -1343,76 +1345,7 @@ Example request payload:
 
 ```json
 {
-  "approved": true,
-  "overrides": {
-    "tool_manual": {
-      "tool_name": "price_compare_helper",
-      "job_to_be_done": "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
-      "summary_for_model": "Looks up product offers across retailers and returns a structured comparison with the best current deal.",
-      "trigger_conditions": [
-        "owner asks to compare prices for a specific product before deciding where to buy",
-        "agent needs current retailer offers to support a shopping recommendation",
-        "request is to find the cheapest or best-value option for a product query"
-      ],
-      "do_not_use_when": [
-        "the owner already chose a seller and wants to place an order immediately",
-        "the request is to complete checkout or move money instead of comparing offers"
-      ],
-      "permission_class": "read_only",
-      "dry_run_supported": true,
-      "requires_connected_accounts": [],
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string",
-            "description": "Product name, model number, or search phrase to compare."
-          },
-          "max_results": {
-            "type": "integer",
-            "description": "Maximum number of offers to return in the comparison.",
-            "default": 5
-          }
-        },
-        "required": ["query"],
-        "additionalProperties": false
-      },
-      "output_schema": {
-        "type": "object",
-        "properties": {
-          "summary": {
-            "type": "string",
-            "description": "One-line overview of the best available deal."
-          },
-          "offers": {
-            "type": "array",
-            "description": "Ranked offers returned by the comparison engine.",
-            "items": {
-              "type": "object"
-            }
-          },
-          "best_offer": {
-            "type": "object",
-            "description": "Top-ranked offer chosen from the returned offers."
-          }
-        },
-        "required": ["summary", "offers", "best_offer"],
-        "additionalProperties": false
-      },
-      "usage_hints": [
-        "Use this tool when the user has named a product and needs evidence-backed price comparison.",
-        "Present the offers in ascending price order and call out important retailer differences."
-      ],
-      "result_hints": [
-        "Highlight the best_offer first, then summarize notable trade-offs such as shipping or stock.",
-        "If multiple offers are close, explain why one is better value instead of only naming the cheapest."
-      ],
-      "error_hints": [
-        "If no offers are found, ask the owner for a clearer product name or model number.",
-        "If retailer coverage is limited, say which sources were searched before suggesting a retry."
-      ]
-    }
-  }
+  "approved": true
 }
 ```
 
@@ -1563,10 +1496,11 @@ This is the currently documented public path for end-to-end validation. The olde
 ### Revising your tool manual after feedback
 
 If your score is below grade B or the publish gate blocks your API, update the
-draft in `/owner/publish`, rerun `siglume score . --remote` (or
-`client.preview_quality_score(...)`), and then repeat the
-`auto-register` → `confirm-auto-register` flow with a corrected full tool
-manual. Public release-publish endpoints are not yet exposed in
+local source, `tool_manual.json`, and runtime validation inputs, rerun
+`siglume score . --remote` (or `client.preview_quality_score(...)`), and then
+repeat the `auto-register` -> `confirm-auto-register` flow with the same
+`capability_key`. `/owner/publish` is read-only after submission. Public
+release-publish endpoints are not yet exposed in
 `openapi/developer-surface.yaml`.
 
 ---

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -333,8 +333,6 @@ Use this flow from CLI / SDK / automation:
   - `tool_manual.json`
   - `runtime_validation.json`
   - optional `oauth_credentials.json` for seller-side OAuth app credentials
-  - optional `input_form_spec.json`
-  - GitHub provenance from your local git checkout when available
 - `siglume register` runs manifest validation and remote Tool Manual quality
   preview before draft creation by default
 - This route requires `SIGLUME_API_KEY` or `~/.siglume/credentials.toml`
@@ -358,9 +356,9 @@ siglume register . --confirm      # confirm + publish
 
 Useful flags:
 
-- `--no-preflight`: skip the CLI preflight and attempt registration directly
-- `--force-draft`: attempt draft creation even after a failed preflight
-- `--allow-generated-manual`: allow registration with the CLI-generated fallback `tool_manual`
+- `--confirm`: confirm the draft and publish it when the self-serve checks pass
+- `--submit-review`: legacy alias for older environments
+- `--json`: emit machine-readable JSON
 
 If the listing is already live, re-run the same `capability_key` to stage an
 upgrade. `siglume register . --confirm` then publishes the next release

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -45,10 +45,16 @@ You build APIs by subclassing `AppAdapter`. The SDK handles manifest validation,
 # Install from PyPI
 pip install siglume-api-sdk
 
-# Generate a starter and validate it
+# Generate a starter and run the no-key local loop
 siglume init --template price-compare
-siglume validate .
 siglume test .
+siglume score . --offline
+
+# After deploying the real API, fill the local runtime_validation.json,
+# set SIGLUME_API_KEY, and run production checks:
+siglume validate .
+siglume score . --remote
+siglume register . --confirm
 ```
 
 Or clone the repo to browse the examples:
@@ -66,11 +72,12 @@ python examples/hello_price_compare.py
 
 ```
 my-awesome-app/
-├── my_app.py          # Your API (subclasses AppAdapter)
-├── stubs.py           # Mock external APIs for testing
-├── tests/
-│   └── test_app.py    # Tests
-└── requirements.txt
+├── adapter.py               # Your API (subclasses AppAdapter)
+├── manifest.json            # Serialized AppManifest snapshot
+├── tool_manual.json         # Editable Tool Manual contract
+├── runtime_validation.json  # Local, Git-ignored public endpoint/review-key checks
+├── .gitignore               # Keeps review keys and OAuth client secrets out of Git
+└── README.md                # Generated local workflow
 ```
 
 ---
@@ -289,12 +296,14 @@ Does your API write to anything external?
 ```
 1. Build and test locally (AppTestHarness)
 2. Deploy the real API to a public URL
-3. Keep `tool_manual.json` and `runtime_validation.json` with the project
-4. If the API uses seller-side OAuth, also keep `oauth_credentials.json` with the project
-5. Run `siglume validate .`, `siglume score . --remote`, and `siglume register`
-6. Review the result in the developer portal when needed
-7. Confirm and publish immediately when all checks pass
-8. Live in the API Store
+3. Keep `tool_manual.json` with the project
+4. Keep the local, Git-ignored `runtime_validation.json` next to the adapter
+5. If the API uses seller-side OAuth, also keep the local, Git-ignored `oauth_credentials.json` with the project
+6. Run `siglume test .` and `siglume score . --offline` before any API key is required
+7. After deployment, run `siglume validate .`, `siglume score . --remote`, and `siglume register`
+8. Review the result in the developer portal when needed
+9. Confirm and publish immediately when all checks pass
+10. Live in the API Store
 ```
 
 ### Step 1: Run local tests
@@ -331,8 +340,8 @@ Use this flow from CLI / SDK / automation:
   `/v1/market/capabilities/auto-register`
 - `siglume register` reads:
   - `tool_manual.json`
-  - `runtime_validation.json`
-  - optional `oauth_credentials.json` for seller-side OAuth app credentials
+  - local, Git-ignored `runtime_validation.json`
+  - optional local, Git-ignored `oauth_credentials.json` for seller-side OAuth app credentials
 - `siglume register` runs manifest validation and remote Tool Manual quality
   preview before draft creation by default
 - This route requires `SIGLUME_API_KEY` or `~/.siglume/credentials.toml`
@@ -347,9 +356,12 @@ Use this flow from CLI / SDK / automation:
 Minimal CLI flow:
 
 ```bash
+siglume test .
+siglume score . --offline
+
+# After deployment and SIGLUME_API_KEY setup:
 siglume validate .
 siglume score . --remote
-siglume test .
 siglume register .                 # preflight + draft only
 siglume register . --confirm      # confirm + publish
 ```
@@ -405,7 +417,7 @@ A quality check runs automatically at confirmation time:
 - Seller OAuth app credentials during `auto-register`
   - if `required_connected_accounts` includes a seller-side OAuth provider
     such as X, Slack, Google, GitHub, Linear, or Notion, include that
-    provider in `oauth_credentials.json`
+    provider in the local, Git-ignored `oauth_credentials.json`
   - if an upgrade adds a new seller-side OAuth provider and the seed is
     missing, registration is rejected
 - Tool Manual quality grade **B** or above
@@ -488,8 +500,8 @@ If your API needs OAuth tokens or API keys from the agent owner (e.g., X/Twitter
 
 If the API itself also needs a seller-owned OAuth app configuration to broker
 that provider flow, include the seller app credentials in
-`oauth_credentials.json` during registration. Do not wait to create that
-configuration in the portal after publish.
+the local, Git-ignored `oauth_credentials.json` during registration. Do not
+wait to create that configuration in the portal after publish.
 
 ---
 
@@ -505,11 +517,11 @@ Submit again with the same `capability_key`.
 
 - If the listing is live, `siglume register` stages an upgrade instead of creating a new product.
 - `siglume register . --confirm` publishes the next release immediately when the self-serve checks pass again.
-- If the upgrade adds a new seller-side OAuth provider, update `oauth_credentials.json` before registering or the upgrade is rejected.
+- If the upgrade adds a new seller-side OAuth provider, update the local, Git-ignored `oauth_credentials.json` before registering or the upgrade is rejected.
 
 ### How do I manage external API credentials?
 
-Declare the account type in `required_connected_accounts`. The agent owner connects their account during API installation. If the API also needs a seller-owned OAuth app, provide that app's Client ID / Client Secret in `oauth_credentials.json` during registration or upgrade. **Never hardcode secrets in your API code.**
+Declare the account type in `required_connected_accounts`. The agent owner connects their account during API installation. If the API also needs a seller-owned OAuth app, provide that app's Client ID / Client Secret in the local, Git-ignored `oauth_credentials.json` during registration or upgrade. **Never hardcode secrets in your API code.**
 
 ### What's the difference between free and paid APIs?
 
@@ -764,7 +776,7 @@ cat > auto-register-paid-action.json <<'JSON'
     "repository_url": "https://github.com/example/growpost-publisher",
     "repo_ref": "main",
     "source_paths": ["runtime.py"],
-    "doc_paths": ["README.md", "tool_manual.json", "runtime_validation.json"],
+    "doc_paths": ["README.md", "tool_manual.json"],
     "generated_by": "siglume-cli"
   },
   "capability_key": "growpost-monthly-publisher",
@@ -972,7 +984,7 @@ response = requests.post(
             "repository_url": "https://github.com/example/my-api",
             "repo_ref": "main",
             "source_paths": ["my_api.py"],
-            "doc_paths": ["README.md", "tool_manual.json", "oauth_credentials.json"],
+            "doc_paths": ["README.md", "tool_manual.json"],
             "generated_by": "codex",
         },
         "manifest": {
@@ -1223,7 +1235,7 @@ The current on-chain flow (live as of Phase 31 on Polygon Amoy, 2026-04-18):
 - Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold the gas token.
 - Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades).
 
-SDK v0.5.0 (current release) ships the Web3 enum values for
+SDK v0.7.6 ships the Web3 enum values for
 payment-permission tools: `SettlementMode.POLYGON_MANDATE` and
 `SettlementMode.EMBEDDED_WALLET_CHARGE`. See
 [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full phase log.

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -31,7 +31,7 @@ Behind the default-on `economy_web3_adapter_enabled` flag:
 - **Provider**: `polygon_wallet` canonical settlement-provider key (aliases: `polygon`, `web3`, `web3_wallet`, `onchain`, `on_chain`). Payout destinations store a Polygon address with checksum validation.
 - **API**: `/v1/market/web3/*` endpoints for wallet lookup, token list, swap quote, mandate CRUD, and receipt listing.
 - **Admin API**: `/v1/admin/market/web3/project` triggers the projector (see Phase 2).
-- **Owner GUI**: `/owner/credits` (OwnerWalletPage) shows the Polygon Smart Wallet, active mandates, receipts, swap quotes, and a dedicated `Payouts` sub-menu for the payout-token selector. `/owner/publish` is for listing review only.
+- **Owner GUI**: `/owner/credits` (OwnerWalletPage) shows the Polygon Smart Wallet, active mandates, receipts, and swap quotes. `/owner/credits/payout` is the Wallet payout-token settings view; `/owner/publish` is for listing review only.
 
 ### Phase 2 — Solidity contracts + backend projector (shipped)
 
@@ -1313,7 +1313,7 @@ The migration has two distinct axes. Phase 9 completes **one of them** (subscrip
 
 - Everything in the **READ_ONLY** and **ACTION** permission classes — publishing, registering, executing, receipts, tool-manual validation.
 - **Free** listings (`price_model="free"`) — unaffected by the payment change.
-- **Paid subscription publish** (`price_model="subscription"`) — publish is **open**. Phase 9 unpaused it under the mock provider; Phase 31 proved it end-to-end on real Polygon Amoy (userOpHash `0xaa55cbae...`, tx_hash `0xa04699ff...`). Revenue now settles to the embedded wallet automatically; `/owner/credits/payout` (the `Payouts` sub-menu inside `/owner/credits`) is where the seller changes the payout token, while `/owner/credits` remains the wallet-claim surface. Buyers purchase via Web3 mandate, and access grants land automatically.
+- **Paid subscription publish** (`price_model="subscription"`) — publish is **open**. Phase 9 unpaused it under the mock provider; Phase 31 proved it end-to-end on real Polygon Amoy (userOpHash `0xaa55cbae...`, tx_hash `0xa04699ff...`). Revenue now settles to the Siglume embedded wallet automatically; `/owner/credits/payout` is where the seller changes the payout token. External payout wallets cannot be specified. Buyers purchase via Web3 mandate, and access grants land automatically.
 - **`PAYMENT` permission class tools** — authorable with any of the four `SettlementMode` values. `stripe_*` continues to work unchanged. `embedded_wallet_charge` is fully runtime-backed on Polygon (Phase 34). `polygon_mandate` authorizes on-chain at tool-auth time; recurring-charge dispatch is a follow-up phase.
 - SDK types, validators, and examples for non-payment flows — stable.
 - **SDK v0.3.0** — current release. The four `SettlementMode` values from
@@ -1338,7 +1338,7 @@ Embedded wallets + gas sponsorship mean this is **not** a "bring your own MetaMa
 ## For SDK users, right now
 
 1. **If your API is READ_ONLY / ACTION / free:** nothing to do. Keep building. The SDK's public API, validators, and examples are unchanged for your flow.
-2. **If you want to publish a paid subscription API:** go ahead. Paid-subscription publish is **no longer paused** as of Phase 9 (mock-backed) and proven on-chain as of Phase 31 (real Polygon Amoy completion, userOpHash `0xaa55cbae...`). The embedded wallet is the payout destination by default; use `/owner/credits` if you need to finish the wallet claim, and use `/owner/credits/payout` (the `Payouts` sub-menu) if you need to switch the payout token. Buyers purchase via Web3 mandate, and access grants land automatically. The registration flow no longer depends on Stripe Connect.
+2. **If you want to publish a paid subscription API:** go ahead. Paid-subscription publish is **no longer paused** as of Phase 9 (mock-backed) and proven on-chain as of Phase 31 (real Polygon Amoy completion, userOpHash `0xaa55cbae...`). The Siglume embedded wallet is the payout destination; use `/owner/credits/payout` only if you need to switch the payout token. Buyers purchase via Web3 mandate, and access grants land automatically. The registration flow no longer depends on Stripe Connect.
 3. **If you want a payment-permission tool that charges on Polygon:** upgrade to
    SDK v0.3.0 or newer (`pip install 'siglume-api-sdk>=0.3.0'` — quote the
    specifier so POSIX shells don't treat `>=` as a redirect) and declare
@@ -1352,6 +1352,6 @@ Embedded wallets + gas sponsorship mean this is **not** a "bring your own MetaMa
 
 - **Server-side:** Codex in-progress on main-repo `siglume` branch. Phase 1 (schema + mock API + GUI) merged 2026-04-18.
 - **SDK-side coordination:** [siglume-api-sdk#31](https://github.com/taihei-05/siglume-api-sdk/issues/31) — tracks the SDK changes that trigger the v0.2.0 breaking release.
-- **Owner GUI:** https://siglume.com/owner/credits for the Polygon wallet surface and payout-token changes (use the `Payouts` sub-menu); https://siglume.com/owner/publish for listing review.
+- **Owner GUI:** https://siglume.com/owner/credits for the Polygon wallet surface, https://siglume.com/owner/credits/payout for payout-token changes, and https://siglume.com/owner/publish for listing review.
 - **Server module:** `packages/shared-python/agent_sns/application/web3_payments.py` in the main repo.
 - This document will be updated when the real (non-mock) wallet integration ships and when the 0x swap execution becomes live.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ No permission needed. No issue to claim. Just build and register.
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
 | CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, local Git-ignored `runtime_validation.json`, and optional local Git-ignored `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
-| Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
+| Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Submitted listing content is read-only in the portal; change content by rerunning the CLI / `auto-register` with the same `capability_key`. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
 
@@ -138,15 +138,17 @@ No permission needed. No issue to claim. Just build and register.
   - paid APIs must satisfy minimum price and verified Polygon payout readiness
 - The canonical agent contract is the Tool Manual in
   `schemas/tool-manual.schema.json`.
-- `confirm-auto-register` is the final self-serve publish gate for that contract.
+- `confirm-auto-register` is the final self-serve publish gate for the immutable
+  contract submitted by `auto-register`.
 - Legal review is mandatory and fail-closed:
   - Siglume runs an LLM review for applicable-law compliance in the declared jurisdiction.
   - Siglume runs an LLM review for public-order / morals compliance.
   - If the LLM legal review cannot produce a valid pass decision, publish is blocked.
 - `source_url` and optional `source_context` let SDK / HTTP automation register
   directly from GitHub provenance. The CLI does not infer these fields from git.
-- Callers can send the full `tool_manual` during `auto-register` or
-  `confirm-auto-register`, and can optionally seed `input_form_spec`.
+- Callers must send the final `tool_manual` and optional `input_form_spec`
+  during `auto-register`; confirmation approves the submitted draft but does
+  not edit its content.
 
 #### Recommended CLI flow
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 <p align="left">
   <img
     src="./docs/assets/demo/siglume-owner-publish-demo.gif"
-    alt="Placeholder for 90s demo: auto-register an API, review it in /owner/publish, let an agent select it, then confirm the embedded-wallet payout flow from /owner/credits/payout"
+    alt="Placeholder for 90s demo: auto-register an API, review it in /owner/publish, let an agent select it, then confirm the embedded-wallet payout token in Wallet"
     width="960"
   />
 </p>
 
-> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout confirmation from `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
+> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
 > 🚀 **v0.5.0 is out** — the platform-integration release. Python + TypeScript
 > now cover webhook handling, seller-side refund / dispute flows,
@@ -114,7 +114,7 @@ No permission needed. No issue to claim. Just build and register.
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
 | CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and optional `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
-| Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Wallet claim and payout-token changes live in `/owner/credits` under the `Payouts` sub-menu. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
+| Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
 
@@ -173,7 +173,7 @@ For upgrades, run the same commands again with the same `capability_key`.
 publishes the next release immediately when the checks pass.
 
 - **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review drafts, blockers, and live status)
-- **Wallet** → [siglume.com/owner/credits](https://siglume.com/owner/credits) (claim the embedded wallet, then use the `Payouts` sub-menu to change the payout token)
+- **Wallet** → [siglume.com/owner/credits/payout](https://siglume.com/owner/credits/payout) (embedded-wallet payout token settings; external payout wallets are not supported)
 - **API Store (buyer view)** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
 - **Getting Started** → [GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
 - **Publish Flow** → [docs/publish-flow.md](./docs/publish-flow.md) (CLI / automation registration, portal confirmation, required checks)
@@ -204,7 +204,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 | **Minimum price** | $5.00/month equivalent for subscription APIs |
 | **Free APIs** | Also supported — no wallet setup required for free listings |
 
-Both free and paid subscription APIs are supported. Free listings are fully live today; paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Paid revenue settles to your embedded Polygon wallet automatically; if you want to change the payout token, use `/owner/credits/payout` or the `Payouts` sub-menu inside `/owner/credits`.
+Both free and paid subscription APIs are supported. Free listings are fully live today; paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Paid revenue settles to your Siglume embedded Polygon wallet automatically; only the payout token is configurable, from Wallet at `/owner/credits/payout`.
 
 > **Note:** The SDK `PriceModel` enum includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`,
 > and `PER_ACTION`. These are **reserved for future phases** and are not accepted

--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> 🚀 **v0.5.0 is out** — the platform-integration release. Python + TypeScript
-> now cover webhook handling, seller-side refund / dispute flows,
-> experimental usage metering, and typed Web3 settlement helpers on top of the
-> v0.4 runtime, grading, diffing, exporter, recorder, buyer-SDK, and example
-> set.
-> Capability bundles are deferred pending a platform-first public bundle API.
-> See [RELEASE_NOTES_v0.5.0.md](./RELEASE_NOTES_v0.5.0.md) for the full release.
+> **Current release: v0.7.6.** Python and TypeScript are version-aligned and
+> cover the current production registration surface: explicit Tool Manual input,
+> runtime validation, seller OAuth seeding, paid payout readiness, webhooks,
+> usage metering, refunds / disputes, and typed Web3 settlement helpers.
+> See [CHANGELOG.md](./CHANGELOG.md) and
+> [RELEASE_NOTES_v0.7.6.md](./RELEASE_NOTES_v0.7.6.md) for the current release.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 > For the current browser-vs-CLI entry points into the same `auto-register`
@@ -76,7 +75,7 @@ If you want to scaffold quickly with an AI coding agent, give it:
 
 Recommended prompt:
 
-> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json`, `runtime_validation.json`, and any required `oauth_credentials.json` next to the adapter; then show the exact `siglume validate .`, `siglume score . --remote`, `siglume test .`, and `siglume register . --confirm` steps.
+> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json` and the local, Git-ignored `runtime_validation.json` next to the adapter; if seller-side OAuth is required, also create the local, Git-ignored `oauth_credentials.json`; then show the exact no-key local loop (`siglume test .`, `siglume score . --offline`) and the API-key production loop (`siglume validate .`, `siglume score . --remote`, `siglume register . --confirm`).
 
 ---
 
@@ -92,19 +91,20 @@ This is the main use case. You build an API, register it, and earn revenue.
 1. Build your API with AppAdapter (see examples/ for templates)
 2. Test locally with AppTestHarness
 3. Deploy the real API to a public URL
-4. Keep `tool_manual.json` and `runtime_validation.json` next to your adapter
-5. If the API uses seller-side OAuth, also keep `oauth_credentials.json` next to your adapter
-6. Run `siglume register . --confirm`
-7. Review the result in the developer portal when needed
-7. Confirm → immediately published to the API Store when all checks pass
-8. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
+4. Keep `tool_manual.json` and the local, Git-ignored `runtime_validation.json` next to your adapter
+5. If the API uses seller-side OAuth, also keep the local, Git-ignored `oauth_credentials.json` next to your adapter
+6. Run `siglume test .` and `siglume score . --offline`
+7. Set `SIGLUME_API_KEY`, then run `siglume validate .`, `siglume score . --remote`, and `siglume register . --confirm`
+8. Review the result in the developer portal when needed
+9. Confirmed listings publish immediately when all checks pass
+10. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
 ```
 
 If the listing already exists and is live, re-run the same `capability_key` to
 stage an upgrade. `siglume register . --confirm` publishes the next release
 immediately when the same self-serve checks pass. If the upgrade adds a new
-seller-side OAuth provider, `oauth_credentials.json` must already include that
-provider or the upgrade is rejected.
+seller-side OAuth provider, the local Git-ignored `oauth_credentials.json` must
+already include that provider or the upgrade is rejected.
 
 **You do not submit a PR to this repo.** You register directly on the platform.
 No permission needed. No issue to claim. Just build and register.
@@ -113,7 +113,7 @@ No permission needed. No issue to claim. Just build and register.
 
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
-| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and optional `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
+| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, local Git-ignored `runtime_validation.json`, and optional local Git-ignored `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
 | Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
@@ -126,7 +126,7 @@ No permission needed. No issue to claim. Just build and register.
 - OAuth-backed APIs now require seller-owned OAuth app credentials during
   registration and upgrade:
   - declare the provider in `required_connected_accounts`
-  - include the seller app credentials in `oauth_credentials.json`
+  - include the seller app credentials in the local Git-ignored `oauth_credentials.json`
   - if a new provider appears in an upgrade and the seed is missing, registration is blocked
 - Siglume blocks draft creation if the public API cannot be reached or the
   functional test does not match the declared response shape.
@@ -154,11 +154,15 @@ No permission needed. No issue to claim. Just build and register.
 siglume init --template price-compare
 # edit adapter.py
 # edit tool_manual.json
-# edit runtime_validation.json with your real deployed API URL and review/test key
-# if the API uses seller-side OAuth, add oauth_credentials.json with the seller OAuth app credentials
+# run the no-key local loop first
+siglume test .
+siglume score . --offline
+
+# deploy the real API, then edit the local runtime_validation.json with your public URL and review/test key
+# if the API uses seller-side OAuth, add the local oauth_credentials.json with the seller OAuth app credentials
+# set SIGLUME_API_KEY or ~/.siglume/credentials.toml before the production checks
 siglume validate .
 siglume score . --remote
-siglume test .
 siglume register .                 # preflight + draft only
 siglume register . --confirm      # confirm + publish
 ```
@@ -235,13 +239,22 @@ Install from PyPI:
 pip install siglume-api-sdk
 ```
 
-Generate a starter project and validate it:
+Generate a starter project and run the no-key local loop:
 
 ```bash
 siglume init --template price-compare
+siglume test .
+siglume score . --offline
+```
+
+After you deploy the real API, replace placeholders in the local
+`runtime_validation.json`, set `SIGLUME_API_KEY`, and run the production
+checks:
+
+```bash
 siglume validate .
 siglume score . --remote
-siglume test .
+siglume register . --confirm
 ```
 
 Or generate a wrapper directly from a first-party owner operation:
@@ -249,6 +262,10 @@ Or generate a wrapper directly from a first-party owner operation:
 ```bash
 siglume init --list-operations
 siglume init --from-operation owner.charter.update ./my-charter-editor
+siglume test ./my-charter-editor
+siglume score ./my-charter-editor --offline
+
+# After replacing runtime_validation.json placeholders and setting SIGLUME_API_KEY:
 siglume validate ./my-charter-editor
 ```
 
@@ -456,7 +473,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is an early-stage project (v0.5.0, alpha) with a growing but still
+This is an early-stage project (v0.7.6, alpha) with a growing but still
 small user base. The SDK and platform are actively evolving. Start with
 a small read-only API to learn the flow.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ print(m)
 
 ---
 
+## Using Codex or Claude Code
+
+If you want to scaffold quickly with an AI coding agent, give it:
+
+- this repository
+- `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`
+- your API idea
+- the external API docs you want to wrap
+- deployed endpoint details and review/test key requirements, if already known
+
+Recommended prompt:
+
+> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json`, `runtime_validation.json`, and any required `oauth_credentials.json` next to the adapter; then show the exact `siglume validate .`, `siglume score . --remote`, `siglume test .`, and `siglume register . --confirm` steps.
+
+---
+
 ## How to participate
 
 There are **two ways** to contribute. Choose the one that fits you:
@@ -97,7 +113,7 @@ No permission needed. No issue to claim. Just build and register.
 
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
-| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, optional `input_form_spec.json`, optional `oauth_credentials.json`, and GitHub provenance when available, runs preflight by default, then calls `auto-register`. Re-run the same `capability_key` to stage an upgrade. |
+| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and optional `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
 | Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Wallet claim and payout-token changes live in `/owner/credits` under the `Payouts` sub-menu. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
@@ -127,8 +143,8 @@ No permission needed. No issue to claim. Just build and register.
   - Siglume runs an LLM review for applicable-law compliance in the declared jurisdiction.
   - Siglume runs an LLM review for public-order / morals compliance.
   - If the LLM legal review cannot produce a valid pass decision, publish is blocked.
-- `source_url` and optional `source_context` let a CLI / coding engine register
-  directly from GitHub provenance.
+- `source_url` and optional `source_context` let SDK / HTTP automation register
+  directly from GitHub provenance. The CLI does not infer these fields from git.
 - Callers can send the full `tool_manual` during `auto-register` or
   `confirm-auto-register`, and can optionally seed `input_form_spec`.
 
@@ -148,10 +164,9 @@ siglume register . --confirm      # confirm + publish
 ```
 
 `siglume register` now runs manifest validation and remote Tool Manual quality
-preview before draft creation. Use `--no-preflight` only when you explicitly
-want to skip that check, `--force-draft` when you still want to attempt draft
-creation after a failed preflight, and `--allow-generated-manual` only when you
-intend to register with the CLI-generated `tool_manual` template.
+preview before draft creation. The supported registration flags are
+`--confirm`, `--submit-review` as a legacy alias, and `--json` for
+machine-readable output.
 
 For upgrades, run the same commands again with the same `capability_key`.
 `siglume register` stages the upgrade, and `siglume register . --confirm`

--- a/RELEASE_NOTES_v0.7.5.md
+++ b/RELEASE_NOTES_v0.7.5.md
@@ -13,8 +13,8 @@ onboarding documentation review items.
 - Publishing docs now make `siglume register . --confirm` the standard SDK path.
 - Paid Action template docs now call out every source, naming,
   connected-account, and GrowPost-specific placeholder to replace.
-- Confirm-auto-register docs now describe Tool Manual overrides as a
-  post-draft correction path only.
+- Confirm-auto-register docs now describe Tool Manual content as finalized
+  during auto-register rather than first supplied during confirmation.
 
 ## Validation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,8 +82,8 @@ Inspect the sdist manifest (`tar -tzf dist/*.tar.gz`) — it should contain `LIC
 There are three ways to publish. In decreasing order of recommendation:
 
 - **Option 0 (strongest): GitHub Actions Trusted Publisher (OIDC)** — no token anywhere, just push a tag
-- **Option A: Persistent `.pypirc`** — convenience, accept a longer-lived token on disk
-- **Option B: Per-release env vars** — strictest token rotation, most manual friction
+- **Option A: Per-release env vars** — fallback only, no token left on disk
+- **Option B: Persistent `.pypirc`** — last-resort fallback only, accepts a longer-lived token on disk
 
 ### Option 0: Trusted Publisher via GitHub Actions (recommended for all production releases)
 
@@ -130,13 +130,29 @@ You can monitor the run at <https://github.com/taihei-05/siglume-api-sdk/actions
 
 ---
 
-### Options A / B: token-based (for bootstrapping before OIDC is set up, or local testing)
+### Options A / B: token-based fallback only
 
-Get a project-scoped API token from <https://pypi.org/manage/account/token/> (see [SECURITY.md](./SECURITY.md#release-token-hygiene)).
+Use this only for emergency bootstrapping or local publish testing when OIDC is
+unavailable. Get a project-scoped API token from
+<https://pypi.org/manage/account/token/> (see
+[SECURITY.md](./SECURITY.md#release-credential-hygiene)).
 
 **Two ways to pass the token** — pick one:
 
-### Option A: Persistent `.pypirc` (recommended, set up once)
+### Option A: Per-release env vars
+
+```powershell
+$env:TWINE_USERNAME = "__token__"
+$env:TWINE_PASSWORD = "pypi-..."   # paste the project-scoped fallback token
+py -3.11 -m twine upload dist\*
+Remove-Item env:TWINE_USERNAME
+Remove-Item env:TWINE_PASSWORD
+```
+
+Use this if OIDC is unavailable and you do not want credentials on disk. Revoke
+the token immediately after the fallback upload.
+
+### Option B: Persistent `.pypirc` (last resort)
 
 Create `~/.pypirc` (on Windows: `%USERPROFILE%\.pypirc`, e.g. `D:\Users\<you>\.pypirc`).
 
@@ -153,7 +169,7 @@ username = __token__
 password = pypi-AgENdGVzdC5weXBpLm9yZwIk...
 ```
 
-After this, every release is just:
+After this, the fallback upload command is:
 
 ```bash
 # bash / WSL / macOS
@@ -165,21 +181,10 @@ python3.11 -m twine upload dist/*
 py -3.11 -m twine upload dist\*
 ```
 
-No token prompts, no env var dance on subsequent releases.
-
-**Security tradeoff — read before choosing Option A:** [SECURITY.md](./SECURITY.md#release-token-hygiene) rule 3 recommends rotating the token after every release. Persistent `.pypirc` trades that per-release rotation for convenience; the token stays valid on disk between releases. Choose Option A only if you accept the longer-lived token and keep the file on a trusted disk (no shared machine, no cloud sync of your user profile). For strict compliance with the rotate-every-release policy, use **Option B** below. In either case, rotate immediately if you suspect compromise, change machines, or see unexpected releases.
-
-### Option B: Per-release env vars
-
-```powershell
-$env:TWINE_USERNAME = "__token__"
-$env:TWINE_PASSWORD = "pypi-..."   # paste the token
-py -3.11 -m twine upload dist\*
-Remove-Item env:TWINE_USERNAME
-Remove-Item env:TWINE_PASSWORD
-```
-
-Use this if you don't want credentials on disk. Revoke the token after each release.
+**Security tradeoff — read before choosing Option B:** Persistent `.pypirc`
+keeps a valid upload token on disk. Prefer OIDC, then env vars. If `.pypirc` is
+unavoidable, keep it on a trusted local disk only, delete it immediately after
+the fallback upload, and revoke the token.
 
 ### Windows terminal encoding workaround
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,25 +33,30 @@ Security-sensitive areas include:
 - receipt and audit logging
 - sandbox escape or privilege escalation paths
 
-## Release Token Hygiene
+## Release Credential Hygiene
 
-The SDK is published to PyPI. If you are publishing a release on behalf
-of the project, follow these rules:
+Production releases are published by GitHub Actions with PyPI Trusted
+Publisher / OIDC. Do not create a PyPI API token or local `.pypirc` for the
+normal release path.
 
-1. **Use a project-scoped PyPI API token.** Go to
-   <https://pypi.org/manage/account/token/>, create a token with
-   **Scope = `Project: siglume-api-sdk`** (not `Entire account`).
-2. **Do not paste tokens into shell history.** Prefer environment
-   variables set in a short-lived subshell, or use `keyring`-backed
-   `twine` configuration.
-3. **Rotate after every release.** Revoke the token on the PyPI token
-   management page immediately after `twine upload` completes, then
-   issue a fresh project-scoped token for the next release.
-4. **Do not commit tokens.** `.pypirc`, `.env`, and any file matching
-   `pypi-*` is excluded by `.gitignore`; verify with `git status`
-   before every commit.
+For a production release:
 
-If a token is accidentally exposed (in shell history, a screenshot, a
-paste into chat, etc.), revoke it immediately via the PyPI token
-management page. The old token becomes invalid; all prior uploads
-remain valid.
+1. Verify `.github/workflows/release.yml` still publishes with the `pypi`
+   environment and `id-token: write`.
+2. Push an annotated `vX.Y.Z` tag that matches `pyproject.toml`.
+3. Let GitHub Actions build, check, and publish the artifacts via OIDC.
+
+Only use a PyPI API token for emergency bootstrapping or local publish testing
+when OIDC is unavailable. If a token is unavoidable:
+
+1. Use a project-scoped token for `siglume-api-sdk`, never an account-wide
+   token.
+2. Pass it through short-lived environment variables; do not write `.pypirc`
+   unless there is no other practical option.
+3. Revoke it immediately after the fallback upload or if it appears in shell
+   history, screenshots, logs, commits, or chat.
+
+Generated developer projects may contain local review keys in
+`runtime_validation.json` and OAuth client secrets in `oauth_credentials.json`.
+The SDK templates generate a `.gitignore` that excludes those files; verify
+with `git status --ignored` before publishing your own API source repository.

--- a/docs/connected-accounts.md
+++ b/docs/connected-accounts.md
@@ -1,7 +1,7 @@
 # Connected Accounts Guide
 
 Siglume APIs can depend on user-linked external accounts such as
-Slack, X, Google, Notion, OpenAI, or MetaMask.
+Slack, X/Twitter, Google, GitHub, Linear, or Notion.
 
 The SDK exposes two distinct concerns:
 
@@ -76,7 +76,7 @@ client.revoke_connected_account("ca_123")
 List required providers in `required_connected_accounts`:
 
 ```python
-required_connected_accounts=["slack", "openai"]
+required_connected_accounts=["slack", "github"]
 ```
 
 ## What Your Runtime Receives
@@ -85,7 +85,7 @@ At execution time, Siglume provides an opaque `ConnectedAccountRef`:
 
 ```python
 ConnectedAccountRef(
-    provider_key="x-twitter",
+    provider_key="twitter",
     session_token="short-lived-scoped-token",
     scopes=["tweet.write"],
     environment=Environment.LIVE,

--- a/docs/demo-capture-guide.md
+++ b/docs/demo-capture-guide.md
@@ -14,8 +14,8 @@ The current beta separates buyer and seller flows:
 
 Paid subscription publishing is open (Phase 31 proven on Polygon Amoy with
 a real user-operation, 2026-04-18; see `PAYMENT_MIGRATION.md`). Record the
-embedded-wallet payout flow from `/owner/credits`, using the dedicated
-`Payouts` sub-menu for payout-token changes. If a live on-chain payout is too
+embedded-wallet payout flow from Wallet at `/owner/credits/payout`, where only
+the payout token can be changed. If a live on-chain payout is too
 fragile for the take, fall back to showing the wallet page and point to the
 release notes.
 
@@ -35,7 +35,7 @@ because viewers can understand the job-to-be-done in a single glance.
    step details if available.
 7. Open `/owner/credits/payout` and show the payout-token control, then switch
    back to the wallet overview if you also want to show the embedded-wallet
-   address or claim state.
+   address.
 
 Optional: if you want a public-store establishing shot, prepend a 2-3 second
 cut of `/owner/apps` before the seller flow. Do not use `/owner/apps` as the
@@ -124,7 +124,7 @@ On-screen text:
 `6. Verify payout setup`
 
 Voiceover:
-`When paid monetization is enabled, the wallet page is where you finish claim and change the payout token. The platform is on on-chain settlement with gas covered; see PAYMENT_MIGRATION.md for the cutover timeline.`
+`When paid monetization is enabled, the wallet page is where you change the payout token. The payout destination is the Siglume embedded wallet; see PAYMENT_MIGRATION.md for the cutover timeline.`
 
 ## Short README GIF
 
@@ -147,7 +147,7 @@ This keeps the README lightweight while still proving the flow.
 - Use `125%-150%` browser zoom so text stays readable.
 - Move the cursor slowly and disable notifications.
 - Blur personal data, external account identifiers, and anything tied to a
-  real payout destination (bank account or wallet address).
+  wallet address, account identifiers, or other personal data.
 
 ## Export the README GIF
 

--- a/docs/demo-capture-guide.md
+++ b/docs/demo-capture-guide.md
@@ -174,12 +174,10 @@ docs/assets/demo/siglume-owner-publish-demo.gif
 [![License](https://img.shields.io/badge/license-MIT-16a34a?style=flat-square)](./LICENSE)
 
 <p align="left">
-  <a href="https://www.loom.com/share/REPLACE_WITH_YOUR_90S_VIDEO_URL">
-    <img
-      src="./docs/assets/demo/siglume-owner-publish-demo.gif"
-      alt="Demo: auto-register an API, review it in the developer portal, let an agent select it, and verify payout setup"
-      width="960"
-    />
-  </a>
+  <img
+    src="./docs/assets/demo/siglume-owner-publish-demo.gif"
+    alt="Demo: auto-register an API, review it in the developer portal, let an agent select it, and verify payout setup"
+    width="960"
+  />
 </p>
 ```

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -120,13 +120,13 @@ manual = ToolManual(
     tool_name="charge_subscription",
     # ... required fields ...
     permission_class=ToolManualPermissionClass.PAYMENT,
-    approval_summary_template="Charge ${amount} to {card}?",
+    approval_summary_template="Charge ${amount} through the owner's embedded wallet?",
     preview_schema={...},
     idempotency_support=True,
     side_effect_summary="Debits the owner's connected wallet via the platform's payment adapter.",
     quote_schema={...},
     currency="USD",
-    settlement_mode=SettlementMode.STRIPE_PAYMENT_INTENT,
+    settlement_mode=SettlementMode.EMBEDDED_WALLET_CHARGE,
     refund_or_cancellation_note="Full refund within 7 days per platform policy.",
     jurisdiction="US",  # required for action/payment
     legal_notes="Refunds follow US FTC Rule 16 CFR 429. Not offered to EU users.",
@@ -145,11 +145,9 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
 - **JSON schemas** (`schemas/app-manifest.schema.json`,
   `schemas/tool-manual.schema.json`) enforce `pattern: ^[A-Z]{2}(-[A-Z0-9]{1,3})?$`.
 - **Platform-side**: the review step checks the declared jurisdiction for
-  consistency with the developer's payout setup (historically the Stripe
-  Connect onboarding country; during the on-chain migration this will move
-  to a wallet/account-level declaration — see
-  [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md)). Mismatches surface as a
-  quality-report warning.
+  consistency with the listing, runtime sample, payout readiness, and legal
+  review result. Mismatches surface as a quality-report warning or a blocking
+  publish error depending on severity.
 
 ## Applicable regulations
 
@@ -175,9 +173,8 @@ dollars. This is enforced:
 - The platform's registration endpoint rejects non-USD payloads with a 422
   (`CURRENCY_NOT_SUPPORTED`).
 
-Why: the payout rail (Stripe Connect today, on-chain embedded wallet after
-cutover), platform-fee accounting, the 93.4% / 6.6% revenue split, and the
-$5.00/month minimum for subscription APIs all
+Why: platform-fee accounting, embedded-wallet settlement, the 93.4% / 6.6%
+revenue split, and the $5.00/month minimum for subscription APIs all
 operate in USD. Mixing currencies would fragment payouts and break the fee
 model.
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -18,11 +18,15 @@ That execution method is used by:
 
 The browser portal does **not** run registration directly. The portal is for:
 
-- reviewing the draft result
+- reviewing the immutable draft result
 - inspecting blockers and live status
 - confirming embedded-wallet payout-token readiness
 - confirming the draft for immediate publish
 - rotating or repairing seller OAuth app credentials after registration
+
+Submitted listing content is read-only in the portal. To change a submitted
+API, edit the source-side registration inputs and rerun `siglume register` /
+`auto-register` with the same `capability_key`.
 
 There is no normal human review step in the self-serve publish flow anymore.
 
@@ -47,7 +51,8 @@ There is no normal human review step in the self-serve publish flow anymore.
    mandatory LLM legal checks.
 10. If the checks pass, Siglume creates a private draft listing or stages an
    upgrade for the existing live listing.
-11. The developer opens the portal confirmation page to inspect the result.
+11. The developer opens the portal confirmation page to inspect the immutable
+    result.
 12. The developer confirms the draft with `siglume register . --confirm` or
     `confirm-auto-register`.
 13. Siglume publishes the listing immediately when the final checks still pass.
@@ -143,8 +148,7 @@ preflight errors before calling `auto-register`.
   - required core fields include `input_schema`, `output_schema`,
     `trigger_conditions`, `do_not_use_when`, `usage_hints`,
     `result_hints`, and `error_hints`
-  - callers can send a full `tool_manual` object during `auto-register`
-    or `confirm-auto-register`
+  - callers must send the final `tool_manual` object during `auto-register`
 - Contract consistency checks:
   - the runtime sample request must satisfy `input_schema`
   - the live response must satisfy `output_schema`
@@ -152,7 +156,7 @@ preflight errors before calling `auto-register`.
   - `requires_connected_accounts` must match between listing data and the Tool Manual
 - Optional UI contract layer:
   - `input_form_spec` can be seeded during `auto-register`
-  - or overridden during `confirm-auto-register`
+  - confirmation does not edit the submitted UI contract
 - For paid APIs: minimum price and an active embedded Polygon wallet before publish
 
 `request_payload` is the canonical runtime sample field. The server accepts
@@ -196,7 +200,7 @@ The intended advanced flow is:
    - `runtime_validation`
    - optional `oauth_credentials`
    - optional `input_form_spec`
-6. You review the resulting draft in the portal.
+6. You review the immutable draft in the portal.
 7. You confirm the draft and publish immediately if the final checks pass.
 
 This is the recommended path for AI-assisted registration because it avoids

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -20,7 +20,7 @@ The browser portal does **not** run registration directly. The portal is for:
 
 - reviewing the draft result
 - inspecting blockers and live status
-- confirming wallet payout readiness
+- confirming embedded-wallet payout-token readiness
 - confirming the draft for immediate publish
 - rotating or repairing seller OAuth app credentials after registration
 
@@ -165,8 +165,9 @@ curl https://siglume.com/v1/market/developer/portal \
 ```
 
 `data.payout_readiness.verified_destination` must be true, or auto-register
-blocks with `store.payout_destination`. If it is false, open `/owner/credits`,
-finish the wallet claim if needed, and confirm the embedded-wallet payout route.
+blocks with `store.payout_destination`. If it is false, open
+`/owner/credits/payout` and confirm the embedded-wallet payout token. External
+payout wallets cannot be specified.
 
 ## GitHub / engine-first mode
 
@@ -257,6 +258,6 @@ Use the portal to:
 - review draft results and validation outcomes
 - inspect publish blockers
 - confirm the draft and verify live status
-- confirm wallet payout readiness
+- confirm embedded-wallet payout-token readiness
 - rotate or repair seller OAuth app credentials after registration
 - issue, delete, or rotate CLI tokens when needed

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -34,20 +34,23 @@ There is no normal human review step in the self-serve publish flow anymore.
    engine.
 4. The engine reads your source, docs, manifest hints, Tool Manual files, and
    runtime validation inputs.
-5. If the API uses seller-side OAuth, the engine also includes
-   `oauth_credentials.json`.
-6. Run CLI preflight first:
+5. If the API uses seller-side OAuth, the engine also includes the local,
+   Git-ignored `oauth_credentials.json`.
+6. Run the no-key local loop first:
+   - `siglume test .`
+   - `siglume score . --offline`
+7. After deployment and `SIGLUME_API_KEY` setup, run CLI production preflight:
    - `siglume validate .`
    - `siglume score . --remote`
-7. The engine calls `siglume register .` or `auto-register`.
-8. Siglume runs runtime, contract, pricing, payout, seller OAuth, and
+8. The engine calls `siglume register .` or `auto-register`.
+9. Siglume runs runtime, contract, pricing, payout, seller OAuth, and
    mandatory LLM legal checks.
-9. If the checks pass, Siglume creates a private draft listing or stages an
+10. If the checks pass, Siglume creates a private draft listing or stages an
    upgrade for the existing live listing.
-10. The developer opens the portal confirmation page to inspect the result.
-11. The developer confirms the draft with `siglume register . --confirm` or
+11. The developer opens the portal confirmation page to inspect the result.
+12. The developer confirms the draft with `siglume register . --confirm` or
     `confirm-auto-register`.
-12. Siglume publishes the listing immediately when the final checks still pass.
+13. Siglume publishes the listing immediately when the final checks still pass.
 
 ## What auto-register does
 
@@ -93,11 +96,11 @@ By default, the CLI expects:
 
 - `adapter.py` or another single `AppAdapter` file
 - `tool_manual.json`
-- `runtime_validation.json`
+- local, Git-ignored `runtime_validation.json`
 
 It also uses these when present:
 
-- `oauth_credentials.json` for seller-side OAuth app credentials
+- local, Git-ignored `oauth_credentials.json` for seller-side OAuth app credentials
 
 SDK / HTTP automation can pass `source_url`, `source_context`, and
 `input_form_spec` directly to `auto-register`, but the current CLI project
@@ -125,7 +128,7 @@ preflight errors before calling `auto-register`.
   - expected response fields
 - For OAuth-backed APIs that use seller-owned OAuth apps:
   - declare the provider in `required_connected_accounts`
-  - include the seller OAuth app credentials in `oauth_credentials.json`
+  - include the seller OAuth app credentials in the local Git-ignored `oauth_credentials.json`
   - upgrades that add a new provider are blocked until the new seed is included
 - Listing metadata such as:
   - `name`
@@ -202,7 +205,7 @@ source repository.
 
 Recommended prompt for a coding engine:
 
-> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json`, `runtime_validation.json`, and any required `oauth_credentials.json` next to the adapter; then show the exact `siglume validate .`, `siglume score . --remote`, `siglume test .`, and `siglume register . --confirm` steps.
+> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json` and the local, Git-ignored `runtime_validation.json` next to the adapter; if seller-side OAuth is required, also create the local, Git-ignored `oauth_credentials.json`; then show the exact no-key local loop (`siglume test .`, `siglume score . --offline`) and the API-key production loop (`siglume validate .`, `siglume score . --remote`, `siglume register . --confirm`).
 
 ## Where the schema lives
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -98,18 +98,18 @@ By default, the CLI expects:
 It also uses these when present:
 
 - `oauth_credentials.json` for seller-side OAuth app credentials
-- `input_form_spec.json`
-- `source_context.json`
-- Git metadata from the local checkout to derive `source_url` and `source_context`
+
+SDK / HTTP automation can pass `source_url`, `source_context`, and
+`input_form_spec` directly to `auto-register`, but the current CLI project
+loader does not read those values from sidecar files.
 
 Before draft creation, `siglume register` runs:
 
 - local manifest validation
 - remote Tool Manual quality preview
 
-Use `--no-preflight` to skip that step, `--force-draft` to continue after a
-failed preflight, and `--allow-generated-manual` only if you intentionally want
-to register with the CLI-generated Tool Manual template.
+The CLI intentionally does not expose a bypass flag for these checks. Fix
+preflight errors before calling `auto-register`.
 
 ## What is required today
 
@@ -198,6 +198,10 @@ The intended advanced flow is:
 This is the recommended path for AI-assisted registration because it avoids
 manual browser form entry and keeps the registration contract close to the
 source repository.
+
+Recommended prompt for a coding engine:
+
+> Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`; use the API idea and external API docs I provide; build a Siglume API that follows the documented CLI-first flow; keep `tool_manual.json`, `runtime_validation.json`, and any required `oauth_credentials.json` next to the adapter; then show the exact `siglume validate .`, `siglume score . --remote`, `siglume test .`, and `siglume register . --confirm` steps.
 
 ## Where the schema lives
 

--- a/docs/template-generator.md
+++ b/docs/template-generator.md
@@ -26,8 +26,12 @@ Generate a starter project for one operation:
 
 ```bash
 siglume init --from-operation owner.charter.update ./my-charter-editor
-siglume validate ./my-charter-editor
 siglume test ./my-charter-editor
+siglume score ./my-charter-editor --offline
+
+# After replacing runtime_validation.json placeholders and setting SIGLUME_API_KEY:
+siglume validate ./my-charter-editor
+siglume score ./my-charter-editor --remote
 ```
 
 You can override the generated capability key and target owner agent:
@@ -48,6 +52,8 @@ The Python CLI writes:
 - `stubs.py`: fallback mock provider for local dry runs
 - `manifest.json`: serialized `AppManifest`
 - `tool_manual.json`: machine-generated `ToolManual`
+- `runtime_validation.json`: local, Git-ignored public endpoint/review-key checks for registration
+- `.gitignore`: excludes local review keys and seller OAuth client secrets
 - `README.md`: generated usage notes
 - `tests/test_adapter.py`: harness smoke test
 

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -20,8 +20,8 @@ What the SDK does **not** do:
 
 The actual settlement flow is owned by the Siglume platform contracts
 (`SubscriptionHub` and related web3 services). Gas is platform-paid. Manifest
-pricing stays USD-only, while settlement tokens may be `JPYC`, `USDC`, or
-other platform-supported Polygon assets.
+pricing stays USD-only. Current Polygon settlement and swap token support is
+limited to `USDC` and `JPYC`.
 
 ## Client helpers
 

--- a/examples/generated/owner_approval_policy_update/.gitignore
+++ b/examples/generated/owner_approval_policy_update/.gitignore
@@ -1,0 +1,23 @@
+# Local secrets and registration-only runtime checks.
+.env
+.env.*
+!.env.example
+runtime_validation.json
+runtime-validation.json
+oauth_credentials.json
+oauth-credentials.json
+
+# Python / test artifacts.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# JavaScript tooling if this project also uses TypeScript helpers.
+node_modules/
+coverage/

--- a/examples/generated/owner_approval_policy_update/README.md
+++ b/examples/generated/owner_approval_policy_update/README.md
@@ -15,12 +15,31 @@ This starter wraps the first-party Siglume owner operation `owner.approval_polic
 - `stubs.py`: mock fallback used when `SIGLUME_API_KEY` is not set
 - `manifest.json`: reviewable manifest snapshot
 - `tool_manual.json`: machine-generated ToolManual scaffold
+- `runtime_validation.json`: local public endpoint and review-key checks used by auto-register
+- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git
 - `tests/test_adapter.py`: smoke test for `AppTestHarness`
+
+Before registering, replace all generated placeholders:
+- In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.
+- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.
+- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.
+- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.
+- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.
 
 ## Commands
 
+Start locally without a Siglume API key:
+
 ```bash
-siglume validate .
 siglume test .
 pytest tests/test_adapter.py
+siglume score . --offline
+```
+
+After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-aligned checks and register:
+
+```bash
+siglume validate .
+siglume score . --remote
+siglume register . --confirm
 ```

--- a/examples/generated/owner_approval_policy_update/adapter.py
+++ b/examples/generated/owner_approval_policy_update/adapter.py
@@ -66,6 +66,8 @@ class OwnerApprovalPolicyUpdateWrapperApp(AppAdapter):
             price_model=PriceModel.FREE,
             jurisdiction="US",
             short_description="Update the owner approval policy.",
+            support_contact="support@example.com",
+            docs_url="https://example.com/docs",
             example_prompts=["Run owner.approval_policy.update for my owned agent."],
         )
 

--- a/examples/generated/owner_approval_policy_update/manifest.json
+++ b/examples/generated/owner_approval_policy_update/manifest.json
@@ -16,8 +16,8 @@
   "applicable_regulations": [],
   "data_residency": "US",
   "short_description": "Update the owner approval policy.",
-  "docs_url": "",
-  "support_contact": "",
+  "docs_url": "https://example.com/docs",
+  "support_contact": "support@example.com",
   "compatibility_tags": [],
   "latency_tier": "normal",
   "example_prompts": [

--- a/examples/generated/owner_budget_get/.gitignore
+++ b/examples/generated/owner_budget_get/.gitignore
@@ -1,0 +1,23 @@
+# Local secrets and registration-only runtime checks.
+.env
+.env.*
+!.env.example
+runtime_validation.json
+runtime-validation.json
+oauth_credentials.json
+oauth-credentials.json
+
+# Python / test artifacts.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# JavaScript tooling if this project also uses TypeScript helpers.
+node_modules/
+coverage/

--- a/examples/generated/owner_budget_get/README.md
+++ b/examples/generated/owner_budget_get/README.md
@@ -15,12 +15,31 @@ This starter wraps the first-party Siglume owner operation `owner.budget.get`.
 - `stubs.py`: mock fallback used when `SIGLUME_API_KEY` is not set
 - `manifest.json`: reviewable manifest snapshot
 - `tool_manual.json`: machine-generated ToolManual scaffold
+- `runtime_validation.json`: local public endpoint and review-key checks used by auto-register
+- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git
 - `tests/test_adapter.py`: smoke test for `AppTestHarness`
+
+Before registering, replace all generated placeholders:
+- In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.
+- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.
+- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.
+- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.
+- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.
 
 ## Commands
 
+Start locally without a Siglume API key:
+
 ```bash
-siglume validate .
 siglume test .
 pytest tests/test_adapter.py
+siglume score . --offline
+```
+
+After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-aligned checks and register:
+
+```bash
+siglume validate .
+siglume score . --remote
+siglume register . --confirm
 ```

--- a/examples/generated/owner_budget_get/adapter.py
+++ b/examples/generated/owner_budget_get/adapter.py
@@ -66,6 +66,8 @@ class OwnerBudgetGetWrapperApp(AppAdapter):
             price_model=PriceModel.FREE,
             jurisdiction="US",
             short_description="Read the current delegated budget.",
+            support_contact="support@example.com",
+            docs_url="https://example.com/docs",
             example_prompts=["Run owner.budget.get for my owned agent."],
         )
 

--- a/examples/generated/owner_budget_get/manifest.json
+++ b/examples/generated/owner_budget_get/manifest.json
@@ -16,8 +16,8 @@
   "applicable_regulations": [],
   "data_residency": "US",
   "short_description": "Read the current delegated budget.",
-  "docs_url": "",
-  "support_contact": "",
+  "docs_url": "https://example.com/docs",
+  "support_contact": "support@example.com",
   "compatibility_tags": [],
   "latency_tier": "normal",
   "example_prompts": [

--- a/examples/generated/owner_charter_update/.gitignore
+++ b/examples/generated/owner_charter_update/.gitignore
@@ -1,0 +1,23 @@
+# Local secrets and registration-only runtime checks.
+.env
+.env.*
+!.env.example
+runtime_validation.json
+runtime-validation.json
+oauth_credentials.json
+oauth-credentials.json
+
+# Python / test artifacts.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# JavaScript tooling if this project also uses TypeScript helpers.
+node_modules/
+coverage/

--- a/examples/generated/owner_charter_update/README.md
+++ b/examples/generated/owner_charter_update/README.md
@@ -15,12 +15,31 @@ This starter wraps the first-party Siglume owner operation `owner.charter.update
 - `stubs.py`: mock fallback used when `SIGLUME_API_KEY` is not set
 - `manifest.json`: reviewable manifest snapshot
 - `tool_manual.json`: machine-generated ToolManual scaffold
+- `runtime_validation.json`: local public endpoint and review-key checks used by auto-register
+- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git
 - `tests/test_adapter.py`: smoke test for `AppTestHarness`
+
+Before registering, replace all generated placeholders:
+- In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.
+- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.
+- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.
+- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.
+- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.
 
 ## Commands
 
+Start locally without a Siglume API key:
+
 ```bash
-siglume validate .
 siglume test .
 pytest tests/test_adapter.py
+siglume score . --offline
+```
+
+After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-aligned checks and register:
+
+```bash
+siglume validate .
+siglume score . --remote
+siglume register . --confirm
 ```

--- a/examples/generated/owner_charter_update/adapter.py
+++ b/examples/generated/owner_charter_update/adapter.py
@@ -66,6 +66,8 @@ class OwnerCharterUpdateWrapperApp(AppAdapter):
             price_model=PriceModel.FREE,
             jurisdiction="US",
             short_description="Update the owner charter.",
+            support_contact="support@example.com",
+            docs_url="https://example.com/docs",
             example_prompts=["Run owner.charter.update for my owned agent."],
         )
 

--- a/examples/generated/owner_charter_update/manifest.json
+++ b/examples/generated/owner_charter_update/manifest.json
@@ -16,8 +16,8 @@
   "applicable_regulations": [],
   "data_residency": "US",
   "short_description": "Update the owner charter.",
-  "docs_url": "",
-  "support_contact": "",
+  "docs_url": "https://example.com/docs",
+  "support_contact": "support@example.com",
   "compatibility_tags": [],
   "latency_tier": "normal",
   "example_prompts": [

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -408,10 +408,10 @@ paths:
         Confirms the auto-registered listing, runs quality check on the tool manual,
         creates a CapabilityRelease, and publishes immediately when the
         runtime, contract, pricing, payout, and mandatory LLM legal checks all pass.
-        This is the canonical publish gate for the final agent contract.
-        Include tool_manual in overrides for best quality score and explicit
-        input_schema / output_schema control. If input_form_spec was already
-        seeded during auto-register, confirm reuses it unless you override it here.
+        This is the canonical publish gate for the immutable agent contract
+        submitted by auto-register. New integrations must put final manifest,
+        tool_manual, and input_form_spec content in auto-register; current SDKs
+        confirm with approved=true only and do not send post-draft content edits.
       tags: [Capabilities]
       parameters:
         - name: listingId
@@ -432,7 +432,8 @@ paths:
                   description: Must be true to confirm
                 overrides:
                   type: object
-                  description: Override auto-detected fields before the final self-serve publish checks run
+                  deprecated: true
+                  description: Legacy compatibility only. Do not use for submitted content edits; send final content during auto-register.
                   properties:
                     name:
                       type: string
@@ -463,8 +464,10 @@ paths:
                       additionalProperties: true
                     input_form_spec:
                       type: object
+                      deprecated: true
                       additionalProperties: true
                     tool_manual:
+                      deprecated: true
                       $ref: '#/components/schemas/ToolManual'
       responses:
         '200':

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -131,7 +131,7 @@ paths:
                   description: Python source code of your API when you want server-side heuristic analysis
                 source_url:
                   type: string
-                  description: Public GitHub URL or other public source reference used by the CLI / coding engine
+                  description: Public GitHub URL or other public source reference used by SDK / HTTP automation
                 source_context:
                   type: object
                   description: Optional provenance for GitHub-driven registration

--- a/scripts/check_public_sdk_sync.py
+++ b/scripts/check_public_sdk_sync.py
@@ -13,6 +13,16 @@ IGNORE_FILE = SDK_ROOT / "public-sync-ignore.txt"
 PRIVATE_REPO = "https://github.com/taihei-05/siglume.git"
 PUBLIC_REPO = "https://github.com/taihei-05/siglume-api-sdk.git"
 PRIVATE_MIRROR_PREFIX = "packages/contracts/sdk"
+BINARY_SUFFIXES = {
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".pdf",
+    ".png",
+    ".webp",
+    ".zip",
+}
 
 
 def _run(*args: str, cwd: Path | None = None) -> str:
@@ -90,6 +100,17 @@ def _mirror_path(repo_root: Path, prefix: str, relative_path: str) -> Path:
     return root / relative_path
 
 
+def _comparable_bytes(path: Path) -> bytes:
+    data = path.read_bytes()
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return data
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
 def _compare_files(peer_dir: Path, patterns: list[str], *, peer_prefix: str) -> list[str]:
     local_files = {path for path in _tracked_files(REPO_ROOT, LOCAL_MIRROR_PREFIX) if not _is_ignored(path, patterns)}
     peer_files = {path for path in _tracked_files(peer_dir, peer_prefix) if not _is_ignored(path, patterns)}
@@ -106,8 +127,8 @@ def _compare_files(peer_dir: Path, patterns: list[str], *, peer_prefix: str) -> 
         issues.extend(f"  - {path}" for path in only_peer)
 
     for rel_path in sorted(local_files & peer_files):
-        local_bytes = _mirror_path(REPO_ROOT, LOCAL_MIRROR_PREFIX, rel_path).read_bytes()
-        peer_bytes = _mirror_path(peer_dir, peer_prefix, rel_path).read_bytes()
+        local_bytes = _comparable_bytes(_mirror_path(REPO_ROOT, LOCAL_MIRROR_PREFIX, rel_path))
+        peer_bytes = _comparable_bytes(_mirror_path(peer_dir, peer_prefix, rel_path))
         if local_bytes != peer_bytes:
             issues.append(f"  - content differs: {rel_path}")
 

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -2,7 +2,7 @@
 
 TypeScript runtime for building, testing, and registering Siglume developer apps.
 
-This package is prepared in the public SDK repo and ships with the current v0.5 release line.
+This package is prepared in the public SDK repo and ships with the current v0.7.6 release line.
 
 It also includes `draft_tool_manual()` and `fill_tool_manual_gaps()` with
 bundled `AnthropicProvider` and `OpenAIProvider` classes. Provide
@@ -58,15 +58,21 @@ For API Store publishing, the recommended CLI flow is:
 
 ```bash
 siglume init --template price-compare
+siglume test .
+siglume score . --offline
+
+# After deployment and SIGLUME_API_KEY setup:
 siglume validate .
 siglume score . --remote
-siglume test .
 siglume register .            # preflight + draft only
 siglume register . --confirm # confirm + publish
 ```
 
-`siglume register` reads `tool_manual.json`, `runtime_validation.json`, and
-optional `oauth_credentials.json`. SDK / HTTP automation can pass
+`siglume register` reads `tool_manual.json`, the local Git-ignored
+`runtime_validation.json`, and optional local Git-ignored
+`oauth_credentials.json`. Generated projects keep runtime validation and OAuth
+credential files Git-ignored because they can contain review keys and client
+secrets. SDK / HTTP automation can pass
 `source_url`, `source_context`, and `input_form_spec` directly to
 `auto-register`. The CLI runs preflight by default, then calls the same
 `auto-register` route used by SDK / automation clients. Re-run the

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -66,9 +66,10 @@ siglume register . --confirm # confirm + publish
 ```
 
 `siglume register` reads `tool_manual.json`, `runtime_validation.json`, and
-optional `input_form_spec.json`. If the API uses seller-side OAuth, it also
-reads `oauth_credentials.json`. The CLI runs preflight by default, then calls
-the same `auto-register` route used by SDK / automation clients. Re-run the
+optional `oauth_credentials.json`. SDK / HTTP automation can pass
+`source_url`, `source_context`, and `input_form_spec` directly to
+`auto-register`. The CLI runs preflight by default, then calls the same
+`auto-register` route used by SDK / automation clients. Re-run the
 same `capability_key` to stage an upgrade. The server-side publish gate
 includes runtime checks, contract checks, seller OAuth checks, pricing / payout
 rules, and a mandatory fail-closed LLM legal review for law compliance plus

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -610,7 +610,7 @@ export async function runRegistration(
     const verifiedDestination = portal.payout_readiness?.verified_destination;
     if (verifiedDestination !== true) {
       throw new SiglumeProjectError(
-        "Paid API registration requires a verified Polygon payout destination. Open https://siglume.com/owner/publish or call GET /v1/market/developer/portal until payout_readiness.verified_destination is true.",
+        "Paid API registration requires a verified Polygon payout destination. Open https://siglume.com/owner/credits/payout and confirm the embedded-wallet payout token, or call GET /v1/market/developer/portal until payout_readiness.verified_destination is true.",
       );
     }
     developerPortalPreflight = toJsonable(portal);

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -704,7 +704,7 @@ export async function writeInitTemplate(template: TemplateName, destination: str
   const gitignore_path = join(root, ".gitignore");
   const readme_path = join(root, "README.md");
 
-  for (const filePath of [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path]) {
+  for (const filePath of [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path]) {
     if (existsSync(filePath)) {
       throw new SiglumeProjectError(`${basename(filePath)} already exists in ${root}`);
     }
@@ -716,7 +716,7 @@ export async function writeInitTemplate(template: TemplateName, destination: str
   await writeFile(manifest_path, renderJson(manifest), "utf8");
   await writeFile(tool_manual_path, renderJson(toolManual), "utf8");
   await writeFile(runtime_validation_path, renderJson(buildRuntimeValidationTemplate(toolManual)), "utf8");
-  await writeFile(gitignore_path, generatedGitignore(), "utf8");
+  await writeOrMergeGitignore(gitignore_path);
   await writeFile(readme_path, readmeTemplate(template), "utf8");
   return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path];
 }
@@ -1239,6 +1239,22 @@ function generatedGitignore(): string {
   ].join("\n");
 }
 
+async function writeOrMergeGitignore(filePath: string): Promise<void> {
+  const generated = generatedGitignore();
+  if (!existsSync(filePath)) {
+    await writeFile(filePath, generated, "utf8");
+    return;
+  }
+  const existing = await readFile(filePath, "utf8");
+  const existingEntries = new Set(existing.split(/\r?\n/).map((line) => line.trim()));
+  const additions = generated.split(/\r?\n/).filter((line) => line.trim() && !existingEntries.has(line.trim()));
+  if (additions.length === 0) {
+    return;
+  }
+  const prefix = existing.endsWith("\n") ? existing : `${existing}\n`;
+  await writeFile(filePath, `${prefix}\n# Siglume generated ignores.\n${additions.join("\n")}\n`, "utf8");
+}
+
 export async function writeOperationTemplate(
   operation_key: string,
   destination: string,
@@ -1263,7 +1279,6 @@ export async function writeOperationTemplate(
     manifest_path,
     tool_manual_path,
     runtime_validation_path,
-    gitignore_path,
     readme_path,
     test_path,
   ]) {
@@ -1296,7 +1311,7 @@ export async function writeOperationTemplate(
   await writeFile(manifest_path, renderJson(manifest), "utf8");
   await writeFile(tool_manual_path, renderJson(tool_manual), "utf8");
   await writeFile(runtime_validation_path, renderJson(buildRuntimeValidationTemplate(tool_manual)), "utf8");
-  await writeFile(gitignore_path, generatedGitignore(), "utf8");
+  await writeOrMergeGitignore(gitignore_path);
   await writeFile(readme_path, operationReadmeTemplate(operation, manifest, warning), "utf8");
   await writeFile(test_path, operationTestSource(operation), "utf8");
   return {

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -701,9 +701,10 @@ export async function writeInitTemplate(template: TemplateName, destination: str
   const manifest_path = join(root, "manifest.json");
   const tool_manual_path = join(root, "tool_manual.json");
   const runtime_validation_path = join(root, "runtime_validation.json");
+  const gitignore_path = join(root, ".gitignore");
   const readme_path = join(root, "README.md");
 
-  for (const filePath of [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path]) {
+  for (const filePath of [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path]) {
     if (existsSync(filePath)) {
       throw new SiglumeProjectError(`${basename(filePath)} already exists in ${root}`);
     }
@@ -715,8 +716,9 @@ export async function writeInitTemplate(template: TemplateName, destination: str
   await writeFile(manifest_path, renderJson(manifest), "utf8");
   await writeFile(tool_manual_path, renderJson(toolManual), "utf8");
   await writeFile(runtime_validation_path, renderJson(buildRuntimeValidationTemplate(toolManual)), "utf8");
+  await writeFile(gitignore_path, generatedGitignore(), "utf8");
   await writeFile(readme_path, readmeTemplate(template), "utf8");
-  return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path];
+  return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path];
 }
 
 export async function listOperationCatalog(
@@ -1176,12 +1178,16 @@ function operationReadmeTemplate(
     "- `stubs.ts`: mock fallback used when `SIGLUME_API_KEY` is not set",
     "- `manifest.json`: reviewable manifest snapshot",
     "- `tool_manual.json`: machine-generated ToolManual scaffold",
-    "- `runtime_validation.json`: public endpoint and review-key checks used by auto-register",
+    "- `runtime_validation.json`: local public endpoint and review-key checks used by auto-register",
+    "- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git",
     "- `tests/test_adapter.ts`: smoke test for `AppTestHarness`",
     "",
     "Before registering, replace all generated placeholders:",
     "- In `adapter.ts` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
-    "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
+    "- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.",
+    "- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.",
+    "- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.",
+    "- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.",
     "",
     "## Commands",
     "",
@@ -1204,6 +1210,35 @@ function operationReadmeTemplate(
   ].join("\n");
 }
 
+function generatedGitignore(): string {
+  return [
+    "# Local secrets and registration-only runtime checks.",
+    ".env",
+    ".env.*",
+    "!.env.example",
+    "runtime_validation.json",
+    "runtime-validation.json",
+    "oauth_credentials.json",
+    "oauth-credentials.json",
+    "",
+    "# Python / test artifacts.",
+    "__pycache__/",
+    "*.py[cod]",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".coverage",
+    "htmlcov/",
+    "dist/",
+    "build/",
+    "*.egg-info/",
+    "",
+    "# JavaScript tooling if this project also uses TypeScript helpers.",
+    "node_modules/",
+    "coverage/",
+    "",
+  ].join("\n");
+}
+
 export async function writeOperationTemplate(
   operation_key: string,
   destination: string,
@@ -1219,9 +1254,19 @@ export async function writeOperationTemplate(
   const manifest_path = join(root, "manifest.json");
   const tool_manual_path = join(root, "tool_manual.json");
   const runtime_validation_path = join(root, "runtime_validation.json");
+  const gitignore_path = join(root, ".gitignore");
   const readme_path = join(root, "README.md");
   const test_path = join(testsDir, "test_adapter.ts");
-  for (const filePath of [adapter_path, stubs_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path, test_path]) {
+  for (const filePath of [
+    adapter_path,
+    stubs_path,
+    manifest_path,
+    tool_manual_path,
+    runtime_validation_path,
+    gitignore_path,
+    readme_path,
+    test_path,
+  ]) {
     if (existsSync(filePath)) {
       throw new SiglumeProjectError(`${basename(filePath)} already exists in ${root}`);
     }
@@ -1251,10 +1296,20 @@ export async function writeOperationTemplate(
   await writeFile(manifest_path, renderJson(manifest), "utf8");
   await writeFile(tool_manual_path, renderJson(tool_manual), "utf8");
   await writeFile(runtime_validation_path, renderJson(buildRuntimeValidationTemplate(tool_manual)), "utf8");
+  await writeFile(gitignore_path, generatedGitignore(), "utf8");
   await writeFile(readme_path, operationReadmeTemplate(operation, manifest, warning), "utf8");
   await writeFile(test_path, operationTestSource(operation), "utf8");
   return {
-    files: [adapter_path, stubs_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path, test_path],
+    files: [
+      adapter_path,
+      stubs_path,
+      manifest_path,
+      tool_manual_path,
+      runtime_validation_path,
+      gitignore_path,
+      readme_path,
+      test_path,
+    ],
     operation,
     report: {
       tool_manual_valid,
@@ -1697,11 +1752,15 @@ function readmeTemplate(template: TemplateName): string {
     "- `adapter.ts`: your AppAdapter implementation",
     "- `manifest.json`: serialized AppManifest snapshot",
     "- `tool_manual.json`: editable ToolManual draft for validation and registration",
-    "- `runtime_validation.json`: live API smoke-test contract used during registration",
+    "- `runtime_validation.json`: local live API smoke-test contract used during registration",
+    "- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git",
     "",
     "Before registering, replace all generated placeholders:",
     "- In `adapter.ts` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
-    "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
+    "- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.",
+    "- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.",
+    "- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.",
+    "- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.",
     "",
     "Suggested workflow:",
     "",

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -2270,22 +2270,11 @@ export class SiglumeClient implements SiglumeClientShape {
     listing_id: string,
     options: { manifest?: AppManifest | Record<string, unknown>; tool_manual?: ToolManual | Record<string, unknown> } = {},
   ): Promise<RegistrationConfirmation> {
-    const pending = this.pendingConfirmations.get(listing_id);
-    const manifestPayload = options.manifest ? coerceMapping(options.manifest, "manifest") : pending?.manifest ?? {};
-    const toolManualPayload = options.tool_manual ? coerceMapping(options.tool_manual, "tool_manual") : pending?.tool_manual ?? {};
-    const overrides: Record<string, unknown> = {};
-    for (const fieldName of ["name", "job_to_be_done"]) {
-      if (manifestPayload[fieldName]) {
-        overrides[fieldName] = manifestPayload[fieldName];
-      }
-    }
-    if (Object.keys(toolManualPayload).length > 0) {
-      overrides.tool_manual = toolManualPayload;
-    }
+    // Registration content is immutable after auto-register. Keep the
+    // historical options source-compatible, but do not send them as
+    // post-draft overrides.
+    void options;
     const payload: Record<string, unknown> = { approved: true };
-    if (Object.keys(overrides).length > 0) {
-      payload.overrides = overrides;
-    }
     const [data, meta] = await this.request("POST", `/market/capabilities/${listing_id}/confirm-auto-register`, { json_body: payload });
     this.pendingConfirmations.delete(listing_id);
     const checklist = isRecord(data.checklist)

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.5.0";
+export const SDK_VERSION = "0.7.6";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -340,7 +340,11 @@ describe("siglume CLI", () => {
     const readmeText = await readFile(join(projectDir, "README.md"), "utf8");
     const validatePayload = JSON.parse(stdout.at(-1) as string) as Record<string, unknown>;
     expect(manifest.capability_key).toBe("echo-starter");
+    const gitignoreText = await readFile(join(projectDir, ".gitignore"), "utf8");
+    expect(gitignoreText).toContain("runtime_validation.json");
+    expect(gitignoreText).toContain("oauth_credentials.json");
     expect(readmeText).toContain("Start locally without a Siglume API key");
+    expect(readmeText).toContain("Do not commit real review keys or OAuth client secrets");
     expect(readmeText.indexOf("siglume score . --offline")).toBeLessThan(readmeText.indexOf("siglume validate ."));
     expect(validatePayload.ok).toBe(true);
   });
@@ -428,13 +432,17 @@ describe("siglume CLI", () => {
     const manifest = JSON.parse(await readFile(join(projectDir, "manifest.json"), "utf8")) as Record<string, unknown>;
     const adapterText = await readFile(join(projectDir, "adapter.ts"), "utf8");
     const readmeText = await readFile(join(projectDir, "README.md"), "utf8");
+    const gitignoreText = await readFile(join(projectDir, ".gitignore"), "utf8");
     expect(manifest.docs_url).toBe("https://example.com/docs");
     expect(manifest.support_contact).toBe("support@example.com");
+    expect(gitignoreText).toContain("runtime_validation.json");
+    expect(gitignoreText).toContain("oauth_credentials.json");
     expect(adapterText).toContain("execute_owner_operation");
     expect(adapterText).toContain("support_contact: \"support@example.com\"");
     expect(adapterText).toContain("docs_url: \"https://example.com/docs\"");
     expect(readmeText).toContain("replace `docs_url` and `support_contact`");
     expect(readmeText).toContain("Start locally without a Siglume API key");
+    expect(readmeText).toContain("Do not commit real review keys or OAuth client secrets");
     expect(readmeText.indexOf("siglume score . --offline")).toBeLessThan(readmeText.indexOf("siglume validate ."));
     expect(readmeText.indexOf("npm test -- tests/test_adapter.ts")).toBeLessThan(
       readmeText.indexOf("siglume register . --confirm"),

--- a/siglume-api-sdk-ts/test/client-extra.test.ts
+++ b/siglume-api-sdk-ts/test/client-extra.test.ts
@@ -122,7 +122,7 @@ describe("SiglumeClient extra branches", () => {
     }
   });
 
-  it("prefers source_url or source_code and allows confirmation overrides", async () => {
+  it("prefers source_url or source_code and keeps confirmation immutable", async () => {
     const requests: Array<{ path: string; body: Record<string, unknown> }> = [];
     const client = new SiglumeClient({
       api_key: "sig_test_key",
@@ -164,10 +164,7 @@ describe("SiglumeClient extra branches", () => {
     expect(receipt.trace_id).toBe("trc_1");
     expect(requests[0]?.body.source_url).toBe("https://github.com/example/repo");
     expect(requests[0]?.body.source_code).toBeUndefined();
-    expect((requests[1]?.body.overrides as Record<string, unknown>).name).toBe("Override Name");
-    expect(((requests[1]?.body.overrides as Record<string, unknown>).tool_manual as Record<string, unknown>).tool_name).toBe(
-      "override_tool",
-    );
+    expect(requests[1]?.body).toEqual({ approved: true });
     expect(confirmation.status).toBe("active");
     expect((confirmation.release as { release_status?: string }).release_status).toBe("published");
     expect(confirmation.quality.grade).toBe("B");

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -216,6 +216,18 @@ describe("cli project helpers", () => {
     const dir = await mkdtemp(join(tmpdir(), "siglume-init-project-"));
     await writeInitTemplate("echo", dir);
     await expect(writeInitTemplate("echo", dir)).rejects.toThrow("adapter.ts already exists");
+  });
+
+  it("merges generated ignores into an existing .gitignore during init", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "siglume-init-existing-gitignore-"));
+    await writeFile(join(dir, ".gitignore"), "custom-local.log\nnode_modules/\n", "utf8");
+    await writeInitTemplate("echo", dir);
+    const gitignore = await readFile(join(dir, ".gitignore"), "utf8");
+
+    expect(gitignore).toContain("custom-local.log");
+    expect(gitignore).toContain("node_modules/");
+    expect(gitignore).toContain("runtime_validation.json");
+    expect(gitignore).toContain("oauth_credentials.json");
   });
 
   it("scores remote projects and marks non-publishable remote reports as failed", async () => {

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.5.0"
+SDK_VERSION = "0.7.6"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -1161,7 +1161,7 @@ def _ensure_paid_payout_ready(project: LoadedProject, client: SiglumeClient) -> 
     if readiness.get("verified_destination") is not True:
         raise click.ClickException(
             "Paid API registration requires a verified Polygon payout destination. "
-            "Open https://siglume.com/owner/publish and finish payout setup, or call "
+            "Open https://siglume.com/owner/credits/payout and confirm the embedded-wallet payout token, or call "
             "`GET /v1/market/developer/portal` and wait until "
             "`payout_readiness.verified_destination` is true."
         )

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -1011,6 +1011,25 @@ def _generated_gitignore() -> str:
     ) + "\n"
 
 
+def _write_or_merge_gitignore(path: Path) -> None:
+    generated_lines = _generated_gitignore().splitlines()
+    if not path.exists():
+        path.write_text("\n".join(generated_lines) + "\n", encoding="utf-8")
+        return
+
+    existing = path.read_text(encoding="utf-8")
+    existing_entries = {line.strip() for line in existing.splitlines()}
+    additions = [line for line in generated_lines if line.strip() and line.strip() not in existing_entries]
+    if not additions:
+        return
+
+    prefix = existing if existing.endswith("\n") else f"{existing}\n"
+    path.write_text(
+        f"{prefix}\n# Siglume generated ignores.\n" + "\n".join(additions) + "\n",
+        encoding="utf-8",
+    )
+
+
 def write_operation_template(
     operation_key: str,
     destination: Path,
@@ -1041,7 +1060,6 @@ def write_operation_template(
         manifest_path,
         tool_manual_path,
         runtime_validation_path,
-        gitignore_path,
         readme_path,
         test_path,
     ):
@@ -1067,7 +1085,7 @@ def write_operation_template(
     manifest_path.write_text(render_json(manifest), encoding="utf-8")
     tool_manual_path.write_text(render_json(tool_manual), encoding="utf-8")
     runtime_validation_path.write_text(render_json(_build_runtime_validation_template(tool_manual)), encoding="utf-8")
-    gitignore_path.write_text(_generated_gitignore(), encoding="utf-8")
+    _write_or_merge_gitignore(gitignore_path)
     readme_path.write_text(_operation_readme_template(operation, manifest, warning), encoding="utf-8")
     test_path.write_text(_operation_test_source(operation), encoding="utf-8")
     return (
@@ -1102,7 +1120,7 @@ def write_init_template(template: str, destination: Path) -> list[Path]:
     gitignore_path = destination / ".gitignore"
     readme_path = destination / "README.md"
 
-    for path in (adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path):
+    for path in (adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path):
         if path.exists():
             raise click.ClickException(f"{path.name} already exists in {destination}")
 
@@ -1120,7 +1138,7 @@ def write_init_template(template: str, destination: Path) -> list[Path]:
         render_json(_build_runtime_validation_template(project.tool_manual)),
         encoding="utf-8",
     )
-    gitignore_path.write_text(_generated_gitignore(), encoding="utf-8")
+    _write_or_merge_gitignore(gitignore_path)
     readme_path.write_text(_readme_template(template), encoding="utf-8")
     return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path]
 

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -947,12 +947,16 @@ def _operation_readme_template(operation: OperationMetadata, manifest: AppManife
             "- `stubs.py`: mock fallback used when `SIGLUME_API_KEY` is not set",
             "- `manifest.json`: reviewable manifest snapshot",
             "- `tool_manual.json`: machine-generated ToolManual scaffold",
-            "- `runtime_validation.json`: public endpoint and review-key checks used by auto-register",
+            "- `runtime_validation.json`: local public endpoint and review-key checks used by auto-register",
+            "- `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git",
             "- `tests/test_adapter.py`: smoke test for `AppTestHarness`",
             "",
             "Before registering, replace all generated placeholders:",
             "- In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.",
-            "- In `runtime_validation.json`, replace the public URL and review-key placeholders.",
+            "- In the local `runtime_validation.json`, replace the public URL and review-key placeholders.",
+            "- If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.",
+            "- Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.",
+            "- Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.",
             "",
             "## Commands",
             "",
@@ -977,6 +981,36 @@ def _operation_readme_template(operation: OperationMetadata, manifest: AppManife
     return "\n".join(lines)
 
 
+def _generated_gitignore() -> str:
+    return "\n".join(
+        [
+            "# Local secrets and registration-only runtime checks.",
+            ".env",
+            ".env.*",
+            "!.env.example",
+            "runtime_validation.json",
+            "runtime-validation.json",
+            "oauth_credentials.json",
+            "oauth-credentials.json",
+            "",
+            "# Python / test artifacts.",
+            "__pycache__/",
+            "*.py[cod]",
+            ".pytest_cache/",
+            ".mypy_cache/",
+            ".coverage",
+            "htmlcov/",
+            "dist/",
+            "build/",
+            "*.egg-info/",
+            "",
+            "# JavaScript tooling if this project also uses TypeScript helpers.",
+            "node_modules/",
+            "coverage/",
+        ]
+    ) + "\n"
+
+
 def write_operation_template(
     operation_key: str,
     destination: Path,
@@ -995,6 +1029,7 @@ def write_operation_template(
     manifest_path = destination / "manifest.json"
     tool_manual_path = destination / "tool_manual.json"
     runtime_validation_path = destination / "runtime_validation.json"
+    gitignore_path = destination / ".gitignore"
     readme_path = destination / "README.md"
     test_path = tests_dir / "test_adapter.py"
 
@@ -1006,6 +1041,7 @@ def write_operation_template(
         manifest_path,
         tool_manual_path,
         runtime_validation_path,
+        gitignore_path,
         readme_path,
         test_path,
     ):
@@ -1031,6 +1067,7 @@ def write_operation_template(
     manifest_path.write_text(render_json(manifest), encoding="utf-8")
     tool_manual_path.write_text(render_json(tool_manual), encoding="utf-8")
     runtime_validation_path.write_text(render_json(_build_runtime_validation_template(tool_manual)), encoding="utf-8")
+    gitignore_path.write_text(_generated_gitignore(), encoding="utf-8")
     readme_path.write_text(_operation_readme_template(operation, manifest, warning), encoding="utf-8")
     test_path.write_text(_operation_test_source(operation), encoding="utf-8")
     return (
@@ -1042,6 +1079,7 @@ def write_operation_template(
             manifest_path,
             tool_manual_path,
             runtime_validation_path,
+            gitignore_path,
             readme_path,
             test_path,
         ],
@@ -1061,9 +1099,10 @@ def write_init_template(template: str, destination: Path) -> list[Path]:
     manifest_path = destination / "manifest.json"
     tool_manual_path = destination / "tool_manual.json"
     runtime_validation_path = destination / "runtime_validation.json"
+    gitignore_path = destination / ".gitignore"
     readme_path = destination / "README.md"
 
-    for path in (adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path):
+    for path in (adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path):
         if path.exists():
             raise click.ClickException(f"{path.name} already exists in {destination}")
 
@@ -1081,8 +1120,9 @@ def write_init_template(template: str, destination: Path) -> list[Path]:
         render_json(_build_runtime_validation_template(project.tool_manual)),
         encoding="utf-8",
     )
+    gitignore_path.write_text(_generated_gitignore(), encoding="utf-8")
     readme_path.write_text(_readme_template(template), encoding="utf-8")
-    return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, readme_path]
+    return [adapter_path, manifest_path, tool_manual_path, runtime_validation_path, gitignore_path, readme_path]
 
 
 def resolve_api_key() -> str:
@@ -1681,11 +1721,15 @@ def _readme_template(template: str) -> str:
         - `adapter.py`: your AppAdapter implementation
         - `manifest.json`: serialized AppManifest snapshot
         - `tool_manual.json`: editable ToolManual draft for validation and registration
-        - `runtime_validation.json`: live API smoke-test contract used during registration
+        - `runtime_validation.json`: local live API smoke-test contract used during registration
+        - `.gitignore`: keeps runtime review keys and OAuth client secrets out of Git
 
         Before registering, replace all generated placeholders:
         - In `adapter.py` and `manifest.json`, replace `docs_url` and `support_contact` with your public documentation and support contact.
-        - In `runtime_validation.json`, replace the public URL and review-key placeholders.
+        - In the local `runtime_validation.json`, replace the public URL and review-key placeholders.
+        - If the API uses seller-side OAuth, create a local `oauth_credentials.json` next to the adapter.
+        - Do not commit real review keys or OAuth client secrets; the generated `.gitignore` excludes those files.
+        - Because `runtime_validation.json` is ignored, GitHub samples do not commit review-key values.
 
         Suggested workflow:
 

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3042,19 +3042,11 @@ class SiglumeClient:
         manifest: "AppManifest | Mapping[str, Any] | None" = None,
         tool_manual: "ToolManual | Mapping[str, Any] | None" = None,
     ) -> RegistrationConfirmation:
-        pending = self._pending_confirmations.get(listing_id, {})
-        manifest_payload = _coerce_mapping(manifest, "manifest") if manifest is not None else _to_dict(pending.get("manifest"))
-        tool_manual_payload = _coerce_mapping(tool_manual, "tool_manual") if tool_manual is not None else _to_dict(pending.get("tool_manual"))
-        overrides: dict[str, Any] = {}
-        for field_name in ("name", "job_to_be_done"):
-            value = manifest_payload.get(field_name)
-            if value:
-                overrides[field_name] = value
-        if tool_manual_payload:
-            overrides["tool_manual"] = tool_manual_payload
+        # Registration content is immutable after auto-register. Keep the
+        # historical keyword arguments source-compatible, but do not send them
+        # as post-draft overrides.
+        _ = (manifest, tool_manual)
         payload: dict[str, Any] = {"approved": True}
-        if overrides:
-            payload["overrides"] = overrides
         data, meta = self._request(
             "POST",
             f"/market/capabilities/{listing_id}/confirm-auto-register",

--- a/tests/cassettes/auto_register_flow.json
+++ b/tests/cassettes/auto_register_flow.json
@@ -158,75 +158,12 @@
         "headers": {
           "accept": "application/json",
           "authorization": "Bearer <REDACTED>",
-          "content-length": "1166",
+          "content-length": "17",
           "content-type": "application/json",
           "user-agent": "siglume-api-sdk/fixture"
         },
         "body": {
-          "approved": true,
-          "overrides": {
-            "job_to_be_done": "Compare retailer prices for a product and return the best current offer.",
-            "name": "Price Compare Helper",
-            "tool_manual": {
-              "do_not_use_when": [
-                "the request is to complete checkout or place an order instead of comparing offers"
-              ],
-              "dry_run_supported": true,
-              "error_hints": [
-                "If no offers are found, ask for a clearer product name or model number."
-              ],
-              "input_schema": {
-                "additionalProperties": false,
-                "properties": {
-                  "query": {
-                    "description": "Product name, model number, or search phrase.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "query"
-                ],
-                "type": "object"
-              },
-              "job_to_be_done": "Search multiple retailers for a product and return a ranked price comparison the agent can cite.",
-              "output_schema": {
-                "additionalProperties": false,
-                "properties": {
-                  "offers": {
-                    "description": "Ranked retailer offers.",
-                    "items": {
-                      "type": "object"
-                    },
-                    "type": "array"
-                  },
-                  "summary": {
-                    "description": "One-line overview of the best available deal.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "summary",
-                  "offers"
-                ],
-                "type": "object"
-              },
-              "permission_class": "read_only",
-              "requires_connected_accounts": [],
-              "result_hints": [
-                "Lead with the best offer and then summarize notable trade-offs."
-              ],
-              "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
-              "tool_name": "price_compare_helper",
-              "trigger_conditions": [
-                "owner asks to compare prices for a product before deciding where to buy",
-                "agent needs retailer offer data to support a shopping recommendation",
-                "request is to find the cheapest or best-value option for a product query"
-              ],
-              "usage_hints": [
-                "Use this tool after the owner has named a product and wants evidence-backed price comparison."
-              ]
-            }
-          }
+          "approved": true
         }
       },
       "response": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,20 @@ def test_init_command_writes_template_files() -> None:
         assert readme_text.index("siglume score . --offline") < readme_text.index("siglume validate .")
 
 
+def test_init_command_merges_existing_gitignore() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(".gitignore").write_text("custom-local.log\nnode_modules/\n", encoding="utf-8")
+        result = runner.invoke(main, ["init", "--template", "echo"])
+        assert result.exit_code == 0, result.output
+        gitignore_text = Path(".gitignore").read_text(encoding="utf-8")
+        assert "custom-local.log" in gitignore_text
+        assert "node_modules/" in gitignore_text
+        assert "runtime_validation.json" in gitignore_text
+        assert "oauth_credentials.json" in gitignore_text
+        assert Path("adapter.py").exists()
+
+
 def test_init_payment_template_writes_valid_tool_manual() -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,9 +131,14 @@ def test_init_command_writes_template_files() -> None:
         assert Path("manifest.json").exists()
         assert Path("tool_manual.json").exists()
         assert Path("runtime_validation.json").exists()
+        assert Path(".gitignore").exists()
         assert Path("README.md").exists()
+        gitignore_text = Path(".gitignore").read_text(encoding="utf-8")
+        assert "runtime_validation.json" in gitignore_text
+        assert "oauth_credentials.json" in gitignore_text
         readme_text = Path("README.md").read_text(encoding="utf-8")
         assert "Start locally without a Siglume API key" in readme_text
+        assert "Do not commit real review keys or OAuth client secrets" in readme_text
         assert readme_text.index("siglume score . --offline") < readme_text.index("siglume validate .")
 
 
@@ -659,7 +664,11 @@ def test_init_command_generates_operation_wrapper_with_grade_b_or_better(monkeyp
         assert Path("adapter.py").exists()
         assert Path("stubs.py").exists()
         assert Path("runtime_validation.json").exists()
+        assert Path(".gitignore").exists()
         assert Path("tests/test_adapter.py").exists()
+        gitignore_text = Path(".gitignore").read_text(encoding="utf-8")
+        assert "runtime_validation.json" in gitignore_text
+        assert "oauth_credentials.json" in gitignore_text
         manifest = json.loads(Path("manifest.json").read_text(encoding="utf-8"))
         assert manifest["docs_url"] == "https://example.com/docs"
         assert manifest["support_contact"] == "support@example.com"
@@ -674,6 +683,7 @@ def test_init_command_generates_operation_wrapper_with_grade_b_or_better(monkeyp
         assert 'docs_url="https://example.com/docs"' in adapter_text
         assert "replace `docs_url` and `support_contact`" in readme_text
         assert "Start locally without a Siglume API key" in readme_text
+        assert "Do not commit real review keys or OAuth client secrets" in readme_text
         assert readme_text.index("siglume score . --offline") < readme_text.index("siglume validate .")
         assert readme_text.index("pytest tests/test_adapter.py") < readme_text.index("siglume register . --confirm")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,7 +208,7 @@ def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: P
 
         if request.url.path == "/v1/market/capabilities/lst_123/confirm-auto-register":
             assert body["approved"] is True
-            assert body["overrides"]["tool_manual"]["tool_name"] == tool_manual.tool_name
+            assert "overrides" not in body
             return httpx.Response(
                 200,
                 json=envelope(

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -13,6 +16,14 @@ import contract_sync  # noqa: E402
 
 
 def _check_public_sdk_sync():
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "--is-inside-work-tree"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip("public SDK sync byte tests require a Git checkout")
     import check_public_sdk_sync  # noqa: PLC0415
 
     return check_public_sdk_sync

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -10,7 +10,12 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import contract_sync  # noqa: E402
-import check_public_sdk_sync  # noqa: E402
+
+
+def _check_public_sdk_sync():
+    import check_public_sdk_sync  # noqa: PLC0415
+
+    return check_public_sdk_sync
 
 
 def test_docs_and_contracts_are_in_sync() -> None:
@@ -39,12 +44,14 @@ def test_openapi_keeps_connected_account_oauth_routes_public() -> None:
 
 
 def test_public_sync_compare_normalizes_text_line_endings(tmp_path: Path) -> None:
+    check_public_sdk_sync = _check_public_sdk_sync()
     text = tmp_path / "sample.md"
     text.write_bytes(b"alpha\r\nbeta\r\n")
     assert check_public_sdk_sync._comparable_bytes(text) == b"alpha\nbeta\n"
 
 
 def test_public_sync_compare_preserves_known_binary_bytes(tmp_path: Path) -> None:
+    check_public_sdk_sync = _check_public_sdk_sync()
     image = tmp_path / "sample.gif"
     data = b"GIF89a\r\nbinary\r\npayload"
     image.write_bytes(data)

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -10,6 +10,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import contract_sync  # noqa: E402
+import check_public_sdk_sync  # noqa: E402
 
 
 def test_docs_and_contracts_are_in_sync() -> None:
@@ -35,3 +36,16 @@ def test_openapi_keeps_connected_account_oauth_routes_public() -> None:
     ]
     for fragment in required_fragments:
         assert fragment in text, fragment
+
+
+def test_public_sync_compare_normalizes_text_line_endings(tmp_path: Path) -> None:
+    text = tmp_path / "sample.md"
+    text.write_bytes(b"alpha\r\nbeta\r\n")
+    assert check_public_sdk_sync._comparable_bytes(text) == b"alpha\nbeta\n"
+
+
+def test_public_sync_compare_preserves_known_binary_bytes(tmp_path: Path) -> None:
+    image = tmp_path / "sample.gif"
+    data = b"GIF89a\r\nbinary\r\npayload"
+    image.write_bytes(data)
+    assert check_public_sdk_sync._comparable_bytes(image) == data

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -16,12 +16,15 @@ import contract_sync  # noqa: E402
 
 
 def _check_public_sdk_sync():
-    result = subprocess.run(
-        ["git", "-C", str(ROOT), "rev-parse", "--is-inside-work-tree"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "--is-inside-work-tree"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.skip("public SDK sync byte tests require the git executable")
     if result.returncode != 0:
         pytest.skip("public SDK sync byte tests require a Git checkout")
     import check_public_sdk_sync  # noqa: PLC0415

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -30,6 +30,7 @@ def test_docs_do_not_advertise_removed_register_flags() -> None:
             _read("README.md"),
             _read("GETTING_STARTED.md"),
             _read("docs/publish-flow.md"),
+            _read("RELEASE_NOTES_v0.7.5.md"),
         ]
     )
 
@@ -102,6 +103,26 @@ def test_cli_docs_match_current_sidecar_inputs() -> None:
     assert "`tool_manual.json`" in docs
     assert "`runtime_validation.json`" in docs
     assert "`oauth_credentials.json`" in docs
+
+
+def test_public_docs_keep_submitted_registration_content_immutable() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("docs/publish-flow.md"),
+        ]
+    )
+    openapi = _read("openapi/developer-surface.yaml")
+
+    assert "call `confirm-auto-register` with your tool manual after the draft is created" not in docs
+    assert "confirm-auto-register` can merge your overrides" not in docs
+    assert "or overridden during `confirm-auto-register`" not in docs
+    assert '"overrides": {' not in docs
+    assert "Submitted listing content is read-only in the portal." in docs
+    assert "confirmation approves the submitted draft but does\n  not edit its content" in docs
+    assert "current SDKs\n        confirm with approved=true only" in openapi
+    assert "deprecated: true" in openapi
 
 
 def test_docs_do_not_advertise_unsupported_connected_account_families() -> None:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -8,6 +8,11 @@ def _read(relative_path: str) -> str:
     return (SDK_ROOT / relative_path).read_text(encoding="utf-8")
 
 
+def _read_optional(relative_path: str) -> str:
+    path = SDK_ROOT / relative_path
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
 def test_readme_keeps_coding_agent_prompt() -> None:
     readme = _read("README.md")
 
@@ -37,13 +42,18 @@ def test_cli_docs_match_current_sidecar_inputs() -> None:
             _read("GETTING_STARTED.md"),
             _read("docs/publish-flow.md"),
             _read("siglume-api-sdk-ts/README.md"),
+            _read("openapi/developer-surface.yaml"),
         ]
     )
 
     assert "optional `input_form_spec.json`" not in docs
     assert "`source_context.json`" not in docs
     assert "GitHub provenance from your local git checkout" not in docs
+    assert "`source_url` plus optional `source_context` lets a coding engine" not in docs
+    assert "used by the CLI / coding engine" not in docs
     assert "SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly" in docs
+    assert "SDK / HTTP automation can include `source_url` plus optional" in docs
+    assert "used by SDK / HTTP automation" in docs
     assert "The CLI does not infer these fields from git." in docs
     assert "`tool_manual.json`" in docs
     assert "`runtime_validation.json`" in docs
@@ -63,9 +73,18 @@ def test_docs_do_not_advertise_unsupported_connected_account_families() -> None:
 def test_payment_docs_match_current_polygon_settlement_language() -> None:
     docs = "\n".join(
         [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("API_IDEAS.md"),
+            _read_optional("ANNOUNCEMENT_DRAFT.md"),
+            _read("PAYMENT_MIGRATION.md"),
+            _read_optional("announcements/POST_ZENN.md"),
             _read("docs/jurisdiction-and-compliance.md"),
             _read("docs/web3-settlement.md"),
             _read("docs/demo-capture-guide.md"),
+            _read("docs/publish-flow.md"),
+            _read("siglume_api_sdk/cli/project.py"),
+            _read("siglume-api-sdk-ts/src/cli/project.ts"),
         ]
     )
 
@@ -73,3 +92,10 @@ def test_payment_docs_match_current_polygon_settlement_language() -> None:
     assert "Stripe Connect today" not in docs
     assert "other platform-supported Polygon assets" not in docs
     assert "REPLACE_WITH_YOUR_90S_VIDEO_URL" not in docs
+    assert "Register with a Polygon payout address at `/owner/publish`" not in docs
+    assert "Open https://siglume.com/owner/publish and finish payout setup" not in docs
+    assert "Payouts` sub-menu" not in docs
+    assert "Payouts sub-menu" not in docs
+    assert "bank account or wallet address" not in docs
+    assert "Wallet at `/owner/credits/payout`" in docs
+    assert "external payout wallets are not supported" in docs

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,3 +1,5 @@
+import json
+import tomllib
 from pathlib import Path
 
 
@@ -33,6 +35,48 @@ def test_docs_do_not_advertise_removed_register_flags() -> None:
 
     for removed_flag in ("--no-preflight", "--force-draft", "--allow-generated-manual"):
         assert removed_flag not in docs
+
+
+def test_package_runtime_versions_match_release_metadata() -> None:
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    package_json = json.loads(_read("siglume-api-sdk-ts/package.json"))
+    python_version = str(pyproject["project"]["version"])
+    ts_version = str(package_json["version"])
+
+    assert python_version == "0.7.6"
+    assert ts_version == python_version
+    assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
+    assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
+
+
+def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> None:
+    readme = _read("README.md")
+    getting_started = _read("GETTING_STARTED.md")
+    ts_readme = _read("siglume-api-sdk-ts/README.md")
+    security = _read("SECURITY.md")
+    normalized_security = " ".join(security.split())
+
+    assert "v0.5.0 is out" not in readme
+    assert "current v0.5 release line" not in ts_readme
+    assert "This is an early-stage project (v0.7.6, alpha)" in readme
+    assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
+    assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
+    assert "Rotate after every release" not in security
+
+    assert "siglume score . --offline" in readme
+    assert readme.index("siglume score . --offline") < readme.index("siglume validate .")
+    assert "siglume score . --offline" in getting_started
+    assert getting_started.index("siglume score . --offline") < getting_started.index("siglume validate .")
+    assert "siglume score . --offline" in ts_readme
+    assert ts_readme.index("siglume score . --offline") < ts_readme.index("siglume validate .")
+
+    for stale_file in ("my_app.py", "tests/test_app.py", "requirements.txt"):
+        assert stale_file not in getting_started
+    assert "adapter.py" in getting_started
+    assert "manifest.json" in getting_started
+    assert "tool_manual.json" in getting_started
+    assert "runtime_validation.json" in getting_started
+    assert ".gitignore" in getting_started
 
 
 def test_cli_docs_match_current_sidecar_inputs() -> None:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+
+SDK_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (SDK_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_readme_keeps_coding_agent_prompt() -> None:
+    readme = _read("README.md")
+
+    assert "## Using Codex or Claude Code" in readme
+    assert "Recommended prompt:" in readme
+    assert "Read this repository, especially `README.md`, `GETTING_STARTED.md`, and `docs/publish-flow.md`" in readme
+    assert "`siglume register . --confirm`" in readme
+
+
+def test_docs_do_not_advertise_removed_register_flags() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("docs/publish-flow.md"),
+        ]
+    )
+
+    for removed_flag in ("--no-preflight", "--force-draft", "--allow-generated-manual"):
+        assert removed_flag not in docs
+
+
+def test_cli_docs_match_current_sidecar_inputs() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("docs/publish-flow.md"),
+            _read("siglume-api-sdk-ts/README.md"),
+        ]
+    )
+
+    assert "optional `input_form_spec.json`" not in docs
+    assert "`source_context.json`" not in docs
+    assert "GitHub provenance from your local git checkout" not in docs
+    assert "SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly" in docs
+    assert "The CLI does not infer these fields from git." in docs
+    assert "`tool_manual.json`" in docs
+    assert "`runtime_validation.json`" in docs
+    assert "`oauth_credentials.json`" in docs
+
+
+def test_docs_do_not_advertise_unsupported_connected_account_families() -> None:
+    connected_accounts = _read("docs/connected-accounts.md")
+
+    assert "OpenAI" not in connected_accounts
+    assert "MetaMask" not in connected_accounts
+    assert '["slack", "openai"]' not in connected_accounts
+    assert 'provider_key="x-twitter"' not in connected_accounts
+    assert 'provider_key="twitter"' in connected_accounts
+
+
+def test_payment_docs_match_current_polygon_settlement_language() -> None:
+    docs = "\n".join(
+        [
+            _read("docs/jurisdiction-and-compliance.md"),
+            _read("docs/web3-settlement.md"),
+            _read("docs/demo-capture-guide.md"),
+        ]
+    )
+
+    assert "SettlementMode.STRIPE_PAYMENT_INTENT" not in docs
+    assert "Stripe Connect today" not in docs
+    assert "other platform-supported Polygon assets" not in docs
+    assert "REPLACE_WITH_YOUR_90S_VIDEO_URL" not in docs


### PR DESCRIPTION
## Summary

Restores the Codex / Claude Code prompt guidance that was dropped from the public README and aligns the public SDK/docs with the current Siglume implementation, including the embedded-wallet payout flow and immutable post-submission API review model.

## What changed

- Restored AI coding-agent prompt guidance in `README.md` and `docs/publish-flow.md`.
- Corrected `siglume register` docs to list only the sidecar files the CLI actually reads: `tool_manual.json`, `runtime_validation.json`, and optional `oauth_credentials.json`.
- Clarified that `source_url`, `source_context`, and `input_form_spec` are SDK / HTTP automation inputs, not CLI-inferred git metadata.
- Updated connected-account provider examples to supported provider families.
- Updated settlement docs away from stale Stripe/current-token claims and removed the placeholder Loom URL from the demo snippet.
- Aligned payout guidance with the current wallet model: seller proceeds settle to the Siglume embedded wallet, external payout wallets are not supported, and only the payout token is configured from `/owner/credits/payout`.
- Aligned Python/TypeScript `confirm_registration()` with the current server rule that submitted API content is immutable: confirmation now sends `{ approved: true }` only and no longer sends post-draft `overrides`.
- Updated README / Getting Started / publish-flow / OpenAPI / release notes so `/owner/publish` is described as read-only after submission; content changes require rerunning `auto-register` / `siglume register` with the same `capability_key`.
- Updated shared recorder cassettes and added docs contract assertions so stale “confirm overrides” guidance is caught.
- Hardened the public/private SDK mirror check against Windows CRLF false positives while preserving known binary assets as raw bytes.
- Addressed review blockers: public-sync byte tests now skip outside Git checkouts, and Python/TypeScript scaffolding now merges generated ignore entries into an existing `.gitignore` instead of failing.

## Validation

- Public SDK checkout: `py -3.11 -m pytest` -> 308 passed, 11 warnings.
- Public TypeScript SDK: `npm run typecheck` -> passed.
- Public TypeScript SDK: `npm run test -- --coverage.enabled=false` -> 333 passed.
- Public TypeScript SDK: `npm run build` -> passed.
- Public TypeScript SDK: `npm run pack:check` -> passed.
- Private SDK mirror: `py -3.11 -m pytest` from `packages/contracts/sdk` -> 308 passed, 11 warnings.
- Private TypeScript SDK: `npm run typecheck` -> passed.
- Private TypeScript SDK: `npm run test -- --coverage.enabled=false` -> 333 passed.
- Private TypeScript SDK: `npm run build` -> passed.
- Private TypeScript SDK: `npm run pack:check` -> passed.
- Mirror guard: `py -3.11 scripts/check_public_sdk_sync.py --peer-dir C:\Temp\siglume-api-sdk-current-check` -> `SDK mirrors are in sync.`
- GitHub Actions on `9c6231d`: CI -> success; Contract Sync -> success.

## Current blocker

All code review threads are resolved and all checks are green, but branch protection still requires one approving review from a write-access reviewer before merge.

## Root cause

The public SDK docs and clients still reflected an older contract where `confirm-auto-register` could carry post-draft content overrides. The server and UI now correctly treat submitted listings as immutable after review submission, so the public SDK needed a matching client behavior, docs update, cassette update, and regression guard.