### PR TITLE
docs: clarify Polygon embedded wallet is the only rail and fully non-custodial

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1395,10 +1395,10 @@ Historical Stripe-Connect-based flow (retired, kept here for reference only):
 
 The current on-chain flow (live as of Phase 31 on Polygon Amoy, 2026-04-18):
 
-- Creates an embedded smart wallet attached to the developer's Siglume account (no external wallet app needed).
+- Creates a **non-custodial** embedded smart wallet attached to the developer's Siglume account (no external wallet app needed). Turnkey-backed ERC-4337 smart account — signing authority stays with the user; Siglume never holds your keys or your funds.
 - Uses that embedded wallet as the fixed payout destination; developers can change the payout token, not specify an external payout wallet.
 - Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold the gas token.
-- Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades).
+- Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades). Buyers pre-authorize an on-chain mandate with a monthly cap; the `SubscriptionHub` contract can only pull within that cap, and the buyer can revoke on-chain at any time.
 
 SDK v0.7.6 ships the Web3 enum values for
 payment-permission tools: `SettlementMode.POLYGON_MANDATE` and

--- a/README.md
+++ b/README.md
@@ -428,9 +428,21 @@ metering surface is marked experimental and confirms event receipt only.
 
 ## Web3 settlement helpers
 
-Use the web3 helper surface when you need typed read models for Polygon
-mandates, settlement receipts, embedded-wallet charges, or 0x cross-currency
-quotes.
+Siglume subscription payments settle on Polygon via **non-custodial
+embedded smart wallets** with platform-sponsored gas — this is the
+only supported settlement rail. Stripe Connect was retired in v0.2.0.
+
+Non-custodial means Siglume never holds your funds, never holds your
+keys, and cannot move tokens on its own. The Polygon mandate is an
+on-chain authorization signed by the buyer's wallet that lets
+Siglume's contract auto-debit a capped amount per period; the buyer
+can revoke it on-chain at any time. Settlements are real on-chain
+ERC-20 transfers, not internal ledger entries.
+
+The web3 helper surface exposes typed read models for Polygon
+mandates, settlement receipts, embedded-wallet charges, and 0x
+cross-currency quotes, plus local simulation helpers so you can test
+your payment adapter without touching a live wallet.
 
 - Python example: [examples/polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py)
 - TypeScript example: [examples-ts/embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts)

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -1,26 +1,49 @@
 # Web3 Settlement Helpers
 
-Siglume's web3 payment contracts already live on the platform. The SDK keeps
-this surface intentionally small: it mirrors the public read models, adds a
-few typed client helpers, and provides local simulation helpers for tests and
-examples.
+## What the settlement rail actually is
 
-What the SDK does:
+Siglume subscription payments settle on Polygon via **non-custodial
+embedded smart wallets** — this is the only supported settlement rail.
+Stripe Connect was retired in v0.2.0.
+
+**Non-custodial** means:
+
+- Siglume never holds buyer or seller funds.
+- Siglume never holds private keys. Embedded wallets are
+  Turnkey-backed ERC-4337 smart accounts where signing authority
+  stays with the end user.
+- Siglume's `SubscriptionHub` contract can pull funds from a buyer's
+  wallet **only** within the limits of an on-chain mandate the buyer
+  has signed (monthly cap, token, payee), and the buyer can revoke
+  that mandate on-chain at any time.
+- Settlements are real on-chain ERC-20 transfers (USDC / JPYC on
+  Polygon), not internal ledger entries in a Siglume database.
+
+Gas is sponsored by the platform (Pimlico paymaster) so buyers and
+sellers do not need to hold native MATIC to transact.
+
+## What the SDK does
+
+The SDK keeps this surface intentionally small: it mirrors the public
+read models, adds a few typed client helpers, and provides local
+simulation helpers for tests and examples.
 
 - reads Polygon mandate, settlement receipt, and 0x quote data from the public API
 - normalizes the public response shapes into `PolygonMandate`, `SettlementReceipt`,
   `EmbeddedWalletCharge`, and `CrossCurrencyQuote`
 - simulates mandates and embedded-wallet charges locally for `AppTestHarness`
 
-What the SDK does **not** do:
+## What the SDK does **not** do
 
-- sign or submit on-chain transactions directly
+- sign or submit on-chain transactions directly (the buyer's wallet
+  signs; the platform contract submits)
 - duplicate platform-side settlement logic
 - manage gas sponsorship or payout contracts
+- take custody of buyer or seller tokens at any point
 
 The actual settlement flow is owned by the Siglume platform contracts
-(`SubscriptionHub` and related web3 services). Gas is platform-paid. Manifest
-pricing stays USD-only. Current Polygon settlement and swap token support is
+(`SubscriptionHub` and related web3 services). Manifest pricing stays
+USD-only. Current Polygon settlement and swap token support is
 limited to `USDC` and `JPYC`.
 
 ## Client helpers

--- a/examples-ts/embedded_wallet_payment.ts
+++ b/examples-ts/embedded_wallet_payment.ts
@@ -1,7 +1,11 @@
 /*
 API: recurring subscription payment through embedded wallet settlement on Polygon.
 Intended user: seller-side payment adapter author shipping a PAYMENT tool.
-Connected account: none (Siglume owns the settlement rails and pays gas).
+Connected account: none — settlement runs on the platform's on-chain contracts
+(SubscriptionHub) and the platform paymaster sponsors gas. Wallets stay
+non-custodial: Siglume never holds the buyer's or seller's funds or keys, and
+the SubscriptionHub contract can only pull up to the mandate cap the buyer
+signed on-chain.
 */
 import {
   AppAdapter,

--- a/examples/polygon_mandate_adapter.py
+++ b/examples/polygon_mandate_adapter.py
@@ -1,7 +1,11 @@
 """API: recurring subscription payment via Polygon mandate + embedded wallet charge.
 
 Intended user: seller-side payment adapter author shipping a PAYMENT tool.
-Connected account: none (Siglume handles the on-chain settlement rails).
+Connected account: none — settlement runs on the platform's on-chain contracts
+(SubscriptionHub) and the platform paymaster sponsors gas. Wallets stay
+non-custodial: Siglume never holds the buyer's or seller's funds or keys, and
+the SubscriptionHub contract can only pull up to the mandate cap the buyer
+signed on-chain.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Two adjacent documentation clarifications:

1. **Polygon embedded wallet is the ONLY supported settlement rail** for subscription purchases. Stripe Connect was retired in v0.2.0. The README "Web3 settlement helpers" section previously read as an optional path (\"*when you need* typed read models\") — readers could misinterpret the rail as one of several options. Rewritten as a statement of fact.
2. **Wallets are fully non-custodial.** The previous language (\"Siglume owns the settlement rails\", \"Siglume handles the on-chain settlement rails\", \"Creates an embedded smart wallet attached to the developer's Siglume account\") left room to misread the design as custodial / internal-ledger. Spelled out: Turnkey-backed ERC-4337 smart accounts where signing authority stays with the end user; Siglume never holds funds or keys; the SubscriptionHub contract can only pull within a buyer-signed on-chain mandate cap, which the buyer can revoke on-chain at any time; settlements are real ERC-20 transfers, not internal ledger entries.

Files touched: `README.md`, `docs/web3-settlement.md`, `GETTING_STARTED.md`, and the two payment example headers (`examples/polygon_mandate_adapter.py`, `examples-ts/embedded_wallet_payment.ts`).

No code changes — docs-only. No version bump needed; v0.8.0 users read the same corrected prose on GitHub.

## Test plan

- [x] Python test suite: 310 passed (sanity after docs edit)
- [x] No pyproject / version / API shape changes → no contract-sync or TS test rerun required (verified via `git diff`)