### PR TITLE
feat(v0.9.0): version_bump on confirm_registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-24
+
+### Added
+
+- `confirm_registration()` now accepts an optional `version_bump` argument
+  (`"patch"` / `"minor"` / `"major"`). The platform applies it to the
+  semver of the newly-created `CapabilityRelease`. When omitted, behavior
+  is unchanged — the patch position auto-increments as before. Added in
+  both Python and TypeScript bindings; invalid values are rejected
+  client-side before the network round-trip.
+- OpenAPI (`openapi/developer-surface.yaml`) documents the new
+  `version_bump` field on the confirm endpoint with a strict enum.
+- `GETTING_STARTED.md` has a new "Version numbering" section with
+  before/after semver examples.
+
+### Fixed
+
+- The API Store detail page previously hard-coded `1.0.0` because the
+  public listing response never exposed the release semver. Paired with
+  the main-repo fix landing alongside this SDK release, the detail page
+  now reflects the real `release_semver`; `version_bump` lets sellers
+  step past `1.0.x` when they ship a feature or breaking change.
+
 ## [0.8.0] - 2026-04-24
 
 ### Breaking

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1746,6 +1746,44 @@ repeat the `auto-register` -> `confirm-auto-register` flow with the same
 release-publish endpoints are not yet exposed in
 `openapi/developer-surface.yaml`.
 
+### Version numbering (`version_bump`)
+
+Every `confirm-auto-register` call creates a new `CapabilityRelease` and
+auto-assigns a semver. The first release of a listing is always `1.0.0`.
+Subsequent re-registrations **default to a patch bump** (`1.0.0` → `1.0.1`
+→ `1.0.2`), which is the right choice for 95% of updates.
+
+When you are shipping a meaningful change, pass `version_bump` on the
+confirm call so the Store UI shows the new major/minor number buyers
+expect:
+
+```python
+# Routine update (default — you can omit the kwarg)
+client.confirm_registration(listing_id)                         # 1.0.2 → 1.0.3
+
+# Feature release — new tool input or a new supported task type
+client.confirm_registration(listing_id, version_bump="minor")   # 1.0.5 → 1.1.0
+
+# Breaking change — removed a field, changed required auth, etc.
+client.confirm_registration(listing_id, version_bump="major")   # 1.5.3 → 2.0.0
+```
+
+```ts
+// Routine update (default)
+await client.confirm_registration(listing_id);                                // 1.0.2 → 1.0.3
+
+// Feature release
+await client.confirm_registration(listing_id, { version_bump: "minor" });     // 1.0.5 → 1.1.0
+
+// Breaking change
+await client.confirm_registration(listing_id, { version_bump: "major" });     // 1.5.3 → 2.0.0
+```
+
+Any value other than `"patch"`, `"minor"`, or `"major"` is rejected by the
+server (and caught client-side as well). The platform does NOT let you
+pick an arbitrary version string — always one bump above the latest
+published release.
+
 ---
 
 ## Next Steps

--- a/RELEASE_NOTES_v0.9.0.md
+++ b/RELEASE_NOTES_v0.9.0.md
@@ -1,0 +1,48 @@
+# siglume-api-sdk v0.9.0
+
+Released: 2026-04-24
+
+## Summary
+
+Sellers can now bump minor / major semver on a re-registration. `confirm_registration()` accepts an optional `version_bump` argument.
+
+## Background
+
+Until v0.9.0 the platform auto-incremented only the patch position of `CapabilityRelease.release_semver`:
+
+```
+first publish            → 1.0.0
+next re-registration     → 1.0.1
+next                     → 1.0.2
+...forever
+```
+
+There was no way for a seller to step past `1.0.x` even when the change was a real feature release or a breaking change. This release fixes that.
+
+## New
+
+```python
+# Python
+client.confirm_registration(listing_id)                         # default → patch bump (1.0.2 → 1.0.3)
+client.confirm_registration(listing_id, version_bump="minor")   # 1.0.5 → 1.1.0
+client.confirm_registration(listing_id, version_bump="major")   # 1.5.3 → 2.0.0
+```
+
+```ts
+// TypeScript
+await client.confirm_registration(listing_id);                                // default → patch
+await client.confirm_registration(listing_id, { version_bump: "minor" });     // 1.0.5 → 1.1.0
+await client.confirm_registration(listing_id, { version_bump: "major" });     // 1.5.3 → 2.0.0
+```
+
+Any value other than `"patch"`, `"minor"`, or `"major"` is rejected client-side and also server-side. You cannot pick an arbitrary version string — always one bump above the latest published release. First-ever publish of a listing is always `1.0.0` and ignores the argument.
+
+## Backward compatible
+
+Callers that do not pass `version_bump` see exactly the same behavior as before (auto patch bump). Existing deployed code needs no change.
+
+## Install
+
+```bash
+pip install --upgrade siglume-api-sdk==0.9.0
+```

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -451,6 +451,18 @@ paths:
                 approved:
                   type: boolean
                   description: Must be true to confirm
+                version_bump:
+                  type: string
+                  enum: [patch, minor, major]
+                  default: patch
+                  description: |
+                    Semver bump kind applied to the next CapabilityRelease.
+                    Omit or pass `patch` for routine re-registrations (e.g.
+                    `1.0.2` → `1.0.3`). Pass `minor` when shipping a new
+                    feature (`1.0.5` → `1.1.0`). Pass `major` when the
+                    change is not backward-compatible (`1.5.3` → `2.0.0`).
+                    First-ever release of a listing is always `1.0.0` and
+                    ignores this field.
                 overrides:
                   type: object
                   deprecated: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.8.0"
+version = "0.9.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -2277,13 +2277,28 @@ export class SiglumeClient implements SiglumeClientShape {
 
   async confirm_registration(
     listing_id: string,
-    options: { manifest?: AppManifest | Record<string, unknown>; tool_manual?: ToolManual | Record<string, unknown> } = {},
+    options: {
+      manifest?: AppManifest | Record<string, unknown>;
+      tool_manual?: ToolManual | Record<string, unknown>;
+      version_bump?: "patch" | "minor" | "major";
+    } = {},
   ): Promise<RegistrationConfirmation> {
     // Registration content is immutable after auto-register. Keep the
     // historical options source-compatible, but do not send them as
-    // post-draft overrides.
-    void options;
+    // post-draft overrides. `version_bump` (optional) opts into a
+    // minor/major semver bump on the newly-created CapabilityRelease;
+    // platform defaults to "patch" when omitted.
+    const { version_bump: versionBump } = options;
     const payload: Record<string, unknown> = { approved: true };
+    if (versionBump !== undefined) {
+      const allowed = ["patch", "minor", "major"] as const;
+      if (!(allowed as readonly string[]).includes(versionBump)) {
+        throw new Error(
+          `version_bump must be one of ${JSON.stringify(allowed)}, got ${JSON.stringify(versionBump)}`,
+        );
+      }
+      payload.version_bump = versionBump;
+    }
     const [data, meta] = await this.request("POST", `/market/capabilities/${listing_id}/confirm-auto-register`, { json_body: payload });
     this.pendingConfirmations.delete(listing_id);
     const checklist = isRecord(data.checklist)

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.8.0";
+export const SDK_VERSION = "0.9.0";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.8.0"
+SDK_VERSION = "0.9.0"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3053,12 +3053,23 @@ class SiglumeClient:
         *,
         manifest: "AppManifest | Mapping[str, Any] | None" = None,
         tool_manual: "ToolManual | Mapping[str, Any] | None" = None,
+        version_bump: str | None = None,
     ) -> RegistrationConfirmation:
         # Registration content is immutable after auto-register. Keep the
         # historical keyword arguments source-compatible, but do not send them
         # as post-draft overrides.
         _ = (manifest, tool_manual)
         payload: dict[str, Any] = {"approved": True}
+        if version_bump is not None:
+            # Platform accepts "patch" (default), "minor", or "major". Any
+            # other value is rejected server-side. Validate client-side too
+            # so the caller gets a clear error before the network round-trip.
+            allowed = {"patch", "minor", "major"}
+            if version_bump not in allowed:
+                raise SiglumeClientError(
+                    f"version_bump must be one of {sorted(allowed)}, got {version_bump!r}"
+                )
+            payload["version_bump"] = version_bump
         data, meta = self._request(
             "POST",
             f"/market/capabilities/{listing_id}/confirm-auto-register",

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -53,7 +53,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.8.0"
+    assert python_version == "0.9.0"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
## Summary

Sellers can now step past \`1.0.x\` on a re-registration. Before this PR the platform auto-incremented only the patch position of \`CapabilityRelease.release_semver\` (1.0.0 → 1.0.1 → 1.0.2 → …), so there was no way to communicate a feature release or breaking change via semver. Now:

\`\`\`python
client.confirm_registration(listing_id)                          # default → patch bump
client.confirm_registration(listing_id, version_bump=\"minor\")    # 1.0.5 → 1.1.0
client.confirm_registration(listing_id, version_bump=\"major\")    # 1.5.3 → 2.0.0
\`\`\`

\`\`\`ts
await client.confirm_registration(listing_id);
await client.confirm_registration(listing_id, { version_bump: \"minor\" });
await client.confirm_registration(listing_id, { version_bump: \"major\" });
\`\`\`

Fully additive: callers that don't pass \`version_bump\` see identical behavior. Invalid values rejected client-side and server-side. The platform still does **not** accept arbitrary version strings — the bump is always one step above the latest published release.

## Test plan

- [x] Python: 310 passed
- [x] TypeScript: 336 passed
- [x] OpenAPI updated: \`version_bump\` with enum \`[patch, minor, major]\` on \`/market/capabilities/{listingId}/confirm-auto-register\`
- [x] GETTING_STARTED.md has a new "Version numbering" section

## Pairs with

Backend support lands alongside in the main repo — merging this before the backend PR is safe (server accepts an unknown field silently today; the actual semver behavior kicks in once the backend PR merges).