### PR TITLE
docs(v0.9.1): document version + active_agent_count on AppListing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-24
+
+### Added
+
+- `AppListing` OpenAPI schema now documents two detail-endpoint-only
+  fields the platform has been returning since the API Store detail
+  brushup:
+  - `version` — semver of the latest published `CapabilityRelease`
+    for this listing. `null` for draft-only listings. Set by
+    `confirm_registration(..., version_bump=...)`.
+  - `active_agent_count` — buyer-facing social-proof counter: distinct
+    agents currently bound to an active grant. `null` on list
+    responses (the detail endpoint is the only place it is computed,
+    so catalog paging stays cheap).
+
+No code changes — purely a docs-level catch-up so generated clients
+and typed HTTP tooling see both fields the server has been returning
+at runtime.
+
 ## [0.9.0] - 2026-04-24
 
 ### Added

--- a/RELEASE_NOTES_v0.9.1.md
+++ b/RELEASE_NOTES_v0.9.1.md
@@ -1,0 +1,20 @@
+# siglume-api-sdk v0.9.1
+
+Released: 2026-04-24
+
+## Summary
+
+Docs-only catch-up. The `AppListing` OpenAPI schema now documents two fields the Siglume platform has already been returning on the detail endpoint since the recent API Store detail brushup, but which were missing from the public SDK contract:
+
+- `version` — semver of the latest published `CapabilityRelease` for this listing. `null` for draft-only listings. Sellers advance it through `confirm_registration(..., version_bump=...)` (v0.9.0).
+- `active_agent_count` — buyer-facing social-proof counter: distinct agents currently bound to an active grant on this listing. `null` on list responses; only computed on the detail endpoint so the catalog stays cheap to page. May be `0` for freshly-published listings.
+
+## Not in this release
+
+No code changes in Python or TypeScript bindings, and no breaking changes. If your tooling generates types from `openapi/developer-surface.yaml` you may want to regenerate.
+
+## Install
+
+```bash
+pip install --upgrade siglume-api-sdk==0.9.1
+```

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -1953,6 +1953,26 @@ components:
         published_at: { type: string, format: date-time }
         review_note: { type: string }
         review_status: { type: string }
+        version:
+          type: string
+          nullable: true
+          description: |
+            Semver of the latest published CapabilityRelease for this
+            listing. Populated **only on the detail endpoint**
+            (`GET /market/capabilities/{listingId}`). List responses
+            omit this field. Listings that never went live (draft-only)
+            return `null`. Sellers control future values with
+            `confirm_registration(..., version_bump=...)`.
+        active_agent_count:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: |
+            Buyer-facing social-proof counter: distinct number of agents
+            currently bound (active binding on an active grant) to this
+            listing. Populated **only on the detail endpoint**; list
+            responses omit this field so the catalog stays cheap to
+            page. May be zero for freshly-published listings.
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.9.0"
+version = "0.9.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.9.0";
+export const SDK_VERSION = "0.9.1";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.9.0"
+SDK_VERSION = "0.9.1"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -53,7 +53,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.9.0"
+    assert python_version == "0.9.1"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
## Summary

Docs-only catch-up. The platform has been returning \`version\` and \`active_agent_count\` on the listing detail endpoint since the recent API Store brushup, but the OpenAPI schema did not document either field. This release adds both to \`AppListing\` with explicit "detail-endpoint-only" semantics.

- \`version\`: nullable semver of the latest published \`CapabilityRelease\`. Sellers advance it via \`confirm_registration(..., version_bump=...)\` which shipped in v0.9.0.
- \`active_agent_count\`: nullable integer ≥ 0. Buyer-facing social-proof counter. Distinct agents bound to an active grant. Only populated on the detail endpoint so catalog paging stays cheap.

No Python or TypeScript code changes. No breaking changes.

## Test plan

- [x] Python: 310 passed
- [x] TypeScript: 336 passed
- [x] OpenAPI: two new fields added under \`AppListing\` with descriptions

## Pairs with

Main repo mirror re-sync will pick this up in the paired PR that also fixes the support-contact UX on the API detail page.