### PR TITLE
fix(client): validate version_bump type

### DIFF
--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3064,10 +3064,10 @@ class SiglumeClient:
             # Platform accepts "patch" (default), "minor", or "major". Any
             # other value is rejected server-side. Validate client-side too
             # so the caller gets a clear error before the network round-trip.
-            allowed = {"patch", "minor", "major"}
-            if version_bump not in allowed:
+            allowed = ("patch", "minor", "major")
+            if not isinstance(version_bump, str) or version_bump not in allowed:
                 raise SiglumeClientError(
-                    f"version_bump must be one of {sorted(allowed)}, got {version_bump!r}"
+                    f"version_bump must be one of {list(allowed)}, got {version_bump!r}"
                 )
             payload["version_bump"] = version_bump
         data, meta = self._request(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -276,6 +276,15 @@ def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: P
     assert replay_confirmation.quality.grade == confirmation.quality.grade
 
 
+def test_confirm_registration_rejects_non_string_version_bump() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Validation should fail before transport: {request.method} {request.url}")
+
+    with build_client(handler) as client:
+        with pytest.raises(SiglumeClientError, match="version_bump must be one of"):
+            client.confirm_registration("lst_123", version_bump=[])  # type: ignore[arg-type]
+
+
 def test_auto_register_accepts_oauth_credentials_sequence() -> None:
     manifest = build_manifest()
     tool_manual = build_tool_manual()


### PR DESCRIPTION
## Summary

- validate `confirm_registration(version_bump=...)` type before membership checks
- keep invalid dynamic Python inputs on the documented `SiglumeClientError` path instead of leaking `TypeError`
- add regression coverage for an unhashable `version_bump` value

## Validation

- `py -3.11 -m pytest tests/test_client.py -q -k "confirm_registration"`
- `py -3.11 -m pytest -q`