### PR TITLE
feat(v0.10.0): forward description/scopes/tags, reject manifest.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-25
+
+### Breaking
+
+- The SDK no longer forwards `AppManifest.version` on `auto_register` /
+  `confirm_auto_register`. The platform rejects submissions that
+  declare a `version` field (top-level or inside the embedded
+  `manifest`) with `422 MANIFEST_VERSION_NOT_ALLOWED`. Use
+  `confirm_registration(..., version_bump=...)` to control the
+  published `release_semver`. `AppManifest.version` remains in the
+  dataclass and is now documented as local-only.
+
+### Added
+
+- `AppManifest.description` — long-form buyer-facing sales copy shown
+  on the API detail page. Complements `short_description`
+  (one-liner). Previously the field existed only server-side and
+  couldn't be populated from the SDK. Same change in the TypeScript
+  `AppManifest` interface.
+- `auto_register` payload builder now forwards `description`,
+  `permission_scopes`, and `compatibility_tags` to the top-level
+  submission. Previously these three fields travelled inside the
+  embedded `manifest` sub-dict only, and the server silently dropped
+  them on listing creation — listings ended up with `description:
+  null`, `permission_scopes: []`, `compatibility_tags: []` on the
+  public detail page despite the seller filling them in. The paired
+  backend change (landing alongside in the main repo) persists all
+  three.
+
+### Docs
+
+- `GETTING_STARTED.md` has a new subsection under "Version numbering"
+  clarifying `AppManifest.version` is local-only, and a new table
+  distinguishing buyer-facing fields from agent-facing Tool Manual
+  fields.
+- `openapi/developer-surface.yaml` documents the
+  `MANIFEST_VERSION_NOT_ALLOWED` reject rule on the auto-register
+  endpoint description and enriches the `description` field schema.
+
+### Migration guide (v0.9.x → v0.10.0)
+
+If your adapter currently sends `manifest.version` on auto-register or
+confirm-auto-register, the server will start rejecting it. The SDK
+strips `version` from the outbound payload before the request leaves
+your process, so typical Python / TypeScript usage is unaffected —
+but if you are calling the HTTP endpoint directly, remove the
+`version` field from your request body.
+
+If your listings show `description: null` / `permission_scopes: []`
+/ `compatibility_tags: []` on the Store detail page despite your
+`AppManifest` populating them, upgrade to 0.10.0 and re-register: the
+new forward list carries them through, and the backend persists them
+as of the paired main-repo release.
+
 ## [0.9.1] - 2026-04-24
 
 ### Added

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1784,6 +1784,36 @@ server (and caught client-side as well). The platform does NOT let you
 pick an arbitrary version string — always one bump above the latest
 published release.
 
+#### `AppManifest.version` is local-only
+
+The SDK's `AppManifest.version` (default `"0.1.0"`) is **for your own
+adapter tracking only** — the Siglume platform ignores it on
+`auto_register` / `confirm_auto_register`. The SDK explicitly strips it
+from the submitted payload, and the server rejects submissions that
+slip a `version` field through (HTTP 422 `MANIFEST_VERSION_NOT_ALLOWED`).
+Use `version_bump` on confirm to control the published `release_semver`
+instead.
+
+### Buyer-facing fields vs. agent-facing Tool Manual
+
+If you want the Store detail page to show your pitch, put it in the
+**buyer-facing fields**. The Tool Manual is the agent contract at
+runtime and is **not** surfaced on the store card or detail page.
+
+| Shown to buyers on the detail page | Not shown to buyers |
+|---|---|
+| `name`, `short_description`, `description` (long-form sales copy), `job_to_be_done` | `tool_manual.summary_for_model` |
+| `permission_class`, `permission_scopes`, `required_connected_accounts` | `tool_manual.trigger_conditions`, `do_not_use_when` |
+| `category`, `compatibility_tags` (discovery), `latency_tier`, `data_sensitivity_tier` | `input_schema`, `output_schema`, `preview_schema`, `quote_schema` |
+| `example_prompts` (min 2, see above), `docs_url`, `support_contact`, `jurisdiction` | `approval_summary_template`, `side_effect_summary` |
+
+The platform already returns `description` / `permission_scopes` /
+`compatibility_tags` on the detail endpoint — if they come back as
+`null` / `[]` on your listing, the most likely cause is that your
+`AppManifest` left them at default. The SDK dataclass exposes every
+buyer-facing field, so set them explicitly when you want the Store UI
+to reflect them.
+
 ---
 
 ## Next Steps

--- a/RELEASE_NOTES_v0.10.0.md
+++ b/RELEASE_NOTES_v0.10.0.md
@@ -1,0 +1,55 @@
+# siglume-api-sdk v0.10.0
+
+Released: 2026-04-25
+
+## Summary
+
+Fixes a long-standing "my listing field is empty on the Store detail page even though I filled it in" class of bug, and locks down release versioning to platform control.
+
+## Breaking
+
+- **`AppManifest.version` is no longer forwarded to the server** on `auto_register` / `confirm_auto_register`. The Siglume platform rejects submissions that declare a `version` field (top-level or inside `manifest`) with `422 MANIFEST_VERSION_NOT_ALLOWED`. Use `confirm_registration(..., version_bump=...)` (added in v0.9.0) to control the published `release_semver`.
+- `AppManifest.version` stays in the dataclass as **local-only** for your own adapter tracking (tests, git tags, etc.); the SDK explicitly strips it from the outbound payload. Typical Python / TS callers are unaffected.
+
+## Added
+
+- **`AppManifest.description`** — long-form buyer-facing sales copy shown on the API detail page. Complements `short_description` (one-liner) with the full pitch: who this is for, what it can / cannot do, limits, quotas. Added in Python + TypeScript.
+- **`auto_register` now forwards `description`, `permission_scopes`, and `compatibility_tags`** to the top-level submission. Previously these three fields travelled only inside the embedded `manifest` sub-dict and the server dropped them silently on listing creation, so listings rendered `description: null` / `permission_scopes: []` / `compatibility_tags: []` on the public detail page. Paired backend fix lands in the main repo alongside this release.
+
+## Docs
+
+- New subsection under "Version numbering" in `GETTING_STARTED.md` clarifying `AppManifest.version` is local-only.
+- New "Buyer-facing fields vs. agent-facing Tool Manual" table so sellers know which fields drive the Store detail page vs. which live in the Tool Manual.
+- OpenAPI (`openapi/developer-surface.yaml`) documents the `MANIFEST_VERSION_NOT_ALLOWED` reject rule and enriches the `description` field description with explicit buyer-facing semantics.
+
+## Migration
+
+Python / TypeScript SDK users:
+
+```python
+# No change needed — the SDK strips version for you
+client.auto_register(manifest, tool_manual)
+
+# Populate long-form buyer copy; previously ignored on the server
+manifest = AppManifest(
+    capability_key="my-api",
+    name="My API",
+    job_to_be_done="...",
+    jurisdiction="US",
+    short_description="One-liner for the card.",
+    description="Full paragraph for the detail page — who this is for, "
+                "what it can / cannot do, limits, required connected "
+                "accounts. Shows under 'Details'.",
+    permission_scopes=["tweet.write", "users.read"],
+    compatibility_tags=["sns", "twitter", "scheduling"],
+    # ...
+)
+```
+
+If you call the HTTP API directly: remove `version` from your request body; send `description`, `permission_scopes`, `compatibility_tags` at the top level of your auto-register payload.
+
+## Install
+
+```bash
+pip install --upgrade siglume-api-sdk==0.10.0
+```

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -116,6 +116,23 @@ paths:
         `support_contact`; those fields may be top-level, inside `manifest`,
         or supplied as `legal.publisher_identity.documentation_url` and
         `legal.publisher_identity.support_contact`.
+
+        **Release versioning is platform-managed.** The first published
+        release of any listing is always `1.0.0`; subsequent re-registrations
+        advance per the `version_bump` argument on the confirm endpoint. Do
+        **not** send a `version` field on the top-level payload or inside
+        the embedded `manifest` object — submissions that declare a version
+        are rejected with `422 MANIFEST_VERSION_NOT_ALLOWED`. The SDK's
+        `AppManifest.version` is local-only and is not forwarded.
+
+        **Buyer-facing copy vs agent-facing Tool Manual.** `description`
+        (long-form), `short_description` (one-liner), `job_to_be_done`,
+        `permission_scopes`, and `compatibility_tags` are shown on the
+        buyer-facing API detail page and drive discovery. The `tool_manual`
+        object is agent-facing at runtime and is not surfaced on the store
+        card or detail page. If you want buyers to see your sales copy,
+        put it in the buyer-facing fields — the Tool Manual is not a
+        substitute.
       tags: [Capabilities]
       requestBody:
         required: true
@@ -1828,7 +1845,15 @@ components:
       properties:
         capability_key: { type: string, minLength: 1, maxLength: 128 }
         name: { type: string, minLength: 1, maxLength: 255 }
-        description: { type: string }
+        description:
+          type: string
+          description: |
+            Long-form buyer-facing sales copy shown on the API detail page.
+            Complements `short_description` (one-liner) with the full pitch:
+            who this is for, what it can / cannot do, limits, required
+            connected accounts, quotas. Plain text. The Tool Manual is
+            agent-facing at runtime and is not shown to buyers — put buyer
+            copy here.
         job_to_be_done: { type: string }
         short_description: { type: string }
         category: { type: string, enum: [commerce, booking, crm, finance, document, communication, monitoring, creative, productivity, summarization, other] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.9.1"
+version = "0.10.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -2216,11 +2216,19 @@ export class SiglumeClient implements SiglumeClientShape {
     if (options.input_form_spec) {
       payload.input_form_spec = coerceMapping(options.input_form_spec, "input_form_spec");
     }
+    // Manifest fields forwarded to the top-level auto-register payload.
+    // `version` is intentionally NOT forwarded — the platform auto-assigns
+    // `release_semver` and rejects submissions that declare a version.
+    // `description` (long-form sales copy), `permission_scopes`, and
+    // `compatibility_tags` are forwarded so the seller's buyer-facing
+    // description, OAuth scope declarations, and discovery tags actually
+    // survive the auto-register pipeline.
     for (const fieldName of [
       "capability_key",
       "name",
       "job_to_be_done",
       "short_description",
+      "description",
       "category",
       "docs_url",
       "documentation_url",
@@ -2234,11 +2242,20 @@ export class SiglumeClient implements SiglumeClientShape {
       "approval_mode",
       "dry_run_supported",
       "required_connected_accounts",
+      "permission_scopes",
+      "compatibility_tags",
     ]) {
       const value = manifestPayload[fieldName];
       if (value !== undefined && value !== null) {
         payload[fieldName] = value;
       }
+    }
+    // Strip `version` from the embedded manifest sub-dict too so the
+    // platform's reject-on-manifest-version check cannot trip on the SDK's
+    // local-tracking default. The SDK's AppManifest.version is local-only
+    // and must not reach the server.
+    if (payload.manifest && typeof payload.manifest === "object") {
+      delete (payload.manifest as Record<string, unknown>).version;
     }
     const docsUrl = String(manifestPayload.docs_url ?? manifestPayload.documentation_url ?? "").trim();
     const supportContact = String(manifestPayload.support_contact ?? "").trim();

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -80,6 +80,13 @@ export interface ConnectedAccountRef {
 
 export interface AppManifest {
   capability_key: string;
+  /**
+   * LOCAL-ONLY identification. The Siglume platform never reads this on
+   * auto_register / confirm_auto_register and rejects submissions that
+   * declare a version — the authoritative `release_semver` is controlled
+   * by the platform per the bump rules on the confirm endpoint
+   * (see `confirm_registration({ version_bump: ... })`).
+   */
   version?: string;
   name: string;
   job_to_be_done: string;
@@ -96,6 +103,14 @@ export interface AppManifest {
   applicable_regulations?: string[];
   data_residency?: string;
   short_description?: string;
+  /**
+   * Long-form sales description shown on the buyer-facing API detail
+   * page. Complements `short_description` (one-liner) with a fuller
+   * pitch: who this is for, what it can / cannot do, limits, required
+   * connected accounts. The Tool Manual is agent-facing and not shown
+   * to buyers; put buyer-facing story here.
+   */
+  description?: string;
   docs_url?: string;
   support_contact?: string;
   seller_homepage_url?: string;

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.9.1";
+export const SDK_VERSION = "0.10.0";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -101,6 +101,13 @@ class AppManifest:
         subscription decision. Default market is "US".
     """
     capability_key: str                    # unique identifier e.g. "amazon-purchase-assistant"
+    # ``version`` is LOCAL-ONLY identification for your own adapter tracking
+    # (tests, git tags, internal release docs). The Siglume platform never
+    # reads it on auto_register / confirm_auto_register and will reject a
+    # submission that sends it, because the platform controls the
+    # authoritative ``release_semver`` per the bump rules documented in the
+    # confirm-auto-register endpoint (see ``confirm_registration(..., version_bump=...)``).
+    # Leave at default or use it locally only.
     version: str = "0.1.0"
     name: str = ""                         # display name
     job_to_be_done: str = ""               # what this app enables the agent to do
@@ -125,6 +132,12 @@ class AppManifest:
     # not something the platform enforces. The platform surfaces `jurisdiction`
     # as a flag icon so buyers can make informed decisions.
     short_description: str = ""
+    # Long-form sales description shown on the buyer-facing API detail page.
+    # Complements ``short_description`` (one-liner for cards) with a fuller
+    # pitch: who this is for, what it can and cannot do, limits, required
+    # connected accounts. The Tool Manual is agent-facing and not shown to
+    # buyers; put the buyer-facing story here.
+    description: str = ""
     docs_url: str = ""                     # public API usage guide; not a seller homepage
     support_contact: str = ""              # real support email address or public support URL
     seller_homepage_url: str = ""          # optional official seller homepage, separate from docs_url

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.9.1"
+SDK_VERSION = "0.10.0"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -1481,11 +1481,20 @@ def _build_auto_register_request(
     if input_form_spec is not None:
         payload["input_form_spec"] = _coerce_mapping(input_form_spec, "input_form_spec")
 
+    # Manifest fields forwarded to the top-level auto-register payload.
+    # ``version`` is intentionally NOT forwarded — the platform auto-assigns
+    # ``release_semver`` and rejects submissions that declare a version.
+    # ``description`` (long-form sales copy), ``permission_scopes``, and
+    # ``compatibility_tags`` are forwarded so the seller's buyer-facing
+    # description, OAuth scope declarations, and discovery tags actually
+    # survive the auto-register pipeline (they previously got dropped
+    # silently and ended up null/[] on the public detail page).
     for field_name in (
         "capability_key",
         "name",
         "job_to_be_done",
         "short_description",
+        "description",
         "category",
         "docs_url",
         "documentation_url",
@@ -1499,10 +1508,19 @@ def _build_auto_register_request(
         "approval_mode",
         "dry_run_supported",
         "required_connected_accounts",
+        "permission_scopes",
+        "compatibility_tags",
     ):
         value = manifest_payload.get(field_name)
         if value is not None:
             payload[field_name] = _enum_value(value)
+
+    # Strip ``version`` from the embedded manifest sub-dict too so the
+    # platform's reject-on-manifest-version check cannot trip on the SDK's
+    # local-tracking default. The SDK's AppManifest.version is documented
+    # as local-only and must not reach the server.
+    if isinstance(payload.get("manifest"), dict):
+        payload["manifest"].pop("version", None)
 
     docs_url = str(manifest_payload.get("docs_url") or manifest_payload.get("documentation_url") or "").strip()
     support_contact = str(manifest_payload.get("support_contact") or "").strip()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -53,7 +53,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.9.1"
+    assert python_version == "0.10.0"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
## Summary

Fixes a \"my listing field is empty on the Store detail page even though I filled it in\" class of bug, and locks down release versioning to platform control.

### Breaking

- SDK no longer forwards \`AppManifest.version\` on auto-register. Platform rejects submissions that declare \`version\` with \`422 MANIFEST_VERSION_NOT_ALLOWED\`. Use \`confirm_registration(..., version_bump=...)\` (v0.9.0+) to control \`release_semver\`.

### Added

- \`AppManifest.description\` — long-form buyer-facing sales copy (Python + TypeScript).
- \`auto_register\` payload builder now forwards \`description\`, \`permission_scopes\`, \`compatibility_tags\` to the top-level submission. Previously these travelled only inside the embedded \`manifest\` sub-dict and the server dropped them silently. Paired backend fix lands in the main repo alongside this release.

### Docs

- \`GETTING_STARTED.md\` new subsection: \`AppManifest.version\` is local-only.
- New \"Buyer-facing fields vs. agent-facing Tool Manual\" table.
- OpenAPI documents the \`MANIFEST_VERSION_NOT_ALLOWED\` rule and enriches the \`description\` field schema.

## Test plan

- [x] Python: 311 passed
- [x] TypeScript: 30 test files, 336 tests passing
- [x] OpenAPI submission schema updated

## Migration (v0.9.x → v0.10.0)

Python / TypeScript callers: no code change needed. The SDK strips \`version\` and forwards the missing fields for you. Populate \`description\`, \`permission_scopes\`, \`compatibility_tags\` on your \`AppManifest\` to see them on the Store detail page.

Direct HTTP callers: remove \`version\` from your request body; send the three fields at top level.