### PR TITLE
docs: mirror final legal review gate

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -509,10 +509,13 @@ the registration blockers earlier.
   - `input_schema` and `output_schema` are part of the canonical contract
   - if you need a stricter contract than the auto-generated seed, send a full
     `tool_manual` during `auto-register`
-- Mandatory fail-closed LLM legal review during `auto-register`
+- Mandatory fail-closed LLM legal review during `auto-register` and again
+  during `confirm-auto-register`
   - Siglume asks the LLM whether the API is publishable in the declared jurisdiction
   - The review must explicitly pass both applicable-law compliance and
     public-order / morals compliance
+  - The confirmation-time review uses the final package after any overrides,
+    so changed buyer-facing copy cannot bypass the legal gate
   - If the LLM is unavailable or does not return a valid pass result, publish is blocked
 - For paid APIs: minimum price and an active embedded Polygon wallet before publish
 
@@ -522,8 +525,8 @@ At confirmation time, Siglume publishes immediately only when:
 - Runtime validation passed against the real public API
 - Tool Manual quality is grade A or B
 - Connected-account and pricing rules are satisfied
-- The mandatory LLM legal review passes for the declared jurisdiction and
-  public-order / morals requirements
+- The final mandatory LLM legal review passes for the declared jurisdiction
+  and public-order / morals requirements
 
 ### Step 5: Live in the API Store
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -72,19 +72,24 @@ There is no normal human review step in the self-serve publish flow anymore.
    - optional seller OAuth app credentials in `oauth_credentials`
    - optional `input_form_spec`
 3. Runs contract, pricing, payout, seller OAuth, and runtime validation preflight checks.
-4. Runs a mandatory fail-closed LLM legal review.
+4. Runs a mandatory fail-closed LLM legal review on the submitted package.
 5. Verifies the public API is reachable from the internet.
 6. Sends a functional test request using your dedicated review/test key.
 7. Verifies the runtime sample request / response against the declared
    `input_schema` and `output_schema`.
 8. Checks connected-account requirements and paid pricing rules.
 9. Persists a private draft only if those checks pass.
+10. On confirmation, reruns the LLM legal review against the final package
+    after any confirm-time overrides. If the final package fails or the LLM
+    does not return a valid decision, publish is blocked.
 
 ## The mandatory LLM legal review
 
 The legal check is not a simple keyword blocklist. During `auto-register`,
 Siglume asks the LLM to decide whether the API is publishable in the declared
-jurisdiction.
+jurisdiction. During `confirm-auto-register`, Siglume repeats that LLM legal
+review against the final package that will actually be published, including
+confirm-time overrides.
 
 The review must explicitly pass:
 


### PR DESCRIPTION
## Summary

Mirror the Siglume API Store publish-flow documentation update from the private monorepo.

- Documents that the mandatory LLM legal review now runs during both `auto-register` and `confirm-auto-register`.
- Clarifies that confirmation-time review uses the final package after overrides, so changed buyer-facing copy cannot bypass the legal gate.

## Validation

- `py -3.11 -m pytest -q tests/test_docs_contract.py` -> 8 passed