### PR TITLE
docs: clarify compatibility tags

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1831,6 +1831,12 @@ The platform already returns `description` / `permission_scopes` /
 buyer-facing field, so set them explicitly when you want the Store UI
 to reflect them.
 
+Use `compatibility_tags` for integrations, workflows, protocols, and discovery
+topics such as `x-twitter`, `crm`, or `content-publishing`. Do not use
+standalone locale tags such as `japanese`, `japan`, `jp`, `english`, or `en`;
+the Store shows country / jurisdiction separately, and the platform filters
+locale-only compatibility tags.
+
 ---
 
 ## Next Steps


### PR DESCRIPTION
## Summary

- Clarify that `compatibility_tags` should describe integrations, workflows, protocols, and discovery topics.
- Document that standalone locale/country terms such as `japanese`, `japan`, `jp`, `english`, and `en` are filtered because jurisdiction is shown separately.

## Validation

- `py -3.11 -m pytest -q tests/test_docs_contract.py` -> 8 passed
- `git diff --check` -> passed with CRLF warnings only