### PR TITLE
docs: clarify immutable confirm flow

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -514,8 +514,12 @@ the registration blockers earlier.
   - Siglume asks the LLM whether the API is publishable in the declared jurisdiction
   - The review must explicitly pass both applicable-law compliance and
     public-order / morals compliance
-  - The confirmation-time review uses the final package after any overrides,
-    so changed buyer-facing copy cannot bypass the legal gate
+  - The confirmation-time review uses the immutable stored package that passed
+    auto-register validation; `confirm-auto-register` does not accept content
+    overrides
+  - To change buyer-facing copy, Tool Manual, tags, scopes, pricing, or
+    connected-account requirements, rerun `auto-register` and confirm the new
+    reviewed draft
   - If the LLM is unavailable or does not return a valid pass result, publish is blocked
 - For paid APIs: minimum price and an active embedded Polygon wallet before publish
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -79,17 +79,19 @@ There is no normal human review step in the self-serve publish flow anymore.
    `input_schema` and `output_schema`.
 8. Checks connected-account requirements and paid pricing rules.
 9. Persists a private draft only if those checks pass.
-10. On confirmation, reruns the LLM legal review against the final package
-    after any confirm-time overrides. If the final package fails or the LLM
-    does not return a valid decision, publish is blocked.
+10. On confirmation, reruns the LLM legal review against the immutable stored
+    draft package. If the final stored package fails or the LLM does not return
+    a valid decision, publish is blocked.
 
 ## The mandatory LLM legal review
 
 The legal check is not a simple keyword blocklist. During `auto-register`,
 Siglume asks the LLM to decide whether the API is publishable in the declared
 jurisdiction. During `confirm-auto-register`, Siglume repeats that LLM legal
-review against the final package that will actually be published, including
-confirm-time overrides.
+review against the stored package that will actually be published. Confirmation
+does not accept content overrides; to change buyer-facing copy, Tool Manual,
+tags, scopes, pricing, or connected-account requirements, rerun
+`auto-register` and confirm the new reviewed draft.
 
 The review must explicitly pass:
 


### PR DESCRIPTION
## Summary
- Document that `confirm-auto-register` reviews the immutable stored package
- Clarify that content changes require rerunning `auto-register`

## Tests
- `py -3.11 -m pytest -q tests/test_docs_contract.py`
- `py -3.11 scripts/check_public_sdk_sync.py --peer-dir C:\develop\ai-agent-sns\packages\contracts\sdk`
- `git diff --check -- GETTING_STARTED.md docs/publish-flow.md`