### PR TITLE
docs(v0.10.1): reflect Polygon mainnet launch + drop migration banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-04-26
+
+### Docs
+
+- README, ROADMAP, and PAYMENT_MIGRATION rewritten to reflect that the
+  Stripe Connect → Polygon on-chain payment migration is **complete**
+  and live in production on Polygon mainnet (chainId 137). Earlier
+  copy still framed paid subscriptions as "publishing is open (Phase
+  31 Polygon Amoy end-to-end proven)" and the payment stack as
+  "migrating," which understated the current state. All five
+  settlement surfaces (Plan / Partner / API Store paid / AIWorks
+  Escrow / Ads) are on-chain.
+- README "Current release" callout now points at v0.10.0 instead of
+  v0.7.6, and the SDK feature inventory is updated to include
+  capability bundles, seller-owned connected-account OAuth,
+  buyer-facing `description`, and `version_bump`.
+- ROADMAP's "Next — v0.7 (not yet scheduled)" section is moved to
+  Shipped (capability bundles + connected-account OAuth landed in
+  v0.7.x). Multipart / file-only flows and external-ingest credential
+  surfaces remain on the not-yet-scheduled list, joined by a note on
+  the platform-side decision needed before `USAGE_BASED` /
+  `PER_ACTION` open for API Store listings.
+- PAYMENT_MIGRATION header now lists the deployed mainnet contract
+  addresses (SubscriptionHub, AdsBillingHub, WorksEscrowHub, FeeVault,
+  platform relayer) and settlement-token addresses (native USDC,
+  JPYC). The phase-by-phase log is preserved as historical record.
+
+### Changed
+
+- `pyproject.toml` classifier moves from `3 - Alpha` to `4 - Beta` to
+  match the production status of the platform the SDK targets.
+
+No code changes — Python and TypeScript runtimes are byte-equivalent
+to v0.10.0; this is a documentation / metadata release. If you are on
+0.10.0, upgrading is purely cosmetic (newer README on PyPI / npm).
+
 ## [0.10.0] - 2026-04-25
 
 ### Breaking

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -640,7 +640,7 @@ Declare the account type in `required_connected_accounts`. The agent owner conne
 Use `price_model="free"` for free APIs. For subscription APIs, use `price_model="subscription"` with `price_value_minor` set to your monthly price in cents (e.g., 999 for $9.99/month). Minimum subscription price is $5.00/month (500 cents). The following pricing models are available:
 
 - **Free** (`price_model="free"`): Anyone can install. You can convert to subscription pricing at any time.
-- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon on-chain embedded-wallet auto-debit (proven end-to-end on Amoy 2026-04-18 — see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md)). Revenue settles to your Siglume embedded wallet automatically; use `/owner/credits/payout` only if you want to change the payout token. Buyers purchase via Web3 mandate, and access grants are automatic.
+- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon mainnet (chainId 137) via on-chain embedded-wallet auto-debit (see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the deployed contract addresses). Revenue settles to your Siglume embedded wallet automatically; use `/owner/credits/payout` only if you want to change the payout token (USDC vs JPYC). Buyers purchase via on-chain Web3 mandate, and access grants are automatic.
 
 The SDK enum `PriceModel` also defines `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are **reserved values for future phases** — they are not accepted by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
 
@@ -1387,26 +1387,20 @@ You receive:            ~$9.33/month, settled directly to your wallet
 
 ### Wallet payout flow (subscription APIs only)
 
-> ✅ **Payouts now run on Polygon.** Paid subscription publish is **open** — proven end-to-end on Polygon Amoy (2026-04-18). Revenue settles to the Siglume embedded wallet automatically; use `/owner/credits/payout` only when you want to change the payout token. Buyers purchase via Web3 mandate, and access grants land automatically. The Stripe Connect onboarding flow shown below is retained only for reference during migration — new publishes use the Polygon path. See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log and real on-chain metrics.
+> ✅ **Payouts run on Polygon mainnet (chainId 137).** Paid subscription publish is live in production — Stripe Connect is fully retired across the platform and the migration is complete for all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). Revenue settles to your Siglume embedded smart wallet automatically; use `/owner/credits/payout` only when you want to change the payout token (USDC vs JPYC). Buyers purchase via on-chain Web3 mandate and access grants land automatically. See [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full migration log and the deployed mainnet contract addresses.
 
-Historical Stripe-Connect-based flow (retired, kept here for reference only):
-
-1. The developer portal returned a hosted onboarding URL.
-2. Developer completed Stripe identity + bank-account verification once.
-3. The developer portal later showed the payout rail as ready.
-4. Subsequent `confirm-auto-register` calls for `price_model="subscription"` went through.
-
-The current on-chain flow (live as of Phase 31 on Polygon Amoy, 2026-04-18):
+The on-chain flow:
 
 - Creates a **non-custodial** embedded smart wallet attached to the developer's Siglume account (no external wallet app needed). Turnkey-backed ERC-4337 smart account — signing authority stays with the user; Siglume never holds your keys or your funds.
-- Uses that embedded wallet as the fixed payout destination; developers can change the payout token, not specify an external payout wallet.
-- Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold the gas token.
-- Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades). Buyers pre-authorize an on-chain mandate with a monthly cap; the `SubscriptionHub` contract can only pull within that cap, and the buyer can revoke on-chain at any time.
+- Uses that embedded wallet as the fixed payout destination; developers can change the payout token (USDC vs JPYC), not specify an external payout wallet.
+- Has the platform cover gas fees end-to-end via Pimlico paymaster, so developers never hold POL/MATIC.
+- Uses session-key-scoped auto-debits for subscription renewals (no Stripe-style retry cascades). Buyers pre-authorize an on-chain mandate with a per-charge cap; the `SubscriptionHub` contract can only pull within that cap, and the buyer can revoke on-chain at any time.
 
-SDK v0.7.6 ships the Web3 enum values for
+SDK ships the Web3 enum values for
 payment-permission tools: `SettlementMode.POLYGON_MANDATE` and
-`SettlementMode.EMBEDDED_WALLET_CHARGE`. See
-[PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full phase log.
+`SettlementMode.EMBEDDED_WALLET_CHARGE` (added in v0.2.0). See
+[PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the full phase log
+and the live mainnet contract addresses.
 
 ### Free APIs need no wallet setup
 

--- a/PAYMENT_MIGRATION.md
+++ b/PAYMENT_MIGRATION.md
@@ -1,9 +1,26 @@
 # Payment Migration: Stripe Connect → Polygon On-Chain Smart Wallet
 
-**Status:** Phases 1–47 shipped. **Phase 47 closes preflight / env alignment and marks the Codex implementation role as handed off.** `web3_preflight_rpc_max_age_seconds` default is now 60 s and `.env.prod.example` matches. Reconciliation cadence is now documented as seconds-based-daily, with external orchestration called out as the way to pin a fixed wall-clock time (e.g., 03:00). `payout_*` primary / `stripe_*` alias stance is further sharpened in OpenAPI + frontend types. **Codex declared its implementation role complete after Phase 47** — branch is handed off in "merge-ready pending operator + release cut" state. Residual code task is `stripe_*` alias tail cleanup (release-cadence decision, not implementation). `recovery-2026-04-18` is **code-complete for mainnet launch prerequisites**; main still untouched. Remaining work is operator-side + release-side: (1) create 2-of-3 operator Safe on Polygon mainnet, (2) populate `.env.prod` from the operator-ready `.env.prod.example`, (3) run `/v1/admin/market/web3/preflight --require-ready` and verify all green, (4) merge `recovery-2026-04-18` → `main` and deploy, (5) re-sync public SDK repo `openapi/developer-surface.yaml` + cut patch release (v0.2.1, additive-only) so SDK consumers see `payout_*` primary.
-**Last updated:** 2026-04-18
+**Status: ✅ COMPLETE — live on Polygon mainnet (chainId 137).**
 
-The Siglume Agent API Store is retiring its Stripe Connect payout stack and moving to **Polygon-based on-chain settlement**. This document tracks the migration so SDK users know what works today vs. what is changing.
+The migration is done. All five Siglume settlement surfaces — Plan / Partner / API Store paid / AIWorks Escrow / Ads — settle on-chain through the Polygon mainnet contracts below. Stripe Connect is retired across the platform; there is no Stripe code path remaining for new purchases.
+
+**Mainnet contracts (chainId 137):**
+
+| Contract | Address |
+|---|---|
+| `SubscriptionHub` | [`0xBe901CcCCF94709105cbCdc4A9799dC05d24Eb16`](https://polygonscan.com/address/0xBe901CcCCF94709105cbCdc4A9799dC05d24Eb16) |
+| `AdsBillingHub` | [`0xFc89FB66CeF46b6A3802E8e4aeDce1B115335744`](https://polygonscan.com/address/0xFc89FB66CeF46b6A3802E8e4aeDce1B115335744) |
+| `WorksEscrowHub` | [`0x6FC58be065F99354932Db2C8ac4030CEf4fa5889`](https://polygonscan.com/address/0x6FC58be065F99354932Db2C8ac4030CEf4fa5889) |
+| `FeeVault` | [`0x1c631A94851cD9cbd4CB631A821EDd6Aa22523b0`](https://polygonscan.com/address/0x1c631A94851cD9cbd4CB631A821EDd6Aa22523b0) |
+| Platform relayer (Safe-4337 smart wallet, gas-sponsored) | `0x2216864a3f9cf8039d49748abc5ee79a006f4fea` |
+
+Settlement tokens: native USDC (`0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`) and JPYC (`0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29`). Buyers and sellers each get a non-custodial embedded smart wallet (Turnkey-backed sub-org per user); platform-sponsored gas via Pimlico means neither side ever holds POL/MATIC. Subscription mandates auto-debit on cadence; the buyer can revoke on-chain at any time.
+
+The phase-by-phase log below is preserved as historical record. The "Phase 47 / mainnet-launch-prerequisites code-complete" status that closes that log was followed shortly after by the actual mainnet deploy and cutover, and the platform has been operating on the on-chain rail since.
+
+**Last updated:** 2026-04-26
+
+The Siglume Agent API Store has retired its Stripe Connect payout stack and moved to **Polygon-based on-chain settlement**. This document records the migration history so SDK users can see how the on-chain contracts and the SDK enums got to their current shape.
 
 ## The new model
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,17 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v0.10.0.** Python and TypeScript are version-aligned and
+> **Current release: v0.10.1.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, seller-owned connected-account OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
 > long-form buyer-facing `description`, and platform-controlled release semver
-> via `version_bump`.
-> See [CHANGELOG.md](./CHANGELOG.md) and
-> [RELEASE_NOTES_v0.10.0.md](./RELEASE_NOTES_v0.10.0.md) for the current release.
+> via `version_bump`. v0.10.1 is a documentation / metadata catch-up over
+> v0.10.0 — runtime behavior is byte-equivalent.
+> See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v0.10.1.md](./RELEASE_NOTES_v0.10.1.md), and
+> [RELEASE_NOTES_v0.10.0.md](./RELEASE_NOTES_v0.10.0.md) for the current
+> release line.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 > For the current browser-vs-CLI entry points into the same `auto-register`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use [docs/coding-agent-guide.md](./docs/coding-agent-guide.md) as the file to
 give your coding agent. Use [API_IDEAS.md](./API_IDEAS.md) if you need a safe
 first idea.
 
-> ⚠️ **Payment stack is migrating.** Siglume is moving from Stripe Connect to fully **on-chain settlement** (embedded smart wallet, platform-covered gas, auto-debit subscriptions). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for what works today vs. what's changing.
+> ✅ **Payment stack is on-chain and live.** Siglume settles 100% on **Polygon mainnet** (chainId 137) — non-custodial embedded smart wallets, platform-sponsored gas, auto-debit subscription mandates. Stripe Connect was retired in v0.2.0; the migration is complete across all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for the migration history and on-chain contract addresses.
 
 Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. The customers are **autonomous AI agents**, not humans.
 
@@ -57,12 +57,14 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v0.7.6.** Python and TypeScript are version-aligned and
+> **Current release: v0.10.0.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
-> runtime validation, seller OAuth seeding, paid payout readiness, webhooks,
-> usage metering and typed Web3 settlement helpers.
+> runtime validation, seller-owned connected-account OAuth, paid payout readiness,
+> capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
+> long-form buyer-facing `description`, and platform-controlled release semver
+> via `version_bump`.
 > See [CHANGELOG.md](./CHANGELOG.md) and
-> [RELEASE_NOTES_v0.7.6.md](./RELEASE_NOTES_v0.7.6.md) for the current release.
+> [RELEASE_NOTES_v0.10.0.md](./RELEASE_NOTES_v0.10.0.md) for the current release.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 > For the current browser-vs-CLI entry points into the same `auto-register`
@@ -267,12 +269,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 |---|---|
 | **Developer share** | 93.4% of subscription revenue |
 | **Platform fee** | 6.6% |
-| **Settlement** | On-chain to a Polygon embedded wallet (see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md)) |
-| **Gas fees** | Covered by the platform — developers and buyers never touch gas tokens |
+| **Settlement** | On-chain on **Polygon mainnet** (chainId 137) via your non-custodial embedded smart wallet (see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md)) |
+| **Gas fees** | Covered by the platform — developers and buyers never touch POL/MATIC |
+| **Settlement tokens** | USDC and JPYC (ERC-20 on Polygon mainnet) |
 | **Minimum price** | $5.00/month equivalent for subscription APIs |
 | **Free APIs** | Also supported — no wallet setup required for free listings |
 
-Both free and paid subscription APIs are supported. Free listings are fully live today; paid subscription publishing is open (Phase 31 Polygon Amoy end-to-end proven, 2026-04-18). Paid revenue settles to your Siglume embedded Polygon wallet automatically; only the payout token is configurable, from Wallet at `/owner/credits/payout`.
+Both free and paid subscription APIs are live in production on Polygon mainnet (chainId 137). Free listings publish without a wallet; paid listings settle automatically to your non-custodial embedded smart wallet on each charge cycle. Only the payout token (USDC vs JPYC) is configurable, from Wallet at `/owner/credits/payout`.
 
 > **Note:** The SDK `PriceModel` enum includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`,
 > and `PER_ACTION`. These are **reserved for future phases** and are not accepted
@@ -545,9 +548,13 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is an early-stage project (v0.7.6, alpha) with a growing but still
-small user base. The SDK and platform are actively evolving. Start with
-a small read-only API to learn the flow.
+This is **v0.10.0 (beta)** — the platform is launched on Polygon mainnet
+(chainId 137) with all five settlement surfaces (Plan / Partner / API
+Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
+reached parity with the production registration and operation surface.
+The user base is still growing, and new SDK surfaces continue to ship
+as the platform exposes them. Start with a small read-only API to learn
+the flow.
 
 ## Questions? Ideas? Feedback?
 

--- a/RELEASE_NOTES_v0.10.1.md
+++ b/RELEASE_NOTES_v0.10.1.md
@@ -1,0 +1,65 @@
+# siglume-api-sdk v0.10.1
+
+Released: 2026-04-26
+
+## Summary
+
+Documentation / metadata release. **No code changes** — Python and
+TypeScript runtimes are byte-equivalent to v0.10.0. The README, ROADMAP,
+and PAYMENT_MIGRATION pages on PyPI and npm were lagging behind the
+actual state of the platform; this release ships the corrected copy.
+
+## What changed
+
+### README
+
+- Removes the "⚠️ Payment stack is migrating" banner. The migration is
+  complete; settlement is on Polygon mainnet (chainId 137) for all five
+  settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow
+  / Ads).
+- Updates "Current release" from v0.7.6 to v0.10.0 and refreshes the
+  feature inventory to include capability bundles, seller-owned
+  connected-account OAuth, long-form `description`, and `version_bump`.
+- Updates the Revenue model table to call out the Polygon mainnet rail
+  explicitly (chainId 137, native USDC + JPYC, gas-sponsored).
+- Project status moves from "early-stage / alpha (v0.7.6)" to
+  "v0.10.0 / beta — platform is launched."
+
+### ROADMAP
+
+- Moves v0.7.0–v0.10.0 from "Next" to "Shipped." In particular,
+  capability bundles and seller-owned connected-account OAuth — which
+  the prior ROADMAP listed as v0.7 platform prerequisites — both shipped
+  in v0.7.x.
+- Keeps Multipart / file-only flows and external-ingest credential
+  surfaces in the not-yet-scheduled section.
+- Adds a note that `USAGE_BASED` / `PER_ACTION` opening for API Store
+  listings is a platform-side decision; metered settlement is already
+  live for Ads via `AdsBillingHub` on-chain.
+
+### PAYMENT_MIGRATION
+
+- Status header replaced with "✅ COMPLETE — live on Polygon mainnet
+  (chainId 137)." Lists the deployed mainnet contract addresses
+  (SubscriptionHub, AdsBillingHub, WorksEscrowHub, FeeVault, platform
+  relayer) and settlement-token addresses (native USDC, JPYC).
+- Phase-by-phase log is preserved unchanged as historical record.
+
+### pyproject.toml
+
+- Classifier moves from `Development Status :: 3 - Alpha` to
+  `Development Status :: 4 - Beta`.
+
+## Upgrade
+
+```bash
+pip install --upgrade siglume-api-sdk==0.10.1
+```
+
+```bash
+npm install @siglume/api-sdk@0.10.1
+```
+
+If you are already on v0.10.0, upgrading is purely cosmetic — you get
+the corrected README on PyPI / npm. The Python and TypeScript runtime
+behavior is unchanged.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,54 @@ what is explicitly out of scope. For the per-release changelog, see
 
 ## Shipped
 
+### v0.10.0 — buyer-facing copy + platform-controlled release semver
+
+`AppManifest.description` (long-form buyer-facing sales copy) and the
+top-level forwarding of `description` / `permission_scopes` /
+`compatibility_tags` on `auto_register`. Server-rejected
+`AppManifest.version` is stripped from outbound payloads; use
+`confirm_registration(..., version_bump=...)` to control
+`release_semver`. See
+[RELEASE_NOTES_v0.10.0.md](./RELEASE_NOTES_v0.10.0.md).
+
+### v0.9.x — semver control + listing detail polish
+
+`confirm_registration(..., version_bump="patch"|"minor"|"major")` lets
+sellers step the published `release_semver` past the auto-incrementing
+patch. `AppListing` documents the `version` and `active_agent_count`
+fields the detail endpoint already returns. See
+[RELEASE_NOTES_v0.9.0.md](./RELEASE_NOTES_v0.9.0.md) /
+[RELEASE_NOTES_v0.9.1.md](./RELEASE_NOTES_v0.9.1.md).
+
+### v0.8.0 — example_prompts ≥ 2 enforced
+
+`example_prompts` now requires at least 2 distinct entries on
+`auto_register` / `confirm_auto_register`; client-side preflight
+mirrors the server rule so the failure surfaces before the network
+round-trip. See
+[RELEASE_NOTES_v0.8.0.md](./RELEASE_NOTES_v0.8.0.md).
+
+### v0.7.x — capability bundles + seller-owned connected-account OAuth
+
+Both v0.7 platform tracks landed:
+
+- **Capability bundles** — typed `/v1/market/bundles` wrappers in
+  Python and TypeScript. One listing exposes multiple capability
+  listings under one subscription; same-seller, 10-member cap, and
+  grade-B-per-member gates are enforced platform-side.
+- **Connected-account OAuth (seller-owned)** — sellers register their
+  own OAuth app credentials per listing via
+  `set_listing_oauth_credentials()`; buyers initiate OAuth against the
+  seller's app rather than a platform-shared one. The
+  `client_secret` never leaves the SDK on the wire.
+
+Plus production-onboarding hardening across v0.7.2 → v0.7.6:
+auto-register payload alignment, runtime-validation contract checks,
+register CLI preflight, jurisdiction enforcement, and `SIGLUME_API_KEY`
+fallback. See
+[RELEASE_NOTES_v0.7.0.md](./RELEASE_NOTES_v0.7.0.md) through
+[RELEASE_NOTES_v0.7.6.md](./RELEASE_NOTES_v0.7.6.md).
+
 ### v0.6.0 — first-party operation surface parity
 
 Every first-party operation on the Siglume platform is reachable
@@ -27,30 +75,20 @@ drafting, manifest / tool-manual diff, tool-schema exporter
 (experimental), seven starter examples. See
 [RELEASE_NOTES_v0.4.0.md](./RELEASE_NOTES_v0.4.0.md).
 
-## Next — v0.7 (not yet scheduled)
+### v0.2.0 — first SDK-visible step of the on-chain payment migration
 
-v0.7 focuses on surfaces **outside** the first-party operation
-registry that v0.6 already covers. Each of the three tracks below is
-blocked on platform-side contract work before the SDK can wrap it.
+`SettlementMode` expanded with `polygon_mandate` and
+`embedded_wallet_charge`. The full migration (Stripe Connect → Polygon
+mainnet, chainId 137) shipped server-side across phases 1–47 and is
+now live in production for all five settlement surfaces (Plan /
+Partner / API Store paid / AIWorks Escrow / Ads). See
+[PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for the detail and
+on-chain contract addresses.
 
-### Capability bundles
+## Next — not yet scheduled
 
-Publish one listing that exposes multiple `ToolManual` entries (one
-per sub-capability) and is sold as a single subscription.
-
-What the SDK will add once the platform ships the bundle contract:
-
-- `AppAdapter.list_tools()` convention for declaring multiple tools
-  on one adapter.
-- Bundle-level registration helpers on `SiglumeClient`.
-- Bundle-aware quality grading in `AppTestHarness`.
-
-Platform prerequisites:
-
-- A public `/v1/market/bundles` (or equivalent) registration and
-  read API.
-- Stable bundle-level identity that maps cleanly onto listing keys,
-  release ids, and per-tool quality validation.
+Each track below is blocked on platform-side contract work before the
+SDK can wrap it.
 
 ### Multipart / file-only flows
 
@@ -107,6 +145,15 @@ Platform prerequisites:
 - A stable provider-family contract in `operation_registry` for
   external credential issuance.
 - Decision on per-provider redaction and audit requirements.
+
+### Usage-based / per-action billing on `PriceModel`
+
+The SDK enum reserves `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and
+`PER_ACTION`, and the `MeterClient` surface ships today as
+experimental ingest-only. Platform-side, `AdsBillingHub` already
+implements metered settlement on Polygon for ad spend; opening the
+same axis for API Store listings is a platform decision, not an
+SDK gap.
 
 ## Not planned
 

--- a/docs/demo-capture-guide.md
+++ b/docs/demo-capture-guide.md
@@ -12,12 +12,12 @@ The current beta separates buyer and seller flows:
 - `/owner/installed-tools` is the installed-tool execution surface
 - `/owner/receipts` is the execution audit trail
 
-Paid subscription publishing is open (Phase 31 proven on Polygon Amoy with
-a real user-operation, 2026-04-18; see `PAYMENT_MIGRATION.md`). Record the
-embedded-wallet payout flow from Wallet at `/owner/credits/payout`, where only
-the payout token can be changed. If a live on-chain payout is too
-fragile for the take, fall back to showing the wallet page and point to the
-release notes.
+Paid subscription publishing is live in production on Polygon mainnet
+(chainId 137); see `PAYMENT_MIGRATION.md` for the deployed contract
+addresses. Record the embedded-wallet payout flow from Wallet at
+`/owner/credits/payout`, where only the payout token (USDC vs JPYC) can
+be changed. If a live on-chain payout is too fragile for the take, fall
+back to showing the wallet page and point to the release notes.
 
 ## Recommended demo flow
 

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -127,8 +127,9 @@ async def main():
     print("     siglume register . --confirm")
     print("")
     print("Revenue share: 93.4% developer / 6.6% platform.")
-    print("Settlement: migrating from Stripe Connect to on-chain embedded wallet")
-    print("(gas covered by the platform). See PAYMENT_MIGRATION.md for details.")
+    print("Settlement: on-chain on Polygon mainnet (chainId 137) via your")
+    print("non-custodial embedded smart wallet. Platform sponsors gas. See")
+    print("PAYMENT_MIGRATION.md for the deployed contract addresses.")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.10.0"
+version = "0.10.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"
@@ -13,7 +13,7 @@ dependencies = ["click>=8.1,<9", "httpx>=0.27,<1"]
 authors = [{name = "Siglume Contributors"}]
 keywords = ["ai", "agent", "api-store", "sdk", "siglume"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -2,7 +2,7 @@
 
 TypeScript runtime for building, testing, and registering Siglume developer apps.
 
-This package is prepared in the public SDK repo and ships with the current v0.7.6 release line.
+This package is prepared in the public SDK repo and ships with the current v0.10.x release line.
 
 It also includes `draft_tool_manual()` and `fill_tool_manual_gaps()` with
 bundled `AnthropicProvider` and `OpenAIProvider` classes. Provide

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.10.0";
+export const SDK_VERSION = "0.10.1";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.10.0"
+SDK_VERSION = "0.10.1"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -53,7 +53,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.10.0"
+    assert python_version == "0.10.1"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -68,7 +68,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is an early-stage project (v0.7.6, alpha)" in readme
+    assert "This is **v0.10.0 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary

Documentation / metadata release. **No code changes** — Python and TypeScript runtimes are byte-equivalent to v0.10.0; this corrects copy on PyPI / npm that lagged behind the actual platform state.

The Stripe Connect → Polygon mainnet (chainId 137) migration is **complete** and live in production for all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). Earlier copy still framed paid subscriptions as "publishing is open (Phase 31 Polygon Amoy end-to-end proven)" and the payment stack as "migrating," which understated the current state.

## What changed

- **README**: drop "⚠️ Payment stack is migrating" banner; bump "Current release" v0.7.6 → v0.10.0; project status alpha → beta + Polygon mainnet
- **ROADMAP**: move v0.7.0–v0.10.0 from Next to Shipped (capability bundles + connected-account OAuth landed in v0.7.x); add USAGE_BASED / PER_ACTION as platform-side decision, not SDK gap
- **PAYMENT_MIGRATION header**: mark COMPLETE; list deployed mainnet contract addresses (SubscriptionHub, AdsBillingHub, WorksEscrowHub, FeeVault, platform relayer) + settlement-token addresses (USDC, JPYC). Phase log preserved as historical record.
- **GETTING_STARTED**: drop "historical Stripe-Connect flow" copy and Amoy references; subscription pricing row references Polygon mainnet
- **examples/hello_price_compare.py**: drop "Settlement: migrating from Stripe Connect" string
- **docs/demo-capture-guide.md**: drop Phase 31 / Polygon Amoy framing
- **pyproject.toml**: classifier `3 - Alpha` → `4 - Beta`; version `0.10.0` → `0.10.1`
- **siglume-api-sdk-ts/package.json**: version `0.10.0` → `0.10.1`
- **siglume_api_sdk/_version.py** + **siglume-api-sdk-ts/src/version.ts**: `SDK_VERSION` `0.10.0` → `0.10.1`
- **tests/test_docs_contract.py**: assertions track new version + new README "Project status" wording
- New **RELEASE_NOTES_v0.10.1.md**
- **CHANGELOG**: 0.10.1 entry

## Test plan

- [x] `pytest -x` — 311 passed
- [x] `pytest tests/test_docs_contract.py` — 8 passed (version + README copy assertions)
- [x] No source code touched outside version constants and one example print line

🤖 Generated with [Claude Code](https://claude.com/claude-code)