### PR TITLE
docs: publish input_form_spec authoring guide, schema, and OpenAPI shape

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -466,7 +466,10 @@ draft; it does not edit the manual. See [Section 13](#13-tool-manual-guide).
 - SDK / HTTP automation can include `source_url` plus optional
   `source_context` to register directly from GitHub provenance
 - `input_form_spec` can be seeded during `auto-register` and is reused at
-  confirm time; confirmation does not edit it
+  confirm time; confirmation does not edit it. See
+  [`docs/input-form-spec.md`](docs/input-form-spec.md) for the authoring
+  guide and [`schemas/input-form-spec.schema.json`](schemas/input-form-spec.schema.json)
+  for the machine-checkable schema.
 
 A quality check runs automatically at confirmation time:
 - Grade B or above (A/B): your API can be published immediately if the

--- a/docs/input-form-spec.md
+++ b/docs/input-form-spec.md
@@ -1,0 +1,335 @@
+# `input_form_spec` — Client-Facing Form Specification
+
+`input_form_spec` is the optional bilingual (Japanese / English) form
+specification you can attach to a listing during `auto-register`. It defines
+the form an agent or buyer fills in when invoking your API.
+
+It is distinct from `input_schema` (the JSON Schema the runtime uses to
+validate the actual tool-call parameters at runtime). Both can coexist; they
+are not redundant. See [§ `input_form_spec` vs `input_schema`](#input_form_spec-vs-input_schema).
+
+The machine-checkable schema lives at
+[`schemas/input-form-spec.schema.json`](../schemas/input-form-spec.schema.json).
+
+---
+
+## Minimal valid example
+
+```json
+{
+  "version": "1.0",
+  "title": { "ja": "Wallet lookup", "en": "Wallet lookup" },
+  "fields": [
+    {
+      "key": "address",
+      "type": "text",
+      "label": { "ja": "Wallet address", "en": "Wallet address" },
+      "description": { "ja": "0x-prefixed EVM address", "en": "0x-prefixed EVM address" },
+      "placeholder": { "ja": "0x...", "en": "0x..." },
+      "required": true
+    }
+  ]
+}
+```
+
+---
+
+## Top-level structure
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `version` | yes | string | Must be exactly `"1.0"` |
+| `title` | yes | bilingual text | Both `ja` and `en` keys required |
+| `description` | no | bilingual text | Both keys required when present |
+| `fields` | yes | array | 1–20 items; **at least one** must have `required: true` |
+| `sections` | no | array | Optional grouping of fields into ordered titled sections (multi-capability composition only) |
+
+A *bilingual text* object is `{ "ja": "...", "en": "..." }` with both keys
+present and non-empty.
+
+---
+
+## Field types
+
+All fields share these base properties:
+
+| Property | Required | Notes |
+|---|---|---|
+| `key` | yes | Lowercase + underscores. Must match `^[a-z][a-z0-9_]*$`. Unique within `fields[]`. |
+| `type` | yes | One of the 9 types listed below |
+| `label` | yes | Bilingual text |
+| `description` | no | Bilingual text |
+| `placeholder` | no (per type) | Bilingual text. Required for `text` / `textarea` / `url` under multi-capability composition |
+| `required` | no | Boolean. At least one field in the form must be `true`. |
+| `default` | no | Optional default value. Type must match the field's input type. |
+| `tool_bindings` | no | Multi-capability composition only. See [Multi-capability composition](#multi-capability-composition). |
+
+### `text`
+
+Single-line free text.
+
+```json
+{
+  "key": "address",
+  "type": "text",
+  "label": { "ja": "Wallet address", "en": "Wallet address" },
+  "placeholder": { "ja": "0x...", "en": "0x..." },
+  "max_length": 64,
+  "required": true
+}
+```
+
+| Extra | Notes |
+|---|---|
+| `max_length` | Optional positive integer. |
+
+### `textarea`
+
+Multi-line free text.
+
+```json
+{
+  "key": "memo",
+  "type": "textarea",
+  "label": { "ja": "Memo", "en": "Memo" },
+  "rows": 5,
+  "max_length": 2000
+}
+```
+
+| Extra | Notes |
+|---|---|
+| `rows` | Optional positive integer (UI hint). |
+| `max_length` | Optional positive integer. |
+
+### `number`
+
+Numeric value.
+
+```json
+{
+  "key": "amount",
+  "type": "number",
+  "label": { "ja": "Amount", "en": "Amount" },
+  "min": 0,
+  "max": 100000,
+  "step": 0.01,
+  "unit": "USD"
+}
+```
+
+| Extra | Notes |
+|---|---|
+| `min`, `max` | Optional bounds. |
+| `step` | Optional, must be > 0. |
+| `unit` | Informational unit string (not validated). |
+
+Booleans are rejected for number fields.
+
+### `select`
+
+Single-choice dropdown.
+
+```json
+{
+  "key": "chain",
+  "type": "select",
+  "label": { "ja": "Chain", "en": "Chain" },
+  "options": [
+    { "value": "ethereum",  "label": { "ja": "Ethereum",  "en": "Ethereum" } },
+    { "value": "polygon",   "label": { "ja": "Polygon",   "en": "Polygon" } }
+  ],
+  "required": true
+}
+```
+
+| Extra | Notes |
+|---|---|
+| `options` | Required, 1–100 items. Each `{ value, label }`. `label` is bilingual. |
+
+Submitted value must equal one of the option `value`s.
+
+### `multiselect`
+
+Multi-choice list.
+
+```json
+{
+  "key": "tags",
+  "type": "multiselect",
+  "label": { "ja": "Tags", "en": "Tags" },
+  "options": [
+    { "value": "defi",   "label": { "ja": "DeFi",   "en": "DeFi" } },
+    { "value": "nft",    "label": { "ja": "NFT",    "en": "NFT" } },
+    { "value": "social", "label": { "ja": "Social", "en": "Social" } }
+  ],
+  "max_selections": 3
+}
+```
+
+Same `options` rules as `select`. Submitted value must be an array of valid
+option `value`s; length capped by `max_selections` if set.
+
+### `file`
+
+File upload.
+
+```json
+{
+  "key": "document",
+  "type": "file",
+  "label": { "ja": "Document", "en": "Document" },
+  "accept": [".pdf", ".docx"],
+  "max_size_mb": 50,
+  "max_files": 1,
+  "required": true
+}
+```
+
+| Extra | Notes |
+|---|---|
+| `accept` | Optional array of dot-prefixed extensions (`".pdf"`, not `"pdf"`). |
+| `max_size_mb` | Optional, must be ≤ 200. |
+| `max_files` | Optional positive integer; default 1. |
+
+### `url`
+
+URL string.
+
+```json
+{
+  "key": "homepage",
+  "type": "url",
+  "label": { "ja": "Homepage", "en": "Homepage" },
+  "placeholder": { "ja": "https://...", "en": "https://..." }
+}
+```
+
+Submitted value must start with `http://` or `https://`.
+
+### `date`
+
+ISO-8601 calendar date (`YYYY-MM-DD`).
+
+```json
+{
+  "key": "departure",
+  "type": "date",
+  "label": { "ja": "Departure", "en": "Departure" },
+  "min_date": "2026-01-01",
+  "max_date": "2026-12-31"
+}
+```
+
+### `boolean`
+
+Toggle / checkbox.
+
+```json
+{
+  "key": "include_history",
+  "type": "boolean",
+  "label": { "ja": "Include history", "en": "Include history" },
+  "default": false
+}
+```
+
+---
+
+## `input_form_spec` vs `input_schema`
+
+Both are required for a complete listing; they describe two different layers
+and the platform validates both.
+
+| | `input_form_spec` | `input_schema` |
+|---|---|---|
+| Purpose | Client-facing UI form | Runtime parameter validation |
+| Audience | Human / agent filling in the form | The platform runtime + LLM tool-use |
+| Granularity | "Pick a chain", "Upload a file" | `{ "chain": "ethereum", "file_url": "https://..." }` |
+| Format | This spec | JSON Schema (Draft-07 compatible) |
+| Required when | You want a buyer / agent to fill in inputs | Always (the runtime needs it to validate calls) |
+
+A single form field maps to one or more parameters in `input_schema`. For
+example a `text` field with `key: "address"` typically maps to a property
+`{ "address": { "type": "string" } }` in `input_schema`. The platform
+enforces type-compatibility between the two — for example, a `number` form
+field cannot bind to a `string` schema property.
+
+---
+
+## Common validator errors
+
+| Message | Cause | Fix |
+|---|---|---|
+| `version must be '1.0'` | Wrong or missing `version` | Set `"version": "1.0"` |
+| `title must have both 'ja' and 'en' keys` | Missing one language | Provide both keys, both non-empty |
+| `fields must be a non-empty array` | `fields: []` or missing | Provide at least one field |
+| `fields must have at most 20 items` | More than 20 fields | Split or simplify the form |
+| `key '...' must match [a-z][a-z0-9_]*` | Uppercase or special chars in key | Use lowercase + underscore only |
+| `duplicate key '...'` | Two fields share a key | Each field's `key` must be unique |
+| `unsupported type '...'` | Unknown field type | Use one of the 9 types above |
+| `label must have both 'ja' and 'en'` | Single-language label | Bilingual labels are mandatory |
+| `at least one field must be required` | All fields are optional | Mark at least one field as `required: true` |
+| `accept entries must be dot-prefixed extensions like '.pdf' (got '...')` | Missing leading dot | Prefix all extensions with `.` |
+| `max_size_mb cannot exceed 200` | File limit too high | Cap at 200 |
+| `<type> must have at least 1 option` | Empty `options` on a `select` / `multiselect` | Provide at least 1 option |
+| `options cannot exceed 100` | Too many options | Limit to ≤ 100 items |
+
+---
+
+## Multi-capability composition
+
+When a single form drives multiple underlying capabilities, each field can
+declare `tool_bindings`:
+
+```json
+{
+  "key": "target_language",
+  "type": "select",
+  "label": { "ja": "Target Language", "en": "Target Language" },
+  "options": [
+    { "value": "ja", "label": { "ja": "Japanese", "en": "Japanese" } },
+    { "value": "en", "label": { "ja": "English",  "en": "English"  } }
+  ],
+  "required": true,
+  "tool_bindings": [
+    { "capability_release_id": "rel_translate", "param": "target_language" },
+    { "capability_release_id": "rel_proofread", "param": "language" }
+  ]
+}
+```
+
+The same field is bound to a different parameter in each downstream
+capability. Each `(capability_release_id, param)` pair must appear at most
+once across all fields. For most single-capability listings you do not need
+`tool_bindings`.
+
+`sections` group field keys into ordered, titled UI sections:
+
+```json
+"sections": [
+  {
+    "key": "source",
+    "title": { "ja": "Source", "en": "Source" },
+    "field_keys": ["source_file", "source_lang"]
+  },
+  {
+    "key": "target",
+    "title": { "ja": "Target", "en": "Target" },
+    "field_keys": ["target_lang", "tone"]
+  }
+]
+```
+
+---
+
+## Where `input_form_spec` is used in the publish flow
+
+- `POST /v1/market/capabilities/auto-register` — pass it alongside
+  `tool_manual` and other manifest fields. The validator runs before the
+  draft listing is created.
+- `POST /v1/market/capabilities/{listing_id}/confirm-auto-register` —
+  confirmation reuses the form spec submitted at auto-register; it does not
+  edit it.
+
+For a CLI flow walkthrough see [`publish-flow.md`](publish-flow.md).

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -69,7 +69,7 @@ There is no normal human review step in the self-serve publish flow anymore.
    - manifest fields
    - Tool Manual
    - optional seller OAuth app credentials in `oauth_credentials`
-   - optional `input_form_spec`
+   - optional `input_form_spec` ([authoring guide](input-form-spec.md))
 3. Runs contract, pricing, payout, seller OAuth, and runtime validation preflight checks.
 4. Runs a mandatory fail-closed LLM legal review on the submitted package.
 5. Verifies the public API is reachable from the internet.

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -224,8 +224,7 @@ paths:
                 tool_manual:
                   $ref: '#/components/schemas/ToolManual'
                 input_form_spec:
-                  type: object
-                  description: Optional structured UI input form spec to seed the release contract
+                  $ref: '#/components/schemas/InputFormSpec'
                 capability_key:
                   type: string
                   description: Override auto-detected capability key
@@ -2965,6 +2964,121 @@ components:
         currency: { type: string, enum: [USD], description: "Must be USD" }
         settlement_mode: { type: string, enum: [stripe_checkout, stripe_payment_intent, polygon_mandate, embedded_wallet_charge] }
         refund_or_cancellation_note: { type: string, minLength: 1 }
+
+    BilingualText:
+      type: object
+      description: Bilingual ja/en text used by input_form_spec for titles, labels, descriptions, placeholders, and option labels.
+      required: [ja, en]
+      additionalProperties: false
+      properties:
+        ja: { type: string, minLength: 1 }
+        en: { type: string, minLength: 1 }
+
+    InputFormSpecField:
+      type: object
+      description: |
+        A single form field. Validator-enforced rules (cannot be expressed
+        purely in OpenAPI):
+        - At least one field in `fields[]` must have `required: true`.
+        - Field `key` must be unique within `fields[]`.
+        - For `text` / `textarea` / `url` fields, `placeholder` is required
+          under multi-capability composition.
+        - For `select` / `multiselect`, `options` is required.
+        See docs/input-form-spec.md for the full rule set.
+      required: [key, type, label]
+      properties:
+        key:
+          type: string
+          pattern: "^[a-z][a-z0-9_]*$"
+          description: Lowercase + underscores only. Unique within fields[].
+        type:
+          type: string
+          enum: [text, textarea, number, select, multiselect, file, url, date, boolean]
+        label: { $ref: '#/components/schemas/BilingualText' }
+        description: { $ref: '#/components/schemas/BilingualText' }
+        placeholder: { $ref: '#/components/schemas/BilingualText' }
+        required: { type: boolean, default: false }
+        default:
+          description: Optional default value. Type must match the field's input type.
+        # text / textarea
+        max_length: { type: integer, minimum: 1 }
+        rows: { type: integer, minimum: 1, description: "textarea only — UI hint" }
+        # number
+        min: { type: number }
+        max: { type: number }
+        step: { type: number, exclusiveMinimum: 0 }
+        unit: { type: string, description: "number only — informational, not validated" }
+        # select / multiselect
+        options:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            type: object
+            required: [value, label]
+            additionalProperties: false
+            properties:
+              value: { type: string, minLength: 1 }
+              label: { $ref: '#/components/schemas/BilingualText' }
+        max_selections: { type: integer, minimum: 1, description: "multiselect only" }
+        # file
+        accept:
+          type: array
+          description: "file only — array of dot-prefixed extensions (e.g. '.pdf')"
+          items: { type: string, pattern: "^\\." }
+        max_size_mb: { type: number, exclusiveMinimum: 0, maximum: 200 }
+        max_files: { type: integer, minimum: 1, default: 1 }
+        # date
+        min_date: { type: string, pattern: "^\\d{4}-\\d{2}-\\d{2}$" }
+        max_date: { type: string, pattern: "^\\d{4}-\\d{2}-\\d{2}$" }
+        # multi-capability composition
+        tool_bindings:
+          type: array
+          description: Multi-capability composition only. Maps this form field to one or more (capability_release_id, param) pairs.
+          items:
+            type: object
+            required: [capability_release_id, param]
+            additionalProperties: false
+            properties:
+              capability_release_id: { type: string }
+              param: { type: string }
+
+    InputFormSpec:
+      type: object
+      description: |
+        Optional bilingual (ja/en) client-facing form spec. The agent or
+        buyer fills in this form to invoke the listing. Distinct from
+        `input_schema`, which the runtime uses to validate the actual
+        tool-call parameters. Canonical machine-checkable schema:
+        schemas/input-form-spec.schema.json. Authoring guide:
+        docs/input-form-spec.md.
+      required: [version, title, fields]
+      additionalProperties: false
+      properties:
+        version:
+          type: string
+          enum: ["1.0"]
+          description: Spec version. Currently only '1.0' is accepted.
+        title: { $ref: '#/components/schemas/BilingualText' }
+        description: { $ref: '#/components/schemas/BilingualText' }
+        fields:
+          type: array
+          minItems: 1
+          maxItems: 20
+          items: { $ref: '#/components/schemas/InputFormSpecField' }
+        sections:
+          type: array
+          description: Optional grouping of field keys into ordered, titled UI sections.
+          items:
+            type: object
+            required: [key, title, field_keys]
+            additionalProperties: false
+            properties:
+              key: { type: string, pattern: "^[a-z][a-z0-9_]*$" }
+              title: { $ref: '#/components/schemas/BilingualText' }
+              field_keys:
+                type: array
+                items: { type: string, pattern: "^[a-z][a-z0-9_]*$" }
 
     ToolManualValidationMessage:
       type: object

--- a/schemas/input-form-spec.schema.json
+++ b/schemas/input-form-spec.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/taihei-05/siglume-api-sdk/schemas/input-form-spec.schema.json",
+  "title": "input_form_spec",
+  "description": "Schema for the optional input_form_spec object passed to /v1/market/capabilities/auto-register and reused at confirm time. Defines the bilingual (ja/en) client-facing form an agent or buyer fills in to invoke a listing. See docs/input-form-spec.md.",
+  "type": "object",
+  "required": ["version", "title", "fields"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Spec version. Currently the only accepted value is '1.0'."
+    },
+    "title": { "$ref": "#/$defs/bilingualText" },
+    "description": { "$ref": "#/$defs/bilingualText" },
+    "fields": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "description": "Form fields. At least one field must have required=true (validator-enforced; not expressible at the schema level).",
+      "items": { "$ref": "#/$defs/field" }
+    },
+    "sections": {
+      "type": "array",
+      "description": "Optional grouping of field keys into ordered, titled sections. Used by multi-capability composition flows.",
+      "items": {
+        "type": "object",
+        "required": ["key", "title", "field_keys"],
+        "additionalProperties": false,
+        "properties": {
+          "key": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+          "title": { "$ref": "#/$defs/bilingualText" },
+          "field_keys": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "bilingualText": {
+      "type": "object",
+      "required": ["ja", "en"],
+      "additionalProperties": false,
+      "properties": {
+        "ja": { "type": "string", "minLength": 1 },
+        "en": { "type": "string", "minLength": 1 }
+      }
+    },
+    "fieldKey": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "description": "Lowercase + underscores only. Must start with a letter. Must be unique within fields[]."
+    },
+    "fieldBase": {
+      "type": "object",
+      "required": ["key", "type", "label"],
+      "properties": {
+        "key": { "$ref": "#/$defs/fieldKey" },
+        "type": {
+          "type": "string",
+          "enum": ["text", "textarea", "number", "select", "multiselect", "file", "url", "date", "boolean"]
+        },
+        "label": { "$ref": "#/$defs/bilingualText" },
+        "description": { "$ref": "#/$defs/bilingualText" },
+        "placeholder": {
+          "$ref": "#/$defs/bilingualText",
+          "description": "Required for text/textarea/url under multi-capability composition (18.6.2)."
+        },
+        "required": { "type": "boolean", "default": false },
+        "default": {
+          "description": "Optional default value. Type must match the field's effective input type."
+        },
+        "tool_bindings": {
+          "type": "array",
+          "description": "Multi-capability composition only. Maps this form field to one or more (capability_release_id, param) pairs.",
+          "items": {
+            "type": "object",
+            "required": ["capability_release_id", "param"],
+            "additionalProperties": false,
+            "properties": {
+              "capability_release_id": { "type": "string" },
+              "param": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "field": {
+      "oneOf": [
+        { "$ref": "#/$defs/textField" },
+        { "$ref": "#/$defs/textareaField" },
+        { "$ref": "#/$defs/numberField" },
+        { "$ref": "#/$defs/selectField" },
+        { "$ref": "#/$defs/multiselectField" },
+        { "$ref": "#/$defs/fileField" },
+        { "$ref": "#/$defs/urlField" },
+        { "$ref": "#/$defs/dateField" },
+        { "$ref": "#/$defs/booleanField" }
+      ]
+    },
+    "textField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "text" },
+            "max_length": { "type": "integer", "minimum": 1 }
+          }
+        }
+      ]
+    },
+    "textareaField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "textarea" },
+            "max_length": { "type": "integer", "minimum": 1 },
+            "rows": { "type": "integer", "minimum": 1 }
+          }
+        }
+      ]
+    },
+    "numberField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "number" },
+            "min": { "type": "number" },
+            "max": { "type": "number" },
+            "step": { "type": "number", "exclusiveMinimum": 0 },
+            "unit": { "type": "string", "description": "Informational unit string (e.g. 'm2'). Not validated." }
+          }
+        }
+      ]
+    },
+    "selectOption": {
+      "type": "object",
+      "required": ["value", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": "string", "minLength": 1 },
+        "label": { "$ref": "#/$defs/bilingualText" }
+      }
+    },
+    "selectField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "required": ["options"],
+          "properties": {
+            "type": { "const": "select" },
+            "options": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 100,
+              "items": { "$ref": "#/$defs/selectOption" }
+            }
+          }
+        }
+      ]
+    },
+    "multiselectField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "required": ["options"],
+          "properties": {
+            "type": { "const": "multiselect" },
+            "options": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 100,
+              "items": { "$ref": "#/$defs/selectOption" }
+            },
+            "max_selections": { "type": "integer", "minimum": 1 }
+          }
+        }
+      ]
+    },
+    "fileField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "file" },
+            "accept": {
+              "type": "array",
+              "description": "Accepted file extensions. Each entry must be dot-prefixed (e.g. '.pdf').",
+              "items": { "type": "string", "pattern": "^\\." }
+            },
+            "max_size_mb": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "maximum": 200
+            },
+            "max_files": { "type": "integer", "minimum": 1, "default": 1 }
+          }
+        }
+      ]
+    },
+    "urlField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "url" }
+          }
+        }
+      ]
+    },
+    "dateField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "date" },
+            "min_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+            "max_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" }
+          }
+        }
+      ]
+    },
+    "booleanField": {
+      "allOf": [
+        { "$ref": "#/$defs/fieldBase" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "boolean" }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #189.

## Summary

- Add `schemas/input-form-spec.schema.json` — machine-checkable JSON Schema for `input_form_spec`, on par with `tool-manual.schema.json`. Encodes the `version: "1.0"` constant, bilingual `ja`/`en` requirement, field key regex, all 9 field types with type-specific constraints, and the size caps the platform validator enforces.
- Add `docs/input-form-spec.md` — authoring guide: minimal example, full top-level shape, every supported field type with a worked example, common validator errors, and the `input_form_spec` vs `input_schema` distinction.
- Expand `openapi/developer-surface.yaml`: replace the `auto-register` request's `input_form_spec` from `type: object` to a real `InputFormSpec` component schema (with `BilingualText` and `InputFormSpecField` helpers). The deprecated post-draft `input_form_spec` on `confirm-auto-register` is intentionally left as `type: object` so this PR does not touch deprecated surfaces.
- Cross-link from `GETTING_STARTED.md` and `docs/publish-flow.md` to the new authoring guide and JSON Schema.

No behavior change. The platform validator's rules are unchanged; this PR only documents what was already enforced server-side.

## Motivation

Reported in #186 — an external developer needed to populate `input_form_spec` and could only find references that the field exists, not how to fill it in. After this PR, a developer can write a valid `input_form_spec` end-to-end without asking.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('openapi/developer-surface.yaml'))"` parses cleanly
- [x] `python -c "import json; json.load(open('schemas/input-form-spec.schema.json'))"` parses cleanly
- [x] Doc examples lifted directly from the platform validator's positive-test fixtures, so they all satisfy the new JSON Schema and the OpenAPI definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)