### PR TITLE
[codex] Accept seller-localized input form text

### DIFF
--- a/docs/input-form-spec.md
+++ b/docs/input-form-spec.md
@@ -1,8 +1,13 @@
 # `input_form_spec` — Client-Facing Form Specification
 
-`input_form_spec` is the optional bilingual (Japanese / English) form
-specification you can attach to a listing during `auto-register`. It defines
-the form an agent or buyer fills in when invoking your API.
+`input_form_spec` is the optional client-facing form specification you can
+attach to a listing during `auto-register`. It defines the form an agent or
+buyer fills in when invoking your API.
+
+You may write buyer-facing text as plain one-language strings. The platform
+normalizes those strings into stored Japanese / English text during
+`auto-register`. If you already have both languages, you may also send the
+stored `{ "ja": "...", "en": "..." }` shape directly.
 
 It is distinct from `input_schema` (the JSON Schema the runtime uses to
 validate the actual tool-call parameters at runtime). Both can coexist; they
@@ -18,14 +23,14 @@ The machine-checkable schema lives at
 ```json
 {
   "version": "1.0",
-  "title": { "ja": "Wallet lookup", "en": "Wallet lookup" },
+  "title": "Wallet lookup",
   "fields": [
     {
       "key": "address",
       "type": "text",
-      "label": { "ja": "Wallet address", "en": "Wallet address" },
-      "description": { "ja": "0x-prefixed EVM address", "en": "0x-prefixed EVM address" },
-      "placeholder": { "ja": "0x...", "en": "0x..." },
+      "label": "Wallet address",
+      "description": "0x-prefixed EVM address",
+      "placeholder": "0x...",
       "required": true
     }
   ]
@@ -39,13 +44,15 @@ The machine-checkable schema lives at
 | Field | Required | Type | Notes |
 |---|---|---|---|
 | `version` | yes | string | Must be exactly `"1.0"` |
-| `title` | yes | bilingual text | Both `ja` and `en` keys required |
-| `description` | no | bilingual text | Both keys required when present |
+| `title` | yes | localized text | Plain string accepted; platform stores `ja` / `en` |
+| `description` | no | localized text | Plain string accepted; platform stores `ja` / `en` |
 | `fields` | yes | array | 1–20 items; **at least one** must have `required: true` |
 | `sections` | no | array | Optional grouping of fields into ordered titled sections (multi-capability composition only) |
 
-A *bilingual text* object is `{ "ja": "...", "en": "..." }` with both keys
-present and non-empty.
+A *localized text* value may be either a plain string or a bilingual object
+`{ "ja": "...", "en": "..." }`. Plain strings are the recommended seller input
+for `auto-register`; bilingual objects are the stored shape and are accepted
+for automation that already owns both translations.
 
 ---
 
@@ -57,9 +64,9 @@ All fields share these base properties:
 |---|---|---|
 | `key` | yes | Lowercase + underscores. Must match `^[a-z][a-z0-9_]*$`. Unique within `fields[]`. |
 | `type` | yes | One of the 9 types listed below |
-| `label` | yes | Bilingual text |
-| `description` | no | Bilingual text |
-| `placeholder` | no (per type) | Bilingual text. Required for `text` / `textarea` / `url` under multi-capability composition |
+| `label` | yes | Localized text |
+| `description` | no | Localized text |
+| `placeholder` | no (per type) | Localized text. Required for `text` / `textarea` / `url` under multi-capability composition |
 | `required` | no | Boolean. At least one field in the form must be `true`. |
 | `default` | no | Optional default value. Type must match the field's input type. |
 | `tool_bindings` | no | Multi-capability composition only. See [Multi-capability composition](#multi-capability-composition). |
@@ -145,9 +152,11 @@ Single-choice dropdown.
 
 | Extra | Notes |
 |---|---|
-| `options` | Required, 1–100 items. Each `{ value, label }`. `label` is bilingual. |
+| `options` | Required, 1–100 items. Each `{ value, label }`. `label` is localized text. |
 
-Submitted value must equal one of the option `value`s.
+Submitted value must equal one of the option `value`s. Option labels follow the
+same localized text rule as field labels: a plain string is accepted during
+`auto-register` and normalized by the platform.
 
 ### `multiselect`
 
@@ -262,13 +271,13 @@ field cannot bind to a `string` schema property.
 | Message | Cause | Fix |
 |---|---|---|
 | `version must be '1.0'` | Wrong or missing `version` | Set `"version": "1.0"` |
-| `title must have both 'ja' and 'en' keys` | Missing one language | Provide both keys, both non-empty |
+| `title must have both 'ja' and 'en' keys` | Stored form spec was not normalized | Send a plain string through `auto-register`, or provide both stored keys |
 | `fields must be a non-empty array` | `fields: []` or missing | Provide at least one field |
 | `fields must have at most 20 items` | More than 20 fields | Split or simplify the form |
 | `key '...' must match [a-z][a-z0-9_]*` | Uppercase or special chars in key | Use lowercase + underscore only |
 | `duplicate key '...'` | Two fields share a key | Each field's `key` must be unique |
 | `unsupported type '...'` | Unknown field type | Use one of the 9 types above |
-| `label must have both 'ja' and 'en'` | Single-language label | Bilingual labels are mandatory |
+| `label must have both 'ja' and 'en'` | Stored form spec was not normalized | Send a plain string through `auto-register`, or provide both stored keys |
 | `at least one field must be required` | All fields are optional | Mark at least one field as `required: true` |
 | `accept entries must be dot-prefixed extensions like '.pdf' (got '...')` | Missing leading dot | Prefix all extensions with `.` |
 | `max_size_mb cannot exceed 200` | File limit too high | Cap at 200 |

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -2967,12 +2967,19 @@ components:
 
     BilingualText:
       type: object
-      description: Bilingual ja/en text used by input_form_spec for titles, labels, descriptions, placeholders, and option labels.
+      description: Stored bilingual ja/en text for input_form_spec titles, labels, descriptions, placeholders, and option labels.
       required: [ja, en]
       additionalProperties: false
       properties:
         ja: { type: string, minLength: 1 }
         en: { type: string, minLength: 1 }
+
+    LocalizedText:
+      oneOf:
+        - type: string
+          minLength: 1
+        - $ref: '#/components/schemas/BilingualText'
+      description: Plain seller-authored strings are accepted during auto-register and normalized by the platform into stored ja/en text.
 
     InputFormSpecField:
       type: object
@@ -2994,9 +3001,9 @@ components:
         type:
           type: string
           enum: [text, textarea, number, select, multiselect, file, url, date, boolean]
-        label: { $ref: '#/components/schemas/BilingualText' }
-        description: { $ref: '#/components/schemas/BilingualText' }
-        placeholder: { $ref: '#/components/schemas/BilingualText' }
+        label: { $ref: '#/components/schemas/LocalizedText' }
+        description: { $ref: '#/components/schemas/LocalizedText' }
+        placeholder: { $ref: '#/components/schemas/LocalizedText' }
         required: { type: boolean, default: false }
         default:
           description: Optional default value. Type must match the field's input type.
@@ -3019,7 +3026,7 @@ components:
             additionalProperties: false
             properties:
               value: { type: string, minLength: 1 }
-              label: { $ref: '#/components/schemas/BilingualText' }
+              label: { $ref: '#/components/schemas/LocalizedText' }
         max_selections: { type: integer, minimum: 1, description: "multiselect only" }
         # file
         accept:
@@ -3046,8 +3053,9 @@ components:
     InputFormSpec:
       type: object
       description: |
-        Optional bilingual (ja/en) client-facing form spec. The agent or
-        buyer fills in this form to invoke the listing. Distinct from
+        Optional client-facing form spec. Sellers may send plain one-language
+        strings; auto-register normalizes them into stored ja/en text. The
+        agent or buyer fills in this form to invoke the listing. Distinct from
         `input_schema`, which the runtime uses to validate the actual
         tool-call parameters. Canonical machine-checkable schema:
         schemas/input-form-spec.schema.json. Authoring guide:
@@ -3059,8 +3067,8 @@ components:
           type: string
           enum: ["1.0"]
           description: Spec version. Currently only '1.0' is accepted.
-        title: { $ref: '#/components/schemas/BilingualText' }
-        description: { $ref: '#/components/schemas/BilingualText' }
+        title: { $ref: '#/components/schemas/LocalizedText' }
+        description: { $ref: '#/components/schemas/LocalizedText' }
         fields:
           type: array
           minItems: 1
@@ -3075,7 +3083,7 @@ components:
             additionalProperties: false
             properties:
               key: { type: string, pattern: "^[a-z][a-z0-9_]*$" }
-              title: { $ref: '#/components/schemas/BilingualText' }
+              title: { $ref: '#/components/schemas/LocalizedText' }
               field_keys:
                 type: array
                 items: { type: string, pattern: "^[a-z][a-z0-9_]*$" }

--- a/schemas/input-form-spec.schema.json
+++ b/schemas/input-form-spec.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/taihei-05/siglume-api-sdk/schemas/input-form-spec.schema.json",
   "title": "input_form_spec",
-  "description": "Schema for the optional input_form_spec object passed to /v1/market/capabilities/auto-register and reused at confirm time. Defines the bilingual (ja/en) client-facing form an agent or buyer fills in to invoke a listing. See docs/input-form-spec.md.",
+  "description": "Schema for the optional input_form_spec object passed to /v1/market/capabilities/auto-register and reused at confirm time. Seller-authored text may be a plain one-language string; the platform normalizes it into stored ja/en text. See docs/input-form-spec.md.",
   "type": "object",
   "required": ["version", "title", "fields"],
   "additionalProperties": false,
@@ -12,8 +12,8 @@
       "const": "1.0",
       "description": "Spec version. Currently the only accepted value is '1.0'."
     },
-    "title": { "$ref": "#/$defs/bilingualText" },
-    "description": { "$ref": "#/$defs/bilingualText" },
+    "title": { "$ref": "#/$defs/localizedText" },
+    "description": { "$ref": "#/$defs/localizedText" },
     "fields": {
       "type": "array",
       "minItems": 1,
@@ -30,7 +30,7 @@
         "additionalProperties": false,
         "properties": {
           "key": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
-          "title": { "$ref": "#/$defs/bilingualText" },
+          "title": { "$ref": "#/$defs/localizedText" },
           "field_keys": {
             "type": "array",
             "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
@@ -49,6 +49,13 @@
         "en": { "type": "string", "minLength": 1 }
       }
     },
+    "localizedText": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "$ref": "#/$defs/bilingualText" }
+      ],
+      "description": "Plain strings are accepted on auto-register and normalized by the platform into ja/en text."
+    },
     "fieldKey": {
       "type": "string",
       "pattern": "^[a-z][a-z0-9_]*$",
@@ -63,10 +70,10 @@
           "type": "string",
           "enum": ["text", "textarea", "number", "select", "multiselect", "file", "url", "date", "boolean"]
         },
-        "label": { "$ref": "#/$defs/bilingualText" },
-        "description": { "$ref": "#/$defs/bilingualText" },
+        "label": { "$ref": "#/$defs/localizedText" },
+        "description": { "$ref": "#/$defs/localizedText" },
         "placeholder": {
-          "$ref": "#/$defs/bilingualText",
+          "$ref": "#/$defs/localizedText",
           "description": "Required for text/textarea/url under multi-capability composition (18.6.2)."
         },
         "required": { "type": "boolean", "default": false },
@@ -147,7 +154,7 @@
       "additionalProperties": false,
       "properties": {
         "value": { "type": "string", "minLength": 1 },
-        "label": { "$ref": "#/$defs/bilingualText" }
+        "label": { "$ref": "#/$defs/localizedText" }
       }
     },
     "selectField": {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -139,6 +139,7 @@ export interface SiglumeClientOptions {
 type PendingConfirmation = {
   manifest: Record<string, unknown>;
   tool_manual: Record<string, unknown>;
+  input_form_spec: Record<string, unknown>;
 };
 
 type RequestMetaTuple = [Record<string, unknown>, EnvelopeMeta];
@@ -2100,9 +2101,13 @@ export class SiglumeClient implements SiglumeClientShape {
   ): Promise<AutoRegistrationReceipt> {
     const manifestPayload = coerceMapping(manifest, "manifest");
     const toolManualPayload = coerceMapping(tool_manual, "tool_manual");
+    const toolManualForRequest = { ...toolManualPayload };
+    const embeddedInputFormSpec = toolManualForRequest.input_form_spec;
+    delete toolManualForRequest.input_form_spec;
+    const inputFormSpec = options.input_form_spec ?? embeddedInputFormSpec;
     const payload: Record<string, unknown> = {
       manifest: { ...manifestPayload },
-      tool_manual: { ...toolManualPayload },
+      tool_manual: toolManualForRequest,
     };
     if (options.source_url) {
       payload.source_url = options.source_url;
@@ -2126,8 +2131,8 @@ export class SiglumeClient implements SiglumeClientShape {
     if (options.source_context) {
       payload.source_context = coerceMapping(options.source_context, "source_context");
     }
-    if (options.input_form_spec) {
-      payload.input_form_spec = coerceMapping(options.input_form_spec, "input_form_spec");
+    if (inputFormSpec !== undefined && inputFormSpec !== null) {
+      payload.input_form_spec = coerceMapping(inputFormSpec, "input_form_spec");
     }
     // Manifest fields forwarded to the top-level auto-register payload.
     // `version` is intentionally NOT forwarded — the platform auto-assigns
@@ -2189,7 +2194,11 @@ export class SiglumeClient implements SiglumeClientShape {
     if (!listing_id) {
       throw new SiglumeClientError("Siglume auto-register response did not include listing_id.");
     }
-    this.pendingConfirmations.set(listing_id, { manifest: manifestPayload, tool_manual: toolManualPayload });
+    this.pendingConfirmations.set(listing_id, {
+      manifest: manifestPayload,
+      tool_manual: toRecord(payload.tool_manual),
+      input_form_spec: toRecord(payload.input_form_spec),
+    });
     return {
       listing_id,
       status: String(data.status ?? "draft"),

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -262,6 +262,56 @@ describe("SiglumeClient", () => {
     expect(receipt.listing_id).toBe("lst_seq");
   });
 
+  it("hoists input_form_spec from tool_manual before auto_register", async () => {
+    const inputFormSpec = {
+      version: "1.0",
+      title: "Wallet lookup",
+      fields: [
+        {
+          key: "wallet_address",
+          type: "text",
+          label: "Wallet address",
+          required: true,
+        },
+      ],
+    };
+    const toolManual = {
+      ...buildToolManual(),
+      input_form_spec: inputFormSpec,
+    };
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/capabilities/auto-register") {
+          const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+          expect(body.input_form_spec).toEqual(inputFormSpec);
+          expect((body.tool_manual as Record<string, unknown>).input_form_spec).toBeUndefined();
+          return new Response(
+            JSON.stringify(
+              envelope({
+                listing_id: "lst_form",
+                status: "draft",
+                auto_manifest: {},
+                confidence: {},
+              }),
+            ),
+            { status: 201 },
+          );
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    const receipt = await client.auto_register(buildManifest(), toolManual, {
+      source_url: "https://github.com/example/wallet",
+      runtime_validation: buildRuntimeValidation(),
+    });
+
+    expect(receipt.listing_id).toBe("lst_form");
+  });
+
   it("rejects non-object oauth_credentials sequence entries before sending the request", async () => {
     const client = new SiglumeClient({
       api_key: "sig_test_key",

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -1365,9 +1365,16 @@ def _build_auto_register_request(
     source_context: Mapping[str, Any] | None,
     input_form_spec: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
+    tool_manual_for_request = dict(tool_manual_payload)
+    embedded_input_form_spec = tool_manual_for_request.pop("input_form_spec", None)
+    input_form_spec_for_request = (
+        input_form_spec
+        if input_form_spec is not None
+        else embedded_input_form_spec
+    )
     payload: dict[str, Any] = {
         "manifest": dict(manifest_payload),
-        "tool_manual": dict(tool_manual_payload),
+        "tool_manual": tool_manual_for_request,
     }
     if source_url:
         payload["source_url"] = source_url
@@ -1391,8 +1398,8 @@ def _build_auto_register_request(
             raise TypeError("oauth_credentials must be a mapping or a sequence of mappings")
     if source_context is not None:
         payload["source_context"] = _coerce_mapping(source_context, "source_context")
-    if input_form_spec is not None:
-        payload["input_form_spec"] = _coerce_mapping(input_form_spec, "input_form_spec")
+    if input_form_spec_for_request is not None:
+        payload["input_form_spec"] = _coerce_mapping(input_form_spec_for_request, "input_form_spec")
 
     # Manifest fields forwarded to the top-level auto-register payload.
     # ``version`` is intentionally NOT forwarded — the platform auto-assigns
@@ -2914,8 +2921,8 @@ class SiglumeClient:
             raise SiglumeClientError("Siglume auto-register response did not include listing_id.")
         self._pending_confirmations[listing_id] = {
             "manifest": manifest_payload,
-            "tool_manual": tool_manual_payload,
-            "input_form_spec": input_form_spec_payload or {},
+            "tool_manual": _to_dict(payload.get("tool_manual")),
+            "input_form_spec": _to_dict(payload.get("input_form_spec")),
         }
         return AutoRegistrationReceipt(
             listing_id=listing_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -331,6 +331,51 @@ def test_auto_register_accepts_oauth_credentials_sequence() -> None:
     assert receipt.listing_id == "lst_seq"
 
 
+def test_auto_register_hoists_input_form_spec_from_tool_manual() -> None:
+    manifest = build_manifest()
+    tool_manual = build_tool_manual().to_dict()
+    input_form_spec = {
+        "version": "1.0",
+        "title": "Wallet lookup",
+        "fields": [
+            {
+                "key": "wallet_address",
+                "type": "text",
+                "label": "Wallet address",
+                "required": True,
+            }
+        ],
+    }
+    tool_manual["input_form_spec"] = input_form_spec
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/market/capabilities/auto-register"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["input_form_spec"] == input_form_spec
+        assert "input_form_spec" not in payload["tool_manual"]
+        return httpx.Response(
+            201,
+            json=envelope(
+                {
+                    "listing_id": "lst_form",
+                    "status": "draft",
+                    "auto_manifest": {"capability_key": manifest.capability_key},
+                    "confidence": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        receipt = client.auto_register(
+            manifest,
+            tool_manual,
+            source_url="https://github.com/example/wallet",
+            runtime_validation=build_runtime_validation(),
+        )
+
+    assert receipt.listing_id == "lst_form"
+
+
 def test_cursor_pages_follow_next_cursor_for_listings_and_usage() -> None:
     call_counter = {"listings": 0, "usage": 0}
 


### PR DESCRIPTION
## Summary

- Allow `input_form_spec` authoring text to be plain one-language strings in the public schema, docs, and OpenAPI contract.
- Hoist `input_form_spec` out of embedded `tool_manual` payloads in both Python and TypeScript clients before `auto_register`, so CLI-authored projects do not send form UI copy as part of the Tool Manual runtime contract.
- Add Python and TypeScript regression coverage for the hoist behavior.

## Why

Translation/localization is a Siglume platform responsibility during `auto-register`. SDK users should not be blocked for providing seller-authored English-only form copy, and `tool_manual.json` should not retain `input_form_spec` as runtime Tool Manual content.

## Validation

- `py -3.11 -m py_compile siglume_api_sdk/client.py tests/test_client.py`
- `py -3.11 -m pytest tests/test_client.py tests/test_docs_contract.py -q` -> 59 passed
- `py -3.11 -m json.tool schemas/input-form-spec.schema.json > $null`
- `npx vitest run --run test/client.test.ts` -> 48 passed
- `npm run typecheck`
- `npm run build`