### PR TITLE
[codex] Harden auto-register SDK contracts

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -18,7 +18,7 @@ Before a listing can publish, make sure you have all of these artifacts:
 | `docs_url` | Yes | Dedicated API usage guide. Root homepages are rejected; the page must be anonymous HTTP 200 and explain how to use this API. |
 | `support_contact` | Yes | Real support email address or public support URL. |
 | `seller_homepage_url` | No | Official seller/company URL. Helpful for buyers, but not a publish blocker. |
-| `oauth_credentials.json` | Only OAuth-backed APIs | Seller-owned OAuth app Client ID / Client Secret. This is separate from the buyer's connected account. |
+| `oauth_credentials.json` | Only platform-managed OAuth APIs | Seller-owned OAuth app Client ID / Client Secret. This is separate from the buyer's connected account. |
 | Verified payout destination | Only paid APIs | Free APIs do not need wallet/payout setup before publish. |
 
 After the no-key local loop and deployment, use the production validation,
@@ -503,10 +503,12 @@ the registration blockers earlier.
   - `output_schema` must declare and match the live response fields
   - `requires_connected_accounts` must match the listing / Tool Manual contract
 - Seller OAuth app credentials during `auto-register`
-  - if `required_connected_accounts` includes a seller-side OAuth provider
-    such as X, Slack, Google, GitHub, Linear, or Notion, include that
+  - if `required_connected_accounts` declares a platform-managed OAuth provider
+    such as `{"provider_key": "slack", "platform_managed": true}`, include that
     provider in the local, Git-ignored `oauth_credentials.json`
-  - if an upgrade adds a new seller-side OAuth provider and the seed is
+  - simple provider strings such as `"slack"` are API-managed requirements and
+    do not require `oauth_credentials.json`
+  - if an upgrade adds a new platform-managed OAuth provider and the seed is
     missing, registration is rejected
 - Tool Manual quality grade **B** or above
   - `input_schema` and `output_schema` are part of the canonical contract
@@ -593,10 +595,12 @@ Setting `AUTO` on an `ACTION` or `PAYMENT` API will fail manifest validation.
 
 If your API needs OAuth tokens or API keys from the agent owner (e.g., X/Twitter credentials, a third-party provider API key), declare them in `required_connected_accounts`. The owner will be prompted to connect these accounts during installation.
 
-If the API itself also needs a seller-owned OAuth app configuration to broker
-that provider flow, include the seller app credentials in
-the local, Git-ignored `oauth_credentials.json` during registration. Do not
-wait to create that configuration in the portal after publish.
+If Siglume should broker that provider flow with a seller-owned OAuth app,
+declare the requirement with `platform_managed: true` and include the seller
+app credentials in the local, Git-ignored `oauth_credentials.json` during
+registration. Plain strings such as `"slack"` mean your API manages that auth
+path itself and do not require `oauth_credentials.json`. Do not wait to create
+platform-managed OAuth configuration in the portal after publish.
 
 Responsibility split:
 
@@ -630,11 +634,11 @@ Submit again with the same `capability_key`.
 
 - If the listing is live, `siglume register` stages an upgrade instead of creating a new product.
 - `siglume register . --confirm` publishes the next release immediately after you approve the staged result and the self-serve checks pass again.
-- If the upgrade adds a new seller-side OAuth provider, update the local, Git-ignored `oauth_credentials.json` before registering or the upgrade is rejected.
+- If the upgrade adds a new platform-managed seller-side OAuth provider, update the local, Git-ignored `oauth_credentials.json` before registering or the upgrade is rejected.
 
 ### How do I manage external API credentials?
 
-Declare the account type in `required_connected_accounts`. The agent owner connects their account during API installation. If the API also needs a seller-owned OAuth app, provide that app's Client ID / Client Secret in the local, Git-ignored `oauth_credentials.json` during registration or upgrade. **Never hardcode secrets in your API code.**
+Declare the account type in `required_connected_accounts`. The agent owner connects their account during API installation. If Siglume should broker that connection with your seller-owned OAuth app, use `{"provider_key": "...", "platform_managed": true}` and provide that app's Client ID / Client Secret in the local, Git-ignored `oauth_credentials.json` during registration or upgrade. **Never hardcode secrets in your API code.**
 
 ### What's the difference between free and paid APIs?
 
@@ -657,7 +661,7 @@ Common causes:
 - `docs_url` points to a homepage instead of a dedicated anonymous API usage guide
 - `support_contact` is a placeholder or malformed email / support URL
 - `runtime_validation.json` still has placeholder URLs, missing expected fields, or a review key that is not dedicated to Siglume
-- OAuth-backed APIs are missing seller app credentials in local `oauth_credentials.json`
+- Platform-managed OAuth APIs are missing seller app credentials in local `oauth_credentials.json`
 - `ACTION` / `PAYMENT` API has `approval_mode=AUTO`
 - `ACTION` / `PAYMENT` API has `dry_run_supported=False`
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This is the main use case. You build an API, register it, and earn revenue.
 If the listing already exists and is live, re-run the same `capability_key` to
 stage an upgrade. Review the staged upgrade, then `siglume register . --confirm`
 publishes the next release immediately when the same self-serve checks pass. If the upgrade adds a new
-seller-side OAuth provider, the local Git-ignored `oauth_credentials.json` must
+platform-managed seller-side OAuth provider, the local Git-ignored `oauth_credentials.json` must
 already include that provider or the upgrade is rejected.
 
 **You do not submit a PR to this repo.** You register directly on the platform.
@@ -188,11 +188,12 @@ No permission needed. No issue to claim. Just build and register.
 - Draft creation now requires runtime validation inputs for a live public API:
   public base URL, healthcheck URL, functional test URL, a dedicated review/test
   key, a sample request payload, and expected response fields.
-- OAuth-backed APIs now require seller-owned OAuth app credentials during
+- Platform-managed OAuth APIs require seller-owned OAuth app credentials during
   registration and upgrade:
-  - declare the provider in `required_connected_accounts`
+  - declare the provider in `required_connected_accounts` with `platform_managed: true`
   - include the seller app credentials in the local Git-ignored `oauth_credentials.json`
-  - if a new provider appears in an upgrade and the seed is missing, registration is blocked
+  - if a new platform-managed provider appears in an upgrade and the seed is missing, registration is blocked
+  - simple provider strings such as `"slack"` are treated as API-managed requirements and do not require `oauth_credentials.json`
 - Siglume blocks draft creation if the public API cannot be reached or the
   functional test does not match the declared response shape.
 - Siglume also blocks draft creation when the Tool Manual contract is incomplete

--- a/docs/connected-accounts.md
+++ b/docs/connected-accounts.md
@@ -3,10 +3,11 @@
 Siglume APIs can depend on user-linked external accounts such as
 Slack, X/Twitter, Google, GitHub, Linear, or Notion.
 
-The SDK exposes two distinct concerns:
+The SDK exposes three distinct concerns:
 
-1. Seller-side OAuth setup on the listing
-2. Buyer-side OAuth authorization for that listing
+1. API-managed connected-account requirements
+2. Platform-managed seller-side OAuth setup on the listing
+3. Buyer-side OAuth authorization for that listing
 
 Your API runtime never receives raw long-lived credentials.
 
@@ -89,10 +90,21 @@ client.revoke_connected_account("ca_123")
 
 ## What To Declare In Your App
 
-List required providers in `required_connected_accounts`:
+If your API manages the provider-specific auth path itself, list required
+providers as plain strings:
 
 ```python
 required_connected_accounts=["slack", "github"]
+```
+
+If Siglume should run the OAuth flow with the seller-owned OAuth app, mark the
+provider as platform-managed and include `oauth_credentials.json` during
+registration:
+
+```python
+required_connected_accounts=[
+    {"provider_key": "slack", "platform_managed": True, "required_scopes": ["chat:write"]}
+]
 ```
 
 ## What Your Runtime Receives

--- a/docs/input-form-spec.md
+++ b/docs/input-form-spec.md
@@ -46,7 +46,7 @@ The machine-checkable schema lives at
 | `version` | yes | string | Must be exactly `"1.0"` |
 | `title` | yes | localized text | Plain string accepted; platform stores `ja` / `en` |
 | `description` | no | localized text | Plain string accepted; platform stores `ja` / `en` |
-| `fields` | yes | array | 1–20 items; **at least one** must have `required: true` |
+| `fields` | yes | array | 1–20 items. Single-API `auto-register` accepts all-optional forms; multi-capability / Works composition requires at least one `required: true` field. |
 | `sections` | no | array | Optional grouping of fields into ordered titled sections (multi-capability composition only) |
 
 A *localized text* value may be either a plain string or a bilingual object
@@ -67,7 +67,7 @@ All fields share these base properties:
 | `label` | yes | Localized text |
 | `description` | no | Localized text |
 | `placeholder` | no (per type) | Localized text. Required for `text` / `textarea` / `url` under multi-capability composition |
-| `required` | no | Boolean. At least one field in the form must be `true`. |
+| `required` | no | Boolean. Single-API `auto-register` may use all-optional filters; multi-capability / Works composition requires at least one required field. |
 | `default` | no | Optional default value. Type must match the field's input type. |
 | `tool_bindings` | no | Multi-capability composition only. See [Multi-capability composition](#multi-capability-composition). |
 
@@ -181,7 +181,10 @@ option `value`s; length capped by `max_selections` if set.
 
 ### `file`
 
-File upload.
+File upload. This field type is for AI Works / client-upload flows. API Store
+single-listing `auto-register` currently rejects `file` fields until the
+uploaded-files transport is exposed for API listings; use a `text` / `url`
+field carrying a file reference or URL for now.
 
 ```json
 {
@@ -278,7 +281,8 @@ field cannot bind to a `string` schema property.
 | `duplicate key '...'` | Two fields share a key | Each field's `key` must be unique |
 | `unsupported type '...'` | Unknown field type | Use one of the 9 types above |
 | `label must have both 'ja' and 'en'` | Stored form spec was not normalized | Send a plain string through `auto-register`, or provide both stored keys |
-| `at least one field must be required` | All fields are optional | Mark at least one field as `required: true` |
+| `at least one field must be required` | All fields are optional in a multi-capability / Works composition form | Mark at least one field as `required: true`, or use single-API `auto-register` where optional-only filter forms are allowed |
+| `uploaded_files transport` | `file` field used in API Store `auto-register` | Use a `text` / `url` field for a file reference until API listings expose uploaded-files transport |
 | `accept entries must be dot-prefixed extensions like '.pdf' (got '...')` | Missing leading dot | Prefix all extensions with `.` |
 | `max_size_mb cannot exceed 200` | File limit too high | Cap at 200 |
 | `<type> must have at least 1 option` | Empty `options` on a `select` / `multiselect` | Provide at least 1 option |

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -144,9 +144,11 @@ preflight errors before calling `auto-register`.
   - sample request payload in `request_payload`
   - expected response fields
 - For OAuth-backed APIs that use seller-owned OAuth apps:
-  - declare the provider in `required_connected_accounts`
+  - declare the provider in `required_connected_accounts` with `platform_managed: true`
   - include the seller OAuth app credentials in the local Git-ignored `oauth_credentials.json`
   - upgrades that add a new provider are blocked until the new seed is included
+- Plain provider strings such as `"slack"` mean the API manages that auth path
+  itself; the CLI does not require `oauth_credentials.json` for those entries.
 - Listing metadata such as:
   - `name`
   - `job_to_be_done`

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -282,18 +282,22 @@ paths:
                   description: Whether the API supports dry-run execution
                 required_connected_accounts:
                   type: array
-                  description: Manifest/listing connected-account provider keys. Must match ToolManual.requires_connected_accounts.
+                  description: Manifest/listing connected-account requirements. Plain strings are API-managed; objects with platform_managed=true require seller OAuth credentials and must match ToolManual.requires_connected_accounts.
                   items:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: object
                 oauth_credentials:
                   type: object
                   description: |
                     Optional seller-owned OAuth app credentials. Required when
-                    the API uses seller-side OAuth providers declared in
-                    `required_connected_accounts`. Include these during the
-                    initial registration and during upgrades that add a new
-                    provider. The portal OAuth panel is for rotation / repair
-                    after registration, not the initial setup step.
+                    `required_connected_accounts` declares platform-managed
+                    OAuth provider objects. Plain provider strings are
+                    API-managed and do not require this seed. Include these
+                    during the initial registration and during upgrades that add
+                    a new platform-managed provider. The portal OAuth panel is
+                    for rotation / repair after registration, not the initial
+                    setup step.
                   properties:
                     items:
                       type: array
@@ -1707,7 +1711,12 @@ components:
         permission_class: { type: string, enum: [read-only, action, payment, recommendation], description: "Supported tiers: read-only / action / payment. `recommendation` is a deprecated alias of read-only kept for backward compatibility; do not use in new manifests." }
         approval_mode: { type: string, enum: [auto, budget-bounded, always-ask, deny] }
         dry_run_supported: { type: boolean, default: false }
-        required_connected_accounts: { type: array, items: { type: string } }
+        required_connected_accounts:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: object
         permission_scopes: { type: array, items: { type: string } }
         price_model:
           type: string
@@ -1804,7 +1813,12 @@ components:
         seller_display_name: { type: string, nullable: true }
         seller_homepage_url: { type: string, nullable: true }
         seller_social_url: { type: string, nullable: true }
-        required_connected_accounts: { type: array, items: { type: string } }
+        required_connected_accounts:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: object
         permission_scopes: { type: array, items: { type: string } }
         compatibility_tags: { type: array, items: { type: string } }
         latency_tier: { type: string }

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -71,7 +71,29 @@
     "required_connected_accounts": {
       "type": "array",
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "provider_key": {
+                "type": "string"
+              },
+              "platform_managed": {
+                "type": "boolean"
+              },
+              "required_scopes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
       }
     },
     "permission_scopes": {

--- a/schemas/input-form-spec.schema.json
+++ b/schemas/input-form-spec.schema.json
@@ -18,7 +18,7 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 20,
-      "description": "Form fields. At least one field must have required=true (validator-enforced; not expressible at the schema level).",
+      "description": "Form fields. Single-API auto-register accepts all-optional forms; multi-capability / Works composition requires at least one required=true field (validator-enforced; not expressible at the schema level).",
       "items": { "$ref": "#/$defs/field" }
     },
     "sections": {

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -310,7 +310,26 @@ const OAUTH_PROVIDER_ALIASES: Record<string, string> = {
   notion: "notion",
 };
 
+function isPlatformManagedRequirement(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.platform_managed === true) return true;
+  const owner = String(
+    value.managed_by ?? value.auth_managed_by ?? value.connection_owner ?? "",
+  )
+    .trim()
+    .toLowerCase()
+    .replaceAll("_", "-");
+  return owner === "platform" || owner === "siglume" || owner === "siglume-platform";
+}
+
 function oauthProviderKeyFromRequirement(value: unknown): string | null {
+  if (isRecord(value)) {
+    for (const key of ["provider_key", "provider", "account_type", "name"]) {
+      const providerKey = oauthProviderKeyFromRequirement(value[key]);
+      if (providerKey) return providerKey;
+    }
+    return null;
+  }
   const raw = String(value ?? "").trim().toLowerCase().replaceAll("_", "-");
   if (!raw) return null;
   if (OAUTH_PROVIDER_ALIASES[raw]) {
@@ -328,12 +347,24 @@ function oauthProviderKeyFromRequirement(value: unknown): string | null {
 function requiredOauthProviders(requirements: unknown[] | undefined): string[] {
   const providers: string[] = [];
   for (const item of requirements ?? []) {
+    if (!isPlatformManagedRequirement(item)) continue;
     const providerKey = oauthProviderKeyFromRequirement(item);
     if (providerKey && !providers.includes(providerKey)) {
       providers.push(providerKey);
     }
   }
   return providers;
+}
+
+function connectedAccountRequirementLabel(value: unknown): string {
+  if (isRecord(value)) {
+    for (const key of ["provider_key", "provider", "account_type", "name"]) {
+      const label = String(value[key] ?? "").trim();
+      if (label) return label;
+    }
+    return "";
+  }
+  return String(value ?? "").trim();
 }
 
 function oauthProviderRecordsMap(payload: Record<string, unknown> | unknown[] | undefined): Record<string, Record<string, unknown>> {
@@ -403,7 +434,7 @@ function ensureRequiredOauthCredentials(project: LoadedProject): void {
   }
   const path = project.oauth_credentials_path ?? join(project.root_dir, "oauth_credentials.json");
   throw new SiglumeProjectError(
-    `${path} is required for OAuth-backed APIs. Missing provider seeds: ${missing.join(", ")}`,
+    `${path} is required for platform-managed OAuth APIs. Missing provider seeds: ${missing.join(", ")}`,
   );
 }
 
@@ -609,7 +640,7 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
     errors.push(`remote Tool Manual quality is not publishable: ${remoteQuality.grade} (${remoteQuality.overall_score}/100)`);
   }
   if (missingOauthProviders.length > 0) {
-    errors.push(`oauth_credentials.json is required for OAuth-backed APIs: ${missingOauthProviders.join(", ")}`);
+    errors.push(`oauth_credentials.json is required for platform-managed OAuth APIs: ${missingOauthProviders.join(", ")}`);
   }
   const preflight = {
     manifest_issues: manifestIssues,
@@ -639,6 +670,7 @@ export async function runRegistration(
   ensureManifestPublisherIdentity(project);
   ensureRuntimeValidationReady(project);
   ensureRequiredOauthCredentials(project);
+  const canonicalOauthCredentials = canonicalOauthCredentialsPayload(project.oauth_credentials);
   const client = await createClient(deps);
   const preflight = await registrationPreflight(project, client);
   let developerPortalPreflight: unknown = null;
@@ -654,7 +686,7 @@ export async function runRegistration(
   }
   const receipt = await client.auto_register(project.manifest, project.tool_manual, {
     runtime_validation: project.runtime_validation,
-    oauth_credentials: canonicalOauthCredentialsPayload(project.oauth_credentials),
+    oauth_credentials: canonicalOauthCredentials,
   });
   const result: Record<string, unknown> = {
     receipt: toJsonable(receipt),
@@ -1298,7 +1330,11 @@ function apiUsageDocsTemplate(manifest: AppManifest): string {
   const jobToBeDone = String(manifest.job_to_be_done ?? "Describe what this API lets an agent do.");
   const permissionClass = String(manifest.permission_class ?? "read-only");
   const priceModel = String(manifest.price_model ?? "free");
-  const requiredAccounts = (manifest.required_connected_accounts ?? []).join(", ") || "none";
+  const requiredAccounts =
+    (manifest.required_connected_accounts ?? [])
+      .map((item) => connectedAccountRequirementLabel(item))
+      .filter(Boolean)
+      .join(", ") || "none";
   const supportContact = String(manifest.support_contact ?? "replace-with-support-contact");
   return [
     `# ${name} API Usage Guide`,

--- a/siglume-api-sdk-ts/src/tool-manual-validator.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-validator.ts
@@ -41,16 +41,24 @@ function checkSchemaForbiddenRecursive(
   path = "",
 ): void {
   for (const keyword of COMPOSITION_KEYWORDS) {
-    if (keyword in schema) {
-      const location = path ? `${rootField}.${path}.${keyword}` : `${rootField}.${keyword}`;
-      pushIssue(
-        issue(
-          "INPUT_SCHEMA",
-          `Composition keyword '${keyword}' is not allowed in beta${path ? ` at ${path}` : ""}`,
-          location,
-        ),
-      );
+    if (!(keyword in schema)) {
+      continue;
     }
+    const branches = schema[keyword];
+    const location = path ? `${rootField}.${path}.${keyword}` : `${rootField}.${keyword}`;
+    if (!Array.isArray(branches) || branches.length === 0) {
+      pushIssue(issue("INPUT_SCHEMA", `${keyword} must be a non-empty array`, location));
+      continue;
+    }
+    branches.forEach((branch, index) => {
+      const branchPath = path ? `${path}.${keyword}[${index}]` : `${keyword}[${index}]`;
+      const branchLocation = `${rootField}.${branchPath}`;
+      if (!isRecord(branch)) {
+        pushIssue(issue("INPUT_SCHEMA", `${keyword}[${index}] must be an object`, branchLocation));
+        return;
+      }
+      checkSchemaForbiddenRecursive(branch, rootField, pushIssue, branchPath);
+    });
   }
 
   for (const forbidden of INPUT_SCHEMA_FORBIDDEN_KEYS) {

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -87,7 +87,7 @@ export interface AppManifest {
   permission_class: PermissionClass;
   approval_mode?: ApprovalMode;
   dry_run_supported?: boolean;
-  required_connected_accounts?: string[];
+  required_connected_accounts?: unknown[];
   permission_scopes?: string[];
   price_model?: PriceModel;
   price_value_minor?: number;

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -328,11 +328,40 @@ describe("cli project helpers", () => {
     expect(autoRegisterCalled).toBe(false);
   });
 
-  it("blocks registration when an OAuth-backed API does not provide oauth_credentials.json", async () => {
+  it("allows API-managed connected accounts without oauth_credentials.json", async () => {
     const projectDir = await createObjectProject({
       manifest: {
         ...manifestBase(),
         required_connected_accounts: ["twitter"],
+      },
+    });
+
+    const report = await runRegistration(
+      projectDir,
+      {},
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async preview_quality_score() {
+              return publishableQualityReport();
+            },
+            async auto_register(_manifest: unknown, _toolManual: unknown, options?: { oauth_credentials?: unknown }) {
+              expect(options?.oauth_credentials).toBeUndefined();
+              return { listing_id: "lst_api_managed", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    expect((report.receipt as { listing_id: string }).listing_id).toBe("lst_api_managed");
+  });
+
+  it("blocks registration when a platform-managed OAuth API does not provide oauth_credentials.json", async () => {
+    const projectDir = await createObjectProject({
+      manifest: {
+        ...manifestBase(),
+        required_connected_accounts: [{ provider_key: "twitter", platform_managed: true }],
       },
     });
     let autoRegisterCalled = false;
@@ -355,7 +384,7 @@ describe("cli project helpers", () => {
             }) as unknown as SiglumeClientShape,
         },
       ),
-    ).rejects.toThrow("oauth_credentials.json is required for OAuth-backed APIs");
+    ).rejects.toThrow("oauth_credentials.json is required for platform-managed OAuth APIs");
     expect(autoRegisterCalled).toBe(false);
   });
 
@@ -363,7 +392,7 @@ describe("cli project helpers", () => {
     const projectDir = await createObjectProject({
       manifest: {
         ...manifestBase(),
-        required_connected_accounts: ["google-drive"],
+        required_connected_accounts: [{ provider_key: "google-drive", platform_managed: true }],
       },
       oauthCredentials: [
         {

--- a/siglume-api-sdk-ts/test/validator.test.ts
+++ b/siglume-api-sdk-ts/test/validator.test.ts
@@ -16,15 +16,19 @@ describe("validate_tool_manual", () => {
     expect(issues.some((issue) => issue.code === "INVALID_PERMISSION_CLASS")).toBe(true);
   });
 
-  it("rejects nested composition keywords and patternProperties", () => {
+  it("allows composition keywords but rejects nested patternProperties", () => {
     const manual = cloneBase();
     manual.input_schema = {
       type: "object",
       properties: {
         query: {
-          type: "object",
-          oneOf: [{ type: "string" }, { type: "number" }],
-          patternProperties: { "^x-": { type: "string" } },
+          oneOf: [
+            { type: "string" },
+            {
+              type: "object",
+              patternProperties: { "^x-": { type: "string" } },
+            },
+          ],
         },
       },
       required: ["query"],
@@ -34,8 +38,8 @@ describe("validate_tool_manual", () => {
     const [ok, issues] = validate_tool_manual(manual);
 
     expect(ok).toBe(false);
-    expect(issues.some((issue) => issue.field === "input_schema.query.oneOf")).toBe(true);
-    expect(issues.some((issue) => issue.field === "input_schema.query.patternProperties")).toBe(true);
+    expect(issues.some((issue) => issue.field === "input_schema.query.oneOf")).toBe(false);
+    expect(issues.some((issue) => issue.field === "input_schema.query.oneOf[1].patternProperties")).toBe(true);
   });
 
   it("warns about platform-injected input fields", () => {

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -27,7 +27,7 @@ export interface AppManifest {
   permission_class: PermissionClass;
   approval_mode: ApprovalMode;
   dry_run_supported: boolean;
-  required_connected_accounts: string[];
+  required_connected_accounts: unknown[];
   permission_scopes: string[];
   price_model: PriceModel;
   price_value_minor: number;

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -108,7 +108,7 @@ class AppManifest:
     permission_class: PermissionClass = PermissionClass.READ_ONLY
     approval_mode: ApprovalMode = ApprovalMode.AUTO
     dry_run_supported: bool = False
-    required_connected_accounts: list[str] = field(default_factory=list)  # e.g. ["amazon", "stripe"]
+    required_connected_accounts: list[Any] = field(default_factory=list)  # e.g. ["amazon"] or {"provider_key": "slack", "platform_managed": True}
     permission_scopes: list[str] = field(default_factory=list)
     price_model: PriceModel = PriceModel.FREE
     price_value_minor: int = 0             # in minor currency units (e.g. cents/yen)
@@ -395,7 +395,7 @@ class ToolManual:
     do_not_use_when: list[str]                          # 1-5 items
     permission_class: ToolManualPermissionClass = ToolManualPermissionClass.READ_ONLY
     dry_run_supported: bool = False
-    requires_connected_accounts: list[str] = field(default_factory=list)
+    requires_connected_accounts: list[Any] = field(default_factory=list)
     input_schema: dict[str, Any] = field(default_factory=dict)   # JSON Schema (type=object)
     output_schema: dict[str, Any] = field(default_factory=dict)  # must include "summary"
     usage_hints: list[str] = field(default_factory=list)
@@ -524,8 +524,9 @@ def _check_schema_forbidden_recursive(
     *,
     path: str = "",
 ) -> None:
-    """Recurse into a JSON Schema rejecting composition keywords and
-    forbidden keys (patternProperties) at any nesting level.
+    """Recurse into a JSON Schema rejecting forbidden keys
+    (patternProperties) at any nesting level while validating composition
+    branch structure.
 
     Server parity: matches `_check_composition_keywords` and
     `_check_forbidden_key` in
@@ -535,11 +536,20 @@ def _check_schema_forbidden_recursive(
         return
 
     for kw in _COMPOSITION_KEYWORDS:
-        if kw in schema:
+        if kw not in schema:
+            continue
+        branches = schema.get(kw)
+        if not isinstance(branches, list) or not branches:
             loc = f"{root_field}.{path}.{kw}" if path else f"{root_field}.{kw}"
-            err_fn("INPUT_SCHEMA",
-                   f"Composition keyword '{kw}' is not allowed in beta{' at ' + path if path else ''}",
-                   loc)
+            err_fn("INPUT_SCHEMA", f"{kw} must be a non-empty array", loc)
+            continue
+        for index, branch in enumerate(branches):
+            branch_path = f"{path}.{kw}[{index}]" if path else f"{kw}[{index}]"
+            loc = f"{root_field}.{branch_path}"
+            if not isinstance(branch, dict):
+                err_fn("INPUT_SCHEMA", f"{kw}[{index}] must be an object", loc)
+                continue
+            _check_schema_forbidden_recursive(branch, root_field, err_fn, path=branch_path)
 
     for forbidden in _INPUT_SCHEMA_FORBIDDEN_KEYS:
         if forbidden in schema:

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -306,7 +306,27 @@ _OAUTH_PROVIDER_ALIASES = {
 }
 
 
+def _is_platform_managed_requirement(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("platform_managed") is True:
+        return True
+    owner = str(
+        value.get("managed_by")
+        or value.get("auth_managed_by")
+        or value.get("connection_owner")
+        or ""
+    ).strip().lower().replace("_", "-")
+    return owner in {"platform", "siglume", "siglume-platform"}
+
+
 def _oauth_provider_key_from_requirement(value: Any) -> str | None:
+    if isinstance(value, dict):
+        for key in ("provider_key", "provider", "account_type", "name"):
+            provider_key = _oauth_provider_key_from_requirement(value.get(key))
+            if provider_key:
+                return provider_key
+        return None
     raw = str(value or "").strip().lower().replace("_", "-")
     if not raw:
         return None
@@ -322,10 +342,22 @@ def _oauth_provider_key_from_requirement(value: Any) -> str | None:
 def _required_oauth_providers(requirements: list[Any] | tuple[Any, ...] | None) -> list[str]:
     providers: list[str] = []
     for item in requirements or []:
+        if not _is_platform_managed_requirement(item):
+            continue
         provider_key = _oauth_provider_key_from_requirement(item)
         if provider_key and provider_key not in providers:
             providers.append(provider_key)
     return providers
+
+
+def _connected_account_requirement_label(value: Any) -> str:
+    if isinstance(value, dict):
+        for key in ("provider_key", "provider", "account_type", "name"):
+            label = str(value.get(key) or "").strip()
+            if label:
+                return label
+        return ""
+    return str(value or "").strip()
 
 
 def _oauth_provider_records_map(payload: dict[str, Any] | list[Any] | None) -> dict[str, dict[str, Any]]:
@@ -390,7 +422,7 @@ def _ensure_required_oauth_credentials(project: LoadedProject) -> None:
         return
     path = project.oauth_credentials_path or (project.root_dir / "oauth_credentials.json")
     raise click.ClickException(
-        f"{path} is required for OAuth-backed APIs. Missing provider seeds: {', '.join(missing)}"
+        f"{path} is required for platform-managed OAuth APIs. Missing provider seeds: {', '.join(missing)}"
     )
 
 
@@ -995,7 +1027,17 @@ def _api_usage_docs_template(manifest: AppManifest) -> str:
     job_to_be_done = str(payload.get("job_to_be_done") or "Describe what this API lets an agent do.")
     permission_class = str(payload.get("permission_class") or "read-only")
     price_model = str(payload.get("price_model") or "free")
-    required_accounts = ", ".join(str(item) for item in (payload.get("required_connected_accounts") or [])) or "none"
+    required_accounts = (
+        ", ".join(
+            label
+            for label in (
+                _connected_account_requirement_label(item)
+                for item in (payload.get("required_connected_accounts") or [])
+            )
+            if label
+        )
+        or "none"
+    )
     support_contact = str(payload.get("support_contact") or "replace-with-support-contact")
     return textwrap.dedent(
         f"""
@@ -1453,7 +1495,7 @@ def _registration_preflight(project: LoadedProject, client: SiglumeClient) -> di
         errors.append(f"remote Tool Manual quality is not publishable: {grade} ({score}/100)")
     if missing_oauth_providers:
         errors.append(
-            "oauth_credentials.json is required for OAuth-backed APIs: "
+            "oauth_credentials.json is required for platform-managed OAuth APIs: "
             + ", ".join(missing_oauth_providers)
         )
     preflight = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def _write_register_project(
     *,
     include_tool_manual: bool = True,
     runtime_validation: dict | None = None,
-    required_connected_accounts: list[str] | None = None,
+    required_connected_accounts: list | None = None,
     oauth_credentials: dict | list | None = None,
     docs_url: str = "https://docs.siglume.test/register-project",
     support_contact: str = "https://support.siglume.test/register-project",
@@ -278,12 +278,56 @@ def test_register_blocks_non_publishable_remote_quality(monkeypatch, tmp_path) -
     assert FakeClient.auto_register_called is False
 
 
-def test_register_requires_oauth_seed_for_oauth_backed_api(monkeypatch, tmp_path) -> None:
+def test_register_allows_api_managed_connected_account_without_oauth_seed(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "api-managed-oauth"
+    _write_register_project(
+        project_dir,
+        required_connected_accounts=["twitter"],
+    )
+
+    class FakeClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def preview_quality_score(self, manual):
+            from siglume_api_sdk import ToolManualQualityReport
+
+            return ToolManualQualityReport(
+                overall_score=90,
+                grade="A",
+                issues=[],
+                keyword_coverage_estimate=70,
+                improvement_suggestions=[],
+                publishable=True,
+                validation_ok=True,
+            )
+
+        def auto_register(self, manifest, tool_manual, **kwargs):
+            assert kwargs.get("oauth_credentials") is None
+            return SimpleNamespace(listing_id="lst_api_managed", status="draft")
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+    monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
+
+    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"listing_id": "lst_api_managed"' in result.output
+
+
+def test_register_requires_oauth_seed_for_platform_managed_oauth_api(monkeypatch, tmp_path) -> None:
     runner = CliRunner()
     project_dir = tmp_path / "oauth-required"
     _write_register_project(
         project_dir,
-        required_connected_accounts=["twitter"],
+        required_connected_accounts=[{"provider_key": "twitter", "platform_managed": True}],
     )
 
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
@@ -325,7 +369,7 @@ def test_register_canonicalizes_oauth_seed_payload(monkeypatch, tmp_path) -> Non
     project_dir = tmp_path / "oauth-canonical"
     _write_register_project(
         project_dir,
-        required_connected_accounts=["google-drive"],
+        required_connected_accounts=[{"provider_key": "google-drive", "platform_managed": True}],
         oauth_credentials=[
             {
                 "provider": "gmail",
@@ -784,6 +828,39 @@ def test_build_tool_manual_template_tolerates_missing_job_to_be_done() -> None:
 
     assert manual["job_to_be_done"] == "Price Compare Helper"
     assert manual["trigger_conditions"][0].startswith("The owner asks for help with")
+
+
+def test_tool_manual_validator_allows_json_schema_composition_keywords() -> None:
+    manifest = AppManifest(
+        capability_key="price-compare-helper",
+        name="Price Compare Helper",
+        job_to_be_done="Compare retailer prices for a product and return the best current offer.",
+        category=AppCategory.COMMERCE,
+        permission_class=PermissionClass.READ_ONLY,
+        approval_mode=ApprovalMode.AUTO,
+        dry_run_supported=True,
+        required_connected_accounts=[],
+        price_model=PriceModel.FREE,
+        jurisdiction="US",
+    )
+    manual = project_module.build_tool_manual_template(manifest)
+    manual["input_schema"] = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "anyOf": [
+                    {"type": "string", "description": "Product query."},
+                    {"type": "null"},
+                ]
+            }
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    }
+
+    valid, issues = validate_tool_manual(manual)
+
+    assert valid, issues
 
 
 def test_validate_and_score_commands_use_remote_preview(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Harden the public SDK-side registration contract for the auto-register incident follow-up.

- Allow API-managed connected accounts as plain provider strings while keeping structured `platform_managed: true` entries tied to seller OAuth seed requirements.
- Align Python and TypeScript SDK preflight/type surfaces with that connected-account distinction.
- Allow common JSON Schema composition keywords in ToolManual schemas while still rejecting unsupported constructs such as `patternProperties` recursively.
- Document that API Store auto-register accepts optional-only single-API input forms, and that `file` fields remain unsupported for API Store listings until uploaded-file transport is exposed.
- Update OpenAPI/schema/docs to match the runtime contract.

## Validation

- `py -3.11 -m pytest tests\test_cli.py -k "api_managed_connected_account or platform_managed_oauth or canonicalizes_oauth_seed_payload or string_oauth_scopes or composition_keywords"`
- `npx vitest run test/project.test.ts test/validator.test.ts --coverage=false`
- `npm run typecheck`
- Main-repo mirror check passed locally after syncing this SDK slice: `py -3.11 packages\contracts\sdk\scripts\check_public_sdk_sync.py --peer-dir C:\tmp\siglume-api-sdk`

## Notes

The matching main-repo runtime hardening PR should land after this SDK PR so the mirror check can compare against the updated public SDK state.