### PR TITLE
[codex] Reject malformed platform-managed OAuth requirements

### DIFF
--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -349,6 +349,11 @@ function requiredOauthProviders(requirements: unknown[] | undefined): string[] {
   for (const item of requirements ?? []) {
     if (!isPlatformManagedRequirement(item)) continue;
     const providerKey = oauthProviderKeyFromRequirement(item);
+    if (!providerKey) {
+      throw new SiglumeProjectError(
+        "required_connected_accounts platform-managed entries must include a supported provider_key",
+      );
+    }
     if (providerKey && !providers.includes(providerKey)) {
       providers.push(providerKey);
     }

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -388,6 +388,34 @@ describe("cli project helpers", () => {
     expect(autoRegisterCalled).toBe(false);
   });
 
+  it("rejects platform-managed OAuth requirements without a provider key", async () => {
+    const projectDir = await createObjectProject({
+      manifest: {
+        ...manifestBase(),
+        required_connected_accounts: [{ platform_managed: true, required_scopes: ["chat:write"] }],
+      },
+    });
+
+    await expect(
+      runRegistration(
+        projectDir,
+        {},
+        {
+          env: { SIGLUME_API_KEY: "sig_test_key" },
+          client_factory: () =>
+            ({
+              async preview_quality_score() {
+                return publishableQualityReport();
+              },
+              async auto_register() {
+                throw new Error("auto_register should not run");
+              },
+            }) as unknown as SiglumeClientShape,
+        },
+      ),
+    ).rejects.toThrow("platform-managed entries must include a supported provider_key");
+  });
+
   it("canonicalizes OAuth seed payloads before auto-register", async () => {
     const projectDir = await createObjectProject({
       manifest: {

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -345,6 +345,10 @@ def _required_oauth_providers(requirements: list[Any] | tuple[Any, ...] | None) 
         if not _is_platform_managed_requirement(item):
             continue
         provider_key = _oauth_provider_key_from_requirement(item)
+        if not provider_key:
+            raise click.ClickException(
+                "required_connected_accounts platform-managed entries must include a supported provider_key"
+            )
         if provider_key and provider_key not in providers:
             providers.append(provider_key)
     return providers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -364,6 +364,22 @@ def test_register_requires_oauth_seed_for_platform_managed_oauth_api(monkeypatch
     assert "twitter" in result.output
 
 
+def test_register_rejects_platform_managed_oauth_without_provider_key(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "oauth-missing-provider"
+    _write_register_project(
+        project_dir,
+        required_connected_accounts=[{"platform_managed": True, "required_scopes": ["chat:write"]}],
+    )
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+
+    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+
+    assert result.exit_code == 1
+    assert "platform-managed entries must include a supported provider_key" in result.output
+
+
 def test_register_canonicalizes_oauth_seed_payload(monkeypatch, tmp_path) -> None:
     runner = CliRunner()
     project_dir = tmp_path / "oauth-canonical"


### PR DESCRIPTION
## Summary

Fix the Codex review finding from #192: platform-managed connected-account requirements must fail closed when no provider key can be resolved.

- Reject `required_connected_accounts` entries with `platform_managed: true` when they omit a supported `provider_key` / provider alias.
- Apply the check in both Python and TypeScript CLI registration paths.
- Add Python and TypeScript regression tests.

## Validation

- `py -3.11 -m pytest tests\test_cli.py -k "platform_managed_oauth_without_provider_key or platform_managed_oauth_api or api_managed_connected_account"`
- `npx vitest run test/project.test.ts --coverage=false`
- `npm run typecheck`