### PR TITLE
Sync packages/contracts/sdk/ from Siglume mirror — support_contact UX + accumulated drift

### DIFF
--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -39,8 +39,8 @@ working and the API is useful enough for owners to pay for monthly access.
 2. Run `siglume test .` and `siglume score . --offline`.
 3. Deploy the real API to a public URL.
 4. Fill the local, Git-ignored `runtime_validation.json`.
-5. Run `siglume validate .`, `siglume score . --remote`, `siglume preflight .`, and `siglume register .`.
-6. Review the draft output or portal page, then publish with `siglume register . --confirm` only when ready.
+5. Run `siglume validate .`, `siglume score . --remote`, `siglume preflight .`, and `siglume register .` when ready to publish.
+6. Use `siglume register . --draft-only` only when you intentionally want an immutable review draft before publishing.
 
 There is no PR review process for API listings. You register directly on the
 platform. See [GETTING_STARTED.md](GETTING_STARTED.md) for the full guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `siglume register .` now confirms publication by default after
+  auto-register and self-serve checks pass. Use `siglume register .
+  --draft-only` for intentional review-only staging; `--confirm` remains
+  accepted as an explicit compatibility alias.
+
 ## [0.10.1] - 2026-04-26
 
 ### Docs

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -108,8 +108,8 @@ siglume validate .
 siglume score . --remote
 siglume preflight .
 siglume register .
-# inspect the draft, then explicitly approve publish:
-siglume register . --confirm
+# review-only staging path:
+siglume register . --draft-only
 ```
 
 Or clone the repo to browse the examples:
@@ -212,9 +212,35 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `price_model` | Billing model | `"free"`, `"subscription"` |
 | `jurisdiction` | **Required.** ISO 3166-1 alpha-2 country code declaring the governing law of your API. [Details](docs/jurisdiction-and-compliance.md) | `"US"`, `"JP"`, `"US-CA"` |
 | `docs_url` | **Required for production registration.** Public usage guide for this API listing. Do not use your company homepage or the same URL as `source_url`. | `"https://docs.your-domain.com/weather-api"` |
-| `support_contact` | **Required for production registration.** Real support email address or public support URL. Placeholder domains are rejected. | `"support@your-domain.com"` |
+| `support_contact` | **Required for production registration.** Real support email address or public support URL. Placeholder domains are rejected. See [How buyer inquiries reach you](#how-buyer-inquiries-reach-you) below for the routing rules. | `"support@your-domain.com"` |
 | `seller_homepage_url` | Optional official seller/company homepage, separate from `docs_url`. | `"https://your-domain.com"` |
 | `seller_social_url` | Optional official seller social/profile URL, separate from `docs_url`. | `"https://x.com/your_account"` |
+
+### How buyer inquiries reach you
+
+Buyers do **not** click through to your `support_contact` value directly. The
+buyer-facing API detail page renders a single "Contact support for this API"
+link that opens Siglume's internal inquiry form, so every case is tracked
+inside the platform. Your `support_contact` is then used only for the
+notification that the platform sends when a buyer files an inquiry — never as
+a clickable link in the buyer UI.
+
+The notification routing rules are deterministic:
+
+| `support_contact` shape | Where the inquiry email is delivered |
+|---|---|
+| Plain email (e.g. `support@your-domain.com`) | That address. Use a dedicated inbox so buyer inquiries do not mix with login/billing mail. |
+| `http(s)://...` URL (e.g. `https://your-domain.com/support`) | **Falls back to your Siglume account email** (the login/billing address). The URL is metadata-only — it is not used as a delivery target and is not shown to buyers. |
+| Empty / missing | Rejected at registration; production listings require a value. |
+
+Recommendation: **prefer a plain email address** for `support_contact` so buyer
+inquiries land in a dedicated inbox you can route to your support team. Use a
+URL only when you genuinely have a public support page — and remember the URL
+itself is never shown or linked to buyers.
+
+In addition to the email, the platform also writes an in-app `Alert` on your
+Developer Portal (`/owner/publish?tab=support`) and persists the case in the
+support thread, so a missed email is not a missed inquiry.
 
 ### capability_key rules
 
@@ -364,9 +390,9 @@ Does your API write to anything external?
 5. If the API uses seller-side OAuth, also keep the local, Git-ignored `oauth_credentials.json` with the project
 6. Run `siglume test .` and `siglume score . --offline` before any API key is required
 7. After deployment, run `siglume validate .`, `siglume score . --remote`, and `siglume preflight .`
-8. Review the result in the developer portal when needed
-9. Run `siglume register .` to create or refresh the draft
-10. Confirm and publish with `siglume register . --confirm` only after human review
+8. Run `siglume register .` to auto-register and publish when the checks pass
+9. Use `siglume register . --draft-only` instead when you intentionally need an immutable review draft
+10. Review the result in the developer portal when needed
 11. Live in the API Store
 ```
 
@@ -407,7 +433,7 @@ Use this flow from CLI / SDK / automation:
   - local, Git-ignored `runtime_validation.json`
   - optional local, Git-ignored `oauth_credentials.json` for seller-side OAuth app credentials
 - `siglume register` runs manifest validation and remote Tool Manual quality
-  preview before draft creation by default
+  preview before auto-registering by default
 - This route requires `SIGLUME_API_KEY` or `~/.siglume/credentials.toml`
   because there is no browser session
 - This is the recommended registration path for CLI users, coding engines, and automation
@@ -427,24 +453,25 @@ siglume score . --offline
 siglume validate .
 siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
-siglume register .                 # preflight + draft only
-siglume register . --confirm      # confirm + publish
+siglume register .                # preflight + auto-register + confirm/publish
+siglume register . --draft-only   # review-only draft staging
 ```
 
 Useful flags:
 
-- `--confirm`: confirm the draft and publish it when the self-serve checks pass
+- `--draft-only`: create or refresh the immutable draft without confirming publication
+- `--confirm`: explicit compatibility alias; confirmation is already the default
 - `--submit-review`: legacy alias for older environments
 - `--json`: emit machine-readable JSON
 
 Coding agents may run `siglume validate .`, `siglume score . --remote`,
-`siglume preflight .`, and `siglume register .` to create the draft. They
-should not run `siglume register . --confirm` unless the human explicitly
-approves immediate publish after reviewing the draft output or portal page.
+`siglume preflight .`, and `siglume register . --draft-only` to create the
+review draft. They should not run `siglume register .` unless the human
+explicitly approves immediate publish.
 
-If the listing is already live, re-run the same `capability_key` to stage an
-upgrade. Review the staged result, then `siglume register . --confirm`
-publishes the next release immediately when the checks pass.
+If the listing is already live, re-run the same `capability_key` to publish a
+non-material upgrade when the checks pass. Use `--draft-only` if you
+intentionally want to stage and inspect the upgrade before publishing.
 
 See [docs/publish-flow.md](./docs/publish-flow.md) and
 [Section 11](#11-auto-register-cli--automation-route) for the automation path.
@@ -633,7 +660,7 @@ Your API runtime
 Submit again with the same `capability_key`.
 
 - If the listing is live, `siglume register` stages an upgrade instead of creating a new product.
-- `siglume register . --confirm` publishes the next release immediately after you approve the staged result and the self-serve checks pass again.
+- `siglume register .` publishes the next release immediately when the self-serve checks pass again; use `--draft-only` when you intentionally want a staged review draft.
 - If the upgrade adds a new platform-managed seller-side OAuth provider, update the local, Git-ignored `oauth_credentials.json` before registering or the upgrade is rejected.
 
 ### How do I manage external API credentials?
@@ -686,8 +713,9 @@ sandbox route only when you need a manual real-agent run.
 
 Most first-time developers can skip this section. The beginner path is:
 `siglume test .`, `siglume score . --offline`, deploy, fill
-`runtime_validation.json`, run `siglume preflight .`, create a draft with
-`siglume register .`, then confirm only after human review.
+`runtime_validation.json`, run `siglume preflight .`, and publish with
+`siglume register .` when ready. Use `siglume register . --draft-only` for a
+review draft.
 
 ### Step 1: Register and confirm with your CLI/API key
 
@@ -712,8 +740,9 @@ contract: `manifest`, `tool_manual`, and `runtime_validation`.
 Open the `review_url` returned by the CLI, or go to
 `https://siglume.com/owner/publish`. Submitted listing content is read-only in
 the portal. If you need to change the API contract, update the local project and
-rerun `siglume register .` with the same `capability_key`. Publish with
-`siglume register . --confirm` only after you approve the immutable draft.
+rerun `siglume register .` with the same `capability_key`. Use
+`siglume register . --draft-only` when you intentionally need an immutable draft
+before publishing.
 
 ### Step 3: Legacy/manual direct REST sandbox fallback
 
@@ -747,8 +776,8 @@ curl "https://siglume.com/v1/market/usage?environment=sandbox&capability_key=my-
 ```
 
 Sandbox mode is isolated from live data. No real payments or side effects occur.
-When you are ready to go live, publish through `siglume register . --confirm`
-and the self-serve checks.
+When you are ready to go live, publish through `siglume register .` and the
+self-serve checks.
 
 ---
 
@@ -766,8 +795,8 @@ through a short-lived, limited-scope CLI token.
 1. Your AI reads your source code
 2. Your AI generates the listing manifest, Tool Manual, and runtime validation payload
 3. Siglume fills the missing second language with LLM translation and stores Japanese and English listing text
-4. Your AI calls the auto-register endpoint
-5. You review the draft and confirm
+4. `siglume register .` calls auto-register and confirms publication by default when immediate publish is approved
+5. `siglume register . --draft-only` stops at the immutable draft when you need review before publishing
 
 ### Authentication for this route
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ payments, and other side effects until your first API is published.
    siglume score . --remote
    siglume preflight .
    siglume register .
-9. Review the draft output or portal page yourself, then publish only when ready:
-   siglume register . --confirm
+9. `siglume register .` publishes when the self-serve checks pass. Use
+   `siglume register . --draft-only` only when you intentionally want to stop at
+   an immutable review draft.
 ```
 
 Use [docs/coding-agent-guide.md](./docs/coding-agent-guide.md) as the file to
@@ -123,7 +124,7 @@ Constraints:
 - Keep runtime_validation.json, oauth_credentials.json, .env, and real secrets Git-ignored.
 - Do not put real secrets in source code or committed docs.
 - Do not ask me to paste browser session tokens or production API keys into chat.
-- Do not run `siglume register . --confirm` unless I explicitly approve the draft for immediate publish.
+- Do not run `siglume register .` unless I explicitly approve immediate publish; use `siglume register . --draft-only` for review-only staging.
 - Make the project pass:
   siglume test .
   siglume score . --offline
@@ -159,15 +160,16 @@ This is the main use case. You build an API, register it, and earn revenue.
 5. If the API uses seller-side OAuth, also keep the local, Git-ignored `oauth_credentials.json` next to your adapter
 6. Run `siglume test .` and `siglume score . --offline`
 7. Issue `SIGLUME_API_KEY` from Developer Portal -> CLI / API keys, then run `siglume validate .`, `siglume score . --remote`, and `siglume preflight .`
-8. Run `siglume register .` to create or refresh the draft
-9. Review the result in the developer portal or CLI output
-10. Run `siglume register . --confirm` only after you explicitly approve immediate publish
+8. Run `siglume register .` to auto-register and publish when the checks pass
+9. Use `siglume register . --draft-only` instead when you explicitly want an immutable review draft
+10. Review the result in the developer portal or CLI output
 11. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
 ```
 
 If the listing already exists and is live, re-run the same `capability_key` to
-stage an upgrade. Review the staged upgrade, then `siglume register . --confirm`
-publishes the next release immediately when the same self-serve checks pass. If the upgrade adds a new
+auto-register and publish the next non-material release when the same
+self-serve checks pass. Use `--draft-only` if you want to inspect the staged
+upgrade before publishing. If the upgrade adds a new
 platform-managed seller-side OAuth provider, the local Git-ignored `oauth_credentials.json` must
 already include that provider or the upgrade is rejected.
 
@@ -178,7 +180,7 @@ No permission needed. No issue to claim. Just build and register.
 
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
-| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, local Git-ignored `runtime_validation.json`, and optional local Git-ignored `oauth_credentials.json`, runs preflight by default, then calls `auto-register`. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to stage an upgrade. |
+| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json`, local Git-ignored `runtime_validation.json`, and optional local Git-ignored `oauth_credentials.json`, runs preflight by default, then calls `auto-register` and confirms publication unless `--draft-only` is set. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to publish an upgrade when checks pass. |
 | Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Submitted listing content is read-only in the portal; change content by rerunning the CLI / `auto-register` with the same `capability_key`. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. The OAuth section is for credential rotation / repair after registration, not the initial registration step. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
@@ -232,19 +234,20 @@ siglume score . --offline
 siglume validate .
 siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
-siglume register .                 # preflight + draft only
-siglume register . --confirm      # confirm + publish
+siglume register .                # preflight + auto-register + confirm/publish
+siglume register . --draft-only   # review-only draft staging
 ```
 
 `siglume register` now runs manifest validation and remote Tool Manual quality
-preview before draft creation. The supported registration flags are
-`--confirm`, `--submit-review` as a legacy alias, and `--json` for
-machine-readable output.
+preview before auto-registering. It confirms and publishes by default when the
+self-serve checks pass. The supported registration flags are `--draft-only`,
+`--confirm` as an explicit compatibility alias, `--submit-review` as a legacy
+alias, and `--json` for machine-readable output.
 
 For upgrades, run the same commands again with the same `capability_key`.
-`siglume register` stages the upgrade, and `siglume register . --confirm`
-publishes the next release immediately when you approve the staged result and
-the checks pass.
+`siglume register` publishes the next release immediately when the checks pass;
+use `siglume register . --draft-only` if you intentionally want to stage and
+review the upgrade before publishing.
 
 - **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review drafts, blockers, and live status)
 - **Wallet** → [siglume.com/owner/credits/payout](https://siglume.com/owner/credits/payout) (embedded-wallet payout token settings; external payout wallets are not supported)
@@ -327,8 +330,8 @@ siglume validate .
 siglume score . --remote
 siglume preflight .
 siglume register .
-# inspect the draft, then explicitly approve publish:
-siglume register . --confirm
+# review-only staging path:
+siglume register . --draft-only
 ```
 
 Or generate a wrapper directly from a first-party owner operation:

--- a/docs/coding-agent-guide.md
+++ b/docs/coding-agent-guide.md
@@ -74,20 +74,19 @@ keys into the coding-agent chat.
 ## Production registration loop
 
 After deployment and `runtime_validation.json` are ready, the coding agent may
-run the non-publishing checks:
+run the non-publishing checks and create an immutable review draft:
 
 ```bash
 siglume validate .
 siglume score . --remote
 siglume preflight .
-siglume register .
+siglume register . --draft-only
 ```
 
-`siglume register .` creates or refreshes the draft only. Stop there and tell
-the human to inspect the CLI output or developer portal. Run
-`siglume register . --confirm` only after the human explicitly approves the
-draft for immediate publish. Use `--json` when another tool needs
-machine-readable output.
+`siglume register . --draft-only` creates or refreshes the draft only. Stop
+there and tell the human to inspect the CLI output or developer portal. Run
+plain `siglume register .` only after the human explicitly approves immediate
+publish. Use `--json` when another tool needs machine-readable output.
 
 ## Secrets and safety
 
@@ -142,8 +141,8 @@ runtime_validation.json before I run:
 siglume validate .
 siglume score . --remote
 siglume preflight .
-siglume register .
+siglume register . --draft-only
 
-Do not run siglume register . --confirm unless I explicitly approve the draft
-for immediate publish.
+Do not run plain siglume register . unless I explicitly approve immediate
+publish.
 ```

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -49,17 +49,16 @@ There is no normal human review step in the self-serve publish flow anymore.
    - `siglume score . --remote`
    - `siglume preflight .`
 8. The engine calls `siglume register .` or `auto-register` to create or
-   refresh the immutable draft.
+   refresh the immutable submitted record.
 9. Siglume runs runtime, contract, pricing, payout, seller OAuth, and
    mandatory LLM legal checks.
-10. If the checks pass, Siglume creates a private draft listing or stages a
-   non-material update for the existing live listing. Material contract changes
-   to a live listing are blocked and must be submitted as a new API.
-11. The developer opens the portal confirmation page to inspect the immutable
-    result.
-12. The developer confirms the draft with `siglume register . --confirm` or
-    `confirm-auto-register` only after explicit human review.
-13. Siglume publishes the listing immediately when the final checks still pass.
+10. If the checks pass, `siglume register .` confirms and publishes the listing
+    or non-material update immediately. Material contract changes to a live
+    listing are blocked and must be submitted as a new API.
+11. Use `siglume register . --draft-only` when a coding agent or developer
+    intentionally needs an immutable draft for explicit human review.
+12. The draft can then be published by rerunning plain `siglume register .` or
+    calling `confirm-auto-register`.
 
 ## What auto-register does
 
@@ -79,7 +78,8 @@ There is no normal human review step in the self-serve publish flow anymore.
 7. Verifies the runtime sample request / response against the declared
    `input_schema` and `output_schema`.
 8. Checks connected-account requirements and paid pricing rules.
-9. Persists a private draft only if those checks pass.
+9. Persists a private draft only if those checks pass. The CLI then confirms it
+   by default unless `--draft-only` was requested.
 10. On confirmation, reruns the LLM legal review against the immutable stored
     draft package. If the final stored package fails or the LLM does not return
     a valid decision, publish is blocked.
@@ -254,8 +254,10 @@ The intended advanced flow is:
    - `runtime_validation`
    - optional `oauth_credentials`
    - optional `input_form_spec`
-6. You review the immutable draft in the portal.
-7. You confirm the draft and publish immediately if the final checks pass.
+6. `siglume register .` confirms and publishes by default when immediate
+   publish is approved.
+7. Use `siglume register . --draft-only` when you need an immutable draft for
+   portal review before publishing.
 
 This is the recommended path for AI-assisted registration because it avoids
 manual browser form entry and keeps the registration contract close to the
@@ -286,10 +288,10 @@ then show the API-key production loop:
 siglume validate .
 siglume score . --remote
 siglume preflight .
-siglume register .
+siglume register . --draft-only
 
-Do not run siglume register . --confirm unless I explicitly approve the draft
-for immediate publish.
+Do not run plain siglume register . unless I explicitly approve immediate
+publish.
 ```
 
 ## Where the schema lives

--- a/examples/generated/owner_approval_policy_update/README.md
+++ b/examples/generated/owner_approval_policy_update/README.md
@@ -41,5 +41,5 @@ After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-ali
 ```bash
 siglume validate .
 siglume score . --remote
-siglume register . --confirm
+siglume register .
 ```

--- a/examples/generated/owner_budget_get/README.md
+++ b/examples/generated/owner_budget_get/README.md
@@ -41,5 +41,5 @@ After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-ali
 ```bash
 siglume validate .
 siglume score . --remote
-siglume register . --confirm
+siglume register .
 ```

--- a/examples/generated/owner_charter_update/README.md
+++ b/examples/generated/owner_charter_update/README.md
@@ -41,5 +41,5 @@ After placeholders are replaced and `SIGLUME_API_KEY` is set, run the server-ali
 ```bash
 siglume validate .
 siglume score . --remote
-siglume register . --confirm
+siglume register .
 ```

--- a/examples/hello_price_compare.py
+++ b/examples/hello_price_compare.py
@@ -124,7 +124,7 @@ async def main():
     print("  5. Deploy, fill runtime_validation.json, then run:")
     print("     siglume validate .")
     print("     siglume score . --remote")
-    print("     siglume register . --confirm")
+    print("     siglume register .")
     print("")
     print("Revenue share: 93.4% developer / 6.6% platform.")
     print("Settlement: on-chain on Polygon mainnet (chainId 137) via your")

--- a/examples/x_publisher.py
+++ b/examples/x_publisher.py
@@ -212,7 +212,7 @@ async def main() -> None:
     print("  6. Deploy, fill runtime_validation.json, then run:")
     print("     siglume validate .")
     print("     siglume score . --remote")
-    print("     siglume register . --confirm")
+    print("     siglume register .")
 
 
 if __name__ == "__main__":

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -65,8 +65,8 @@ siglume score . --offline
 siglume validate .
 siglume score . --remote
 siglume preflight .         # checks blockers without creating a draft
-siglume register .            # preflight + draft only
-siglume register . --confirm # confirm + publish
+siglume register .          # preflight + auto-register + confirm/publish
+siglume register . --draft-only # review-only draft staging
 ```
 
 `siglume register` reads `tool_manual.json`, the local Git-ignored
@@ -76,8 +76,9 @@ credential files Git-ignored because they can contain review keys and client
 secrets. SDK / HTTP automation can pass
 `source_url`, `source_context`, and `input_form_spec` directly to
 `auto-register`. The CLI runs preflight by default, then calls the same
-`auto-register` route used by SDK / automation clients. Re-run the
-same `capability_key` to stage an upgrade. The server-side publish gate
+`auto-register` route used by SDK / automation clients and confirms publication
+unless `--draft-only` is set. Re-run the same `capability_key` to publish a
+non-material upgrade when checks pass. The server-side publish gate
 includes runtime checks, contract checks, seller OAuth checks, pricing / payout
 rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -265,12 +265,24 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
 
   program
     .command("register")
-    .option("--confirm", "confirm the draft registration immediately and publish it when the self-serve checks pass", false)
+    .option("--confirm", "explicitly confirm the registration; this is the default unless --draft-only is set", false)
+    .option("--draft-only", "create or refresh the draft without confirming publication", false)
     .option("--submit-review", "legacy alias: publish immediately if your environment still routes through submit-review", false)
     .option("--json", "emit machine-readable JSON", false)
     .argument("[path]", ".", "project path")
-    .action(async (path: string, options: { confirm?: boolean; submitReview?: boolean; json?: boolean; ["submit-review"]?: boolean }) => {
-      const report = await runRegistration(path, { confirm: options.confirm, submit_review: options.submitReview }, deps);
+    .action(async (
+      path: string,
+      options: { confirm?: boolean; draftOnly?: boolean; submitReview?: boolean; json?: boolean; ["draft-only"]?: boolean; ["submit-review"]?: boolean },
+    ) => {
+      const draftOnly = Boolean(options.draftOnly);
+      if (draftOnly && options.confirm) {
+        throw new SiglumeProjectError("--draft-only cannot be combined with --confirm.");
+      }
+      if (draftOnly && options.submitReview) {
+        throw new SiglumeProjectError("--draft-only cannot be combined with --submit-review.");
+      }
+      const shouldConfirm = Boolean(options.confirm) || (!draftOnly && !options.submitReview);
+      const report = await runRegistration(path, { confirm: shouldConfirm, draft_only: draftOnly, submit_review: options.submitReview }, deps);
       if (options.json) {
         emit(stdout, renderJson(report));
       } else {
@@ -284,10 +296,11 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
           trace_id?: string | null;
           request_id?: string | null;
         };
-        if (report.confirmation) {
-          emit(stdout, "Listing published.");
-        } else if (report.review) {
-          emit(stdout, "Listing published via legacy submit-review alias.");
+        const published = Boolean(report.confirmation || report.review);
+        if (published && receipt.registration_mode === "upgrade") {
+          emit(stdout, "Upgrade registered.");
+        } else if (published) {
+          emit(stdout, "Registration accepted.");
         } else if (receipt.registration_mode === "upgrade") {
           emit(stdout, "Upgrade staged.");
         } else if (receipt.registration_mode === "refresh") {
@@ -307,10 +320,12 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
             status?: string | null;
             release?: { release_status?: string | null } | null;
           };
+          emit(stdout, "Listing published.");
           if (confirmation.status) emit(stdout, `confirmation_status: ${confirmation.status}`);
           if (confirmation.release?.release_status) emit(stdout, `release_status: ${confirmation.release.release_status}`);
         } else if (report.review) {
           const review = report.review as { status?: string | null };
+          emit(stdout, "Listing published via legacy submit-review alias.");
           if (review.status) emit(stdout, `publish_status: ${review.status}`);
         }
         const preflight = report.registration_preflight as { remote_quality?: { grade?: string; overall_score?: number } } | undefined;

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -678,7 +678,7 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
 
 export async function runRegistration(
   path = ".",
-  options: { confirm?: boolean; submit_review?: boolean } = {},
+  options: { confirm?: boolean; draft_only?: boolean; submit_review?: boolean } = {},
   deps: CliProjectDependencies = {},
 ): Promise<Record<string, unknown>> {
   const project = await loadProject(path);
@@ -713,7 +713,8 @@ export async function runRegistration(
   if (developerPortalPreflight) {
     result.developer_portal_preflight = developerPortalPreflight;
   }
-  if (options.confirm) {
+  const shouldConfirm = Boolean(options.confirm) || (options.confirm === undefined && !options.draft_only && !options.submit_review);
+  if (shouldConfirm) {
     result.confirmation = toJsonable(await client.confirm_registration(receipt.listing_id));
     if (options.submit_review) {
       result.submit_review_skipped = true;
@@ -1333,8 +1334,8 @@ function operationReadmeTemplate(
     "siglume score . --remote",
     "siglume preflight .",
     "siglume register .",
-    "# inspect the draft, then explicitly approve publish:",
-    "siglume register . --confirm",
+    "# review-only staging path:",
+    "siglume register . --draft-only",
     "```",
     "",
   ].join("\n");
@@ -1979,8 +1980,8 @@ function readmeTemplate(template: TemplateName): string {
     "siglume score . --remote",
     "siglume preflight .",
     "siglume register .",
-    "# inspect the draft, then explicitly approve publish:",
-    "siglume register . --confirm",
+    "# review-only staging path:",
+    "siglume register . --draft-only",
     "```",
     "",
   ].join("\n");

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -488,7 +488,7 @@ describe("siglume CLI", () => {
     expect(readmeText).toContain("Do not commit real review keys or OAuth client secrets");
     expect(readmeText.indexOf("siglume score . --offline")).toBeLessThan(readmeText.indexOf("siglume validate ."));
     expect(readmeText.indexOf("npm test -- tests/test_adapter.ts")).toBeLessThan(
-      readmeText.indexOf("siglume register . --confirm"),
+      readmeText.indexOf("siglume register ."),
     );
     expect(await readFile(join(projectDir, "tool_manual.json"), "utf8")).toContain("\"owner_charter_update\"");
     expect(await readFile(join(projectDir, "runtime_validation.json"), "utf8")).toContain("\"expected_response_fields\"");
@@ -569,13 +569,60 @@ describe("siglume CLI", () => {
     });
 
     expect(registerExit).toBe(0);
-    expect(stdout.join("\n")).toContain("Upgrade staged.");
+    expect(stdout.join("\n")).toContain("Upgrade registered.");
+    expect(stdout.join("\n")).toContain("Listing published.");
     expect(stdout.join("\n")).toContain("listing_status: active");
     expect(stdout.join("\n")).toContain("oauth_configured: true");
+    expect(stdout.join("\n")).toContain("confirmation_status: active");
+    expect(stdout.join("\n")).toContain("release_status: published");
     expect(stdout.join("\n")).toContain("review_url: https://siglume.com/owner/publish?listing=lst_123");
     expect(stdout.join("\n")).toContain("trace_id: trc_reg");
     expect(stdout.join("\n")).toContain("request_id: req_reg");
     expect(stdout.join("\n")).toContain("preflight_quality: A (92/100)");
+  });
+
+  it("stops after auto-register when --draft-only is set", async () => {
+    const projectDir = await createTestProject();
+    const stdout: string[] = [];
+    let confirmCalled = false;
+    const clientFactory = () => ({
+      ...createMockClient(),
+      async confirm_registration() {
+        confirmCalled = true;
+        throw new Error("draft-only must not confirm registration");
+      },
+    });
+
+    const registerExit = await runCli(["register", projectDir, "--draft-only"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(registerExit).toBe(0);
+    expect(confirmCalled).toBe(false);
+    expect(stdout.join("\n")).toContain("Upgrade staged.");
+    expect(stdout.join("\n")).toContain("receipt_status: draft");
+    expect(stdout.join("\n")).not.toContain("Listing published.");
+  });
+
+  it("rejects --draft-only combined with publish flags", async () => {
+    const projectDir = await createTestProject();
+    const stderr: string[] = [];
+
+    const confirmExit = await runCli(["register", projectDir, "--draft-only", "--confirm"], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+    const submitExit = await runCli(["register", projectDir, "--draft-only", "--submit-review"], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(confirmExit).toBe(1);
+    expect(submitExit).toBe(1);
+    expect(stderr.join("\n")).toContain("--draft-only cannot be combined with --confirm.");
+    expect(stderr.join("\n")).toContain("--draft-only cannot be combined with --submit-review.");
   });
 
   it("runs preflight without creating a draft", async () => {

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -83,6 +83,16 @@ function manualBase() {
   };
 }
 
+function confirmedRegistration(listing_id: string) {
+  return {
+    listing_id,
+    status: "active",
+    release: { release_status: "published" },
+    quality: { overall_score: 80, grade: "B", issues: [], improvement_suggestions: [], raw: {} },
+    raw: {},
+  };
+}
+
 async function createObjectProject(options: {
   manualFileName?: "tool_manual.json" | "tool-manual.json";
   toolManual?: Record<string, unknown>;
@@ -350,6 +360,9 @@ describe("cli project helpers", () => {
               expect(options?.oauth_credentials).toBeUndefined();
               return { listing_id: "lst_api_managed", status: "draft", auto_manifest: {}, confidence: {} };
             },
+            async confirm_registration(listing_id: string) {
+              return confirmedRegistration(listing_id);
+            },
           }) as unknown as SiglumeClientShape,
       },
     );
@@ -463,6 +476,9 @@ describe("cli project helpers", () => {
               });
               return { listing_id: "lst_oauth", status: "draft", auto_manifest: {}, confidence: {} };
             },
+            async confirm_registration(listing_id: string) {
+              return confirmedRegistration(listing_id);
+            },
           }) as unknown as SiglumeClientShape,
       },
     );
@@ -523,6 +539,9 @@ describe("cli project helpers", () => {
               });
               return { listing_id: "lst_custom_oauth", status: "draft", auto_manifest: {}, confidence: {} };
             },
+            async confirm_registration(listing_id: string) {
+              return confirmedRegistration(listing_id);
+            },
           }) as unknown as SiglumeClientShape,
       },
     );
@@ -582,6 +601,9 @@ describe("cli project helpers", () => {
             async auto_register() {
               autoRegisterCalled = true;
               return { listing_id: "lst_warning", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+            async confirm_registration(listing_id: string) {
+              return confirmedRegistration(listing_id);
             },
           }) as unknown as SiglumeClientShape,
       },

--- a/siglume_api_sdk/cli/commands/register_cmd.py
+++ b/siglume_api_sdk/cli/commands/register_cmd.py
@@ -6,19 +6,31 @@ from siglume_api_sdk.cli.project import render_json, run_registration
 
 
 @click.command("register")
-@click.option("--confirm", is_flag=True, help="Confirm the registration and publish it when the self-serve checks pass.")
+@click.option("--confirm", is_flag=True, help="Explicitly confirm the registration. This is the default unless --draft-only is set.")
+@click.option("--draft-only", is_flag=True, help="Create or refresh the draft without confirming publication.")
 @click.option("--submit-review", is_flag=True, help="Legacy alias: publish immediately if your environment still routes through submit-review.")
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
 @click.argument("path", required=False, default=".")
-def register_command(confirm: bool, submit_review: bool, json_output: bool, path: str) -> None:
-    result = run_registration(path, confirm=confirm, submit_review=submit_review)
+def register_command(confirm: bool, draft_only: bool, submit_review: bool, json_output: bool, path: str) -> None:
+    if draft_only and confirm:
+        raise click.ClickException("--draft-only cannot be combined with --confirm.")
+    if draft_only and submit_review:
+        raise click.ClickException("--draft-only cannot be combined with --submit-review.")
+
+    should_confirm = confirm or (not draft_only and not submit_review)
+    result = run_registration(path, confirm=should_confirm, submit_review=submit_review)
     if json_output:
         click.echo(render_json(result))
         return
 
     receipt = result["receipt"]
     registration_mode = receipt.get("registration_mode")
-    if registration_mode == "upgrade":
+    published = "confirmation" in result or "review" in result
+    if published and registration_mode == "upgrade":
+        click.secho("Upgrade registered.", fg="green")
+    elif published:
+        click.secho("Registration accepted.", fg="green")
+    elif registration_mode == "upgrade":
         click.secho("Upgrade staged.", fg="green")
     elif registration_mode == "refresh":
         click.secho("Draft refreshed.", fg="green")

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -1035,8 +1035,8 @@ def _operation_readme_template(operation: OperationMetadata, manifest: AppManife
             "siglume score . --remote",
             "siglume preflight .",
             "siglume register .",
-            "# inspect the draft, then explicitly approve publish:",
-            "siglume register . --confirm",
+            "# review-only staging path:",
+            "siglume register . --draft-only",
             "```",
             "",
         ]
@@ -1956,8 +1956,8 @@ def _readme_template(template: str) -> str:
         siglume score . --remote
         siglume preflight .
         siglume register .
-        # inspect the draft, then explicitly approve publish:
-        siglume register . --confirm
+        # review-only staging path:
+        siglume register . --draft-only
         ```
         """
     ).strip() + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,7 +204,7 @@ def test_register_requires_explicit_tool_manual(tmp_path) -> None:
     project_dir = tmp_path / "missing-manual"
     _write_register_project(project_dir, include_tool_manual=False)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 1
     assert "tool_manual.json is required for `siglume register`" in result.output
@@ -226,7 +226,7 @@ def test_register_blocks_runtime_placeholders_after_publisher_identity_is_real(t
         },
     )
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 1
     assert "runtime_validation.json is not ready for production registration" in result.output
@@ -270,7 +270,7 @@ def test_register_blocks_non_publishable_remote_quality(monkeypatch, tmp_path) -
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 1
     assert "Registration preflight failed" in result.output
@@ -316,7 +316,7 @@ def test_register_allows_api_managed_connected_account_without_oauth_seed(monkey
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 0, result.output
     assert '"listing_id": "lst_api_managed"' in result.output
@@ -439,7 +439,7 @@ def test_register_canonicalizes_oauth_seed_payload(monkeypatch, tmp_path) -> Non
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 0, result.output
     assert '"listing_id": "lst_oauth"' in result.output
@@ -506,7 +506,7 @@ def test_register_canonicalizes_contract_defined_unknown_oauth_provider(monkeypa
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 0, result.output
     assert '"listing_id": "lst_custom_oauth"' in result.output
@@ -530,7 +530,7 @@ def test_register_rejects_string_oauth_scopes(tmp_path) -> None:
         ],
     )
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 1
     assert "required_scopes must be a JSON array" in result.output
@@ -541,7 +541,7 @@ def test_register_rejects_root_docs_url_before_remote_registration(tmp_path) -> 
     project_dir = tmp_path / "root-docs-url"
     _write_register_project(project_dir, docs_url="https://docs.siglume.test")
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 1
     assert "manifest.docs_url must be a dedicated API usage page" in result.output
@@ -590,7 +590,7 @@ def test_register_preflight_allows_tool_manual_warnings(monkeypatch, tmp_path) -
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
-    result = runner.invoke(main, ["register", str(project_dir), "--json"])
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
 
     assert result.exit_code == 0, result.output
     assert '"listing_id": "lst_warning"' in result.output
@@ -684,20 +684,91 @@ def test_register_human_output_includes_review_and_trace_metadata(monkeypatch, t
                 request_id="req_reg",
             )
 
+        def confirm_registration(self, listing_id: str):
+            assert listing_id == "lst_123"
+            return SimpleNamespace(
+                listing_id=listing_id,
+                status="active",
+                release={"release_status": "published"},
+                quality=SimpleNamespace(overall_score=91, grade="A"),
+            )
+
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
     monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
 
     result = runner.invoke(main, ["register", str(project_dir)])
 
     assert result.exit_code == 0, result.output
-    assert "Upgrade staged." in result.output
+    assert "Upgrade registered." in result.output
     assert "receipt_status: draft" in result.output
+    assert "Listing published." in result.output
+    assert "confirmation_status: active" in result.output
+    assert "release_status: published" in result.output
     assert "listing_status: active" in result.output
     assert "oauth_configured: True" in result.output
     assert "review_url: https://siglume.com/owner/publish?listing=lst_123" in result.output
     assert "trace_id: trc_reg" in result.output
     assert "request_id: req_reg" in result.output
     assert "preflight_quality: A (91/100)" in result.output
+
+
+def test_register_draft_only_stops_after_auto_register(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "draft-only"
+    _write_register_project(project_dir)
+
+    class FakeClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def preview_quality_score(self, manual):
+            from siglume_api_sdk import ToolManualQualityReport
+
+            return ToolManualQualityReport(
+                overall_score=91,
+                grade="A",
+                issues=[],
+                keyword_coverage_estimate=72,
+                improvement_suggestions=[],
+                publishable=True,
+                validation_ok=True,
+            )
+
+        def auto_register(self, manifest, tool_manual, **kwargs):
+            return SimpleNamespace(listing_id="lst_draft", status="draft")
+
+        def confirm_registration(self, listing_id: str):
+            raise AssertionError("draft-only must not confirm registration")
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+    monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
+
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only"])
+
+    assert result.exit_code == 0, result.output
+    assert "Draft listing created." in result.output
+    assert "receipt_status: draft" in result.output
+    assert "Listing published." not in result.output
+
+
+def test_register_draft_only_conflicts_with_publish_flags(tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "draft-only-conflict"
+    _write_register_project(project_dir)
+
+    confirm_result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--confirm"])
+    submit_result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--submit-review"])
+
+    assert confirm_result.exit_code == 1
+    assert "--draft-only cannot be combined with --confirm" in confirm_result.output
+    assert submit_result.exit_code == 1
+    assert "--draft-only cannot be combined with --submit-review" in submit_result.output
 
 
 def test_register_submit_review_human_output_uses_publish_wording(monkeypatch, tmp_path) -> None:
@@ -894,7 +965,7 @@ def test_init_command_generates_operation_wrapper_with_grade_b_or_better(monkeyp
         assert "Start locally without a Siglume API key" in readme_text
         assert "Do not commit real review keys or OAuth client secrets" in readme_text
         assert readme_text.index("siglume score . --offline") < readme_text.index("siglume validate .")
-        assert readme_text.index("pytest tests/test_adapter.py") < readme_text.index("siglume register . --confirm")
+        assert readme_text.index("pytest tests/test_adapter.py") < readme_text.index("siglume register .")
 
 
 def test_build_tool_manual_template_tolerates_missing_job_to_be_done() -> None:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -25,11 +25,11 @@ def test_readme_keeps_coding_agent_prompt() -> None:
     assert "docs/coding-agent-guide.md" in readme
     assert "Start as a FREE and READ_ONLY API" in readme
     assert "siglume preflight ." in readme
-    assert "siglume register . --confirm" in readme
-    assert "Do not run `siglume register . --confirm` unless I explicitly approve" in readme
+    assert "siglume register . --draft-only" in readme
+    assert "Do not run `siglume register .` unless I explicitly approve immediate publish" in readme
     assert "## Default beginner path" in agent_guide
     assert "Start with a free, read-only API" in agent_guide
-    assert "Do not run siglume register . --confirm unless I explicitly approve" in agent_guide
+    assert "Do not run plain siglume register . unless I explicitly approve immediate" in agent_guide
     assert "Never commit:" in agent_guide
 
 


### PR DESCRIPTION
## Summary

Brings this public mirror to parity with the private Siglume monorepo at commit `4267bf4` (private `main`).

**Largest change**: new "How buyer inquiries reach you" section in `GETTING_STARTED.md` documenting how the platform routes support inquiry emails for `support_contact`:

- Plain email (`support@your-domain.com`) → that address
- `http(s)://...` URL → falls back to the seller's Siglume account email
- Empty / missing → rejected at registration

This pairs with the buyer-facing UI fix in private [taihei-05/siglume#194](https://github.com/taihei-05/siglume/pull/194), which replaces the seller's raw `support_contact` value on the API detail page with a fixed "Contact support for this API" link to Siglume's internal inquiry form. The two changes together resolve the display-vs-action mismatch (showing a GitHub URL but routing through a different form) and make the email-routing fallback explicit for SDK developers.

## Other accumulated drift in this sync

The remaining 19 files are catching this mirror up on changes that landed in the private SDK tree since the last sync:

- siglume register . CLI default flow (now confirms publication; --draft-only for review-only staging)
- TS SDK CLI: siglume-api-sdk-ts/src/cli/{index,project}.ts updates and matching tests
- CHANGELOG.md, README.md, docs/coding-agent-guide.md, docs/publish-flow.md refreshes
- Generated example READMEs and Python examples (hello_price_compare.py, x_publisher.py)
- Test coverage updates in tests/test_cli.py, tests/test_docs_contract.py

## Verification

After merge, running the mirror sync check from either side should report SDK mirrors are in sync:

  python packages/contracts/sdk/scripts/check_public_sdk_sync.py
  python scripts/check_public_sdk_sync.py --peer-repo https://github.com/taihei-05/siglume.git

20 files changed, 326 insertions(+), 117 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)