### PR TITLE
chore: sync publisher-dev-tools (siglume dev <subcommand>) from Siglume mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `siglume dev` subcommand group exposing publisher-side observability:
+  - `siglume dev gap-report [--days N] [--min-occurrences M] [--limit L]` —
+    cross-publisher anonymized aggregate of "what capability shapes the
+    planner asked for but no installed tool matched" (server enforces
+    `min_occurrences >= 3` floor as singleton-fingerprinting privacy
+    guardrail). High-occurrence shapes are unmet demand a publisher can
+    target.
+  - `siglume dev stats <listing-id> [--days N]` — installs / revenue /
+    executions / success and selection rates for one of your listings.
+  - `siglume dev miss-analysis <listing-id> [--days N]` — why your listing
+    was a candidate but not selected, with actionable improvement reasons
+    and suggested trigger keywords.
+  - `siglume dev keywords <listing-id>` — keyword suggestions to add to
+    your tool manual to improve discoverability (manual coverage vs.
+    high-frequency request words).
+  - `siglume dev tail [--agent-id …] [--status …] [--follow] [--interval S]`
+    — recent execution receipts in the caller's owner scope; `--follow`
+    polls live with dedup across polls. `Ctrl-C` exits gracefully.
+- `SiglumeClient` gains five matching methods (`get_gap_report`,
+  `get_seller_listing_stats`, `get_seller_selection_analysis`,
+  `get_seller_keyword_suggestions`, `list_execution_receipts`). All are
+  thin GET wrappers; buyer prompts, agent IDs, and owner IDs are never
+  in any response payload.
+
+Triggered by [`siglume-api-sdk#186`](https://github.com/taihei-05/siglume-api-sdk/issues/186)
+(publisher observability gap raised by @sanrishi); tracking
+[`siglume-api-sdk#195`](https://github.com/taihei-05/siglume-api-sdk/issues/195).
+
 ### Changed
 
 - `siglume register .` now confirms publication by default after

--- a/siglume_api_sdk/cli/__init__.py
+++ b/siglume_api_sdk/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import click
 
+from siglume_api_sdk.cli.commands.dev_cmd import dev_command
 from siglume_api_sdk.cli.commands.diff_cmd import diff_command
 from siglume_api_sdk.cli.commands.init_cmd import init_command
 from siglume_api_sdk.cli.commands.preflight_cmd import preflight_command
@@ -27,3 +28,4 @@ main.add_command(preflight_command)
 main.add_command(register_command)
 main.add_command(support_command)
 main.add_command(usage_command)
+main.add_command(dev_command)

--- a/siglume_api_sdk/cli/commands/dev_cmd.py
+++ b/siglume_api_sdk/cli/commands/dev_cmd.py
@@ -1,0 +1,342 @@
+"""Publisher developer tools — observability subcommands.
+
+Wraps the /v1/seller/analytics/* and /v1/capability-execution-receipts endpoints
+so publishers can inspect their API's marketplace performance from the CLI.
+
+Subcommands:
+- ``siglume dev gap-report``      : cross-publisher unmet-demand shapes
+- ``siglume dev stats``           : per-listing install / revenue / execution stats
+- ``siglume dev miss-analysis``   : why your listing was candidate-but-not-selected
+- ``siglume dev keywords``        : keyword suggestions for the tool manual
+- ``siglume dev tail``            : tail recent execution receipts (your scope)
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import click
+
+from siglume_api_sdk.cli.project import render_json, resolve_api_key
+from siglume_api_sdk.client import SiglumeAPIError, SiglumeClient
+
+
+@click.group("dev")
+def dev_command() -> None:
+    """Publisher developer tools — observability into your API's marketplace performance.
+
+    Subcommands wrap the seller-analytics and execution-receipts endpoints so
+    you can inspect why your listing is (or isn't) being selected, what
+    capability shapes the planner is asking for but no tool serves, and live
+    execution traces.
+    """
+
+
+# ---------------------------------------------------------------------------
+# gap-report
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("gap-report")
+@click.option("--days", default=30, show_default=True, type=click.IntRange(1, 365))
+@click.option(
+    "--min-occurrences",
+    "min_occ",
+    default=3,
+    show_default=True,
+    type=click.IntRange(3, 1000),
+    help="Floor of 3 enforced server-side as singleton-fingerprinting privacy guardrail.",
+)
+@click.option("--limit", default=50, show_default=True, type=click.IntRange(1, 200))
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+def gap_report_command(
+    days: int, min_occ: int, limit: int, json_output: bool,
+) -> None:
+    """Cross-publisher gap report: capability shapes the planner asked for but no tool matched.
+
+    Anonymized aggregate. Never returns buyer prompts, agent IDs, or owner IDs.
+    Use this to see what publishers should build next — high-occurrence shapes
+    are unmet demand.
+    """
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        data, _ = client.get_gap_report(days=days, min_occurrences=min_occ, limit=limit)
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    shape_count = data.get("shape_count", 0) if isinstance(data, dict) else 0
+    since = data.get("since", "?") if isinstance(data, dict) else "?"
+    until = data.get("until", "?") if isinstance(data, dict) else "?"
+    floor = data.get("min_occurrences", "?") if isinstance(data, dict) else "?"
+    click.secho(f"Gap report: {shape_count} unmet shapes ({since} → {until})", fg="green")
+    click.echo(f"min_occurrences floor: {floor}")
+    if shape_count == 0:
+        click.echo("")
+        click.echo("(No shapes met the threshold yet — instrumentation may need more traffic to accumulate.)")
+        return
+    click.echo("")
+    for shape in (data.get("shapes", []) if isinstance(data, dict) else []):
+        if not isinstance(shape, dict):
+            continue
+        words = ", ".join(str(w) for w in (shape.get("sample_words") or []))
+        shape_hash = str(shape.get("shape_hash", "?"))
+        click.echo(
+            f"- [{int(shape.get('occurrences', 0)):>4}×] "
+            f"miss={str(shape.get('top_miss_kind', '?')):<25} "
+            f"hash={shape_hash[:12]}…  "
+            f"words=[{words}]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# stats
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("stats")
+@click.argument("listing_id")
+@click.option("--days", default=30, show_default=True, type=click.IntRange(0, 3650))
+@click.option("--json", "json_output", is_flag=True)
+def stats_command(listing_id: str, days: int, json_output: bool) -> None:
+    """Per-listing stats: installs, revenue, executions, success and selection rates."""
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        data, _ = client.get_seller_listing_stats(listing_id, days=days)
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    if not isinstance(data, dict):
+        click.secho("Unexpected response shape.", fg="red", err=True)
+        return
+
+    click.secho(f"Listing {listing_id} ({data.get('period_days', days)} days)", fg="green")
+    click.echo(
+        f"  Installs:    total={data.get('total_bindings', 0)}, "
+        f"active={data.get('active_bindings', 0)}"
+    )
+    click.echo(
+        f"  Revenue:     period={data.get('period_revenue_minor', 0)} "
+        f"{data.get('revenue_currency', '?')} (minor units)"
+    )
+    click.echo(
+        f"  Executions:  total={data.get('total_executions', 0)}, "
+        f"success_rate={data.get('success_rate_pct', 0)}%"
+    )
+    click.echo(
+        f"  Selection:   candidate={data.get('times_candidate', 0)}, "
+        f"selected={data.get('times_selected', 0)}, "
+        f"rate={data.get('selection_rate_pct', 0)}%"
+    )
+    click.echo(
+        f"  Latency:     avg={data.get('avg_latency_ms')}ms "
+        f"p95={data.get('p95_latency_ms')}ms"
+    )
+
+
+# ---------------------------------------------------------------------------
+# miss-analysis
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("miss-analysis")
+@click.argument("listing_id")
+@click.option("--days", default=30, show_default=True, type=click.IntRange(1, 365))
+@click.option("--json", "json_output", is_flag=True)
+def miss_analysis_command(listing_id: str, days: int, json_output: bool) -> None:
+    """Why your listing was a CANDIDATE but NOT selected — improvement suggestions."""
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        data, _ = client.get_seller_selection_analysis(listing_id, days=days)
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    if not isinstance(data, dict):
+        click.secho("Unexpected response shape.", fg="red", err=True)
+        return
+
+    total = data.get("total_missed", 0)
+    click.secho(
+        f"Listing {listing_id}: {total} candidate-but-not-selected events ({days} days)",
+        fg="green",
+    )
+    reasons = data.get("reasons") or []
+    for reason in reasons:
+        if not isinstance(reason, dict):
+            continue
+        click.echo(
+            f"- {reason.get('reason', '?')}: "
+            f"{reason.get('count', 0)} ({reason.get('percentage', 0)}%) — "
+            f"{reason.get('suggestion', '')}"
+        )
+    competing = data.get("top_competing_tools") or []
+    if competing:
+        click.echo("")
+        click.echo("Top competing tools (winners):")
+        for c in competing[:5]:
+            click.echo(f"  - {c}")
+    suggested = data.get("suggested_trigger_keywords") or []
+    if suggested:
+        click.echo("")
+        click.echo(f"Suggested trigger keywords to add: {', '.join(str(s) for s in suggested)}")
+
+
+# ---------------------------------------------------------------------------
+# keywords
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("keywords")
+@click.argument("listing_id")
+@click.option("--json", "json_output", is_flag=True)
+def keywords_command(listing_id: str, json_output: bool) -> None:
+    """Keyword suggestions to add to your tool manual to improve discoverability."""
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        data, _ = client.get_seller_keyword_suggestions(listing_id)
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    if not isinstance(data, dict):
+        click.secho("Unexpected response shape.", fg="red", err=True)
+        return
+
+    click.secho(f"Keyword suggestions for {listing_id}", fg="green")
+    current = data.get("current_keywords") or []
+    missing = data.get("missing_keywords") or []
+    high_freq = data.get("high_frequency_request_words") or []
+    suggestions = data.get("suggestions") or []
+    click.echo(f"Current ({len(current)}): {', '.join(str(w) for w in current)}")
+    click.echo(f"Missing from manual ({len(missing)}): {', '.join(str(w) for w in missing)}")
+    click.echo(
+        f"High-frequency request words ({len(high_freq)}): "
+        f"{', '.join(str(w) for w in high_freq)}"
+    )
+    click.echo(f"Suggested additions: {', '.join(str(w) for w in suggestions)}")
+
+
+# ---------------------------------------------------------------------------
+# tail
+# ---------------------------------------------------------------------------
+
+
+def _format_receipt_line(r: dict[str, Any]) -> str:
+    return (
+        f"{r.get('created_at', '?')} "
+        f"agent={(str(r.get('agent_id') or '?'))[:8]} "
+        f"status={str(r.get('status', '?')):<10} "
+        f"steps={r.get('step_count', 0)} "
+        f"latency={r.get('total_latency_ms', '?')}ms "
+        f"id={(str(r.get('id') or '?'))[:8]}"
+    )
+
+
+@dev_command.command("tail")
+@click.option("--agent-id", default=None, help="Filter by agent_id.")
+@click.option(
+    "--status",
+    default=None,
+    help="Filter by status (pending / running / completed / failed).",
+)
+@click.option(
+    "--limit",
+    default=20,
+    show_default=True,
+    type=click.IntRange(1, 100),
+    help="Receipts to fetch per poll.",
+)
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    help="Continuously poll for new receipts (Ctrl-C to stop).",
+)
+@click.option(
+    "--interval",
+    default=5,
+    show_default=True,
+    type=click.IntRange(1, 600),
+    help="Poll interval in seconds when --follow is set.",
+)
+@click.option("--json", "json_output", is_flag=True)
+def tail_command(
+    agent_id: str | None,
+    status: str | None,
+    limit: int,
+    follow: bool,
+    interval: int,
+    json_output: bool,
+) -> None:
+    """Tail recent execution receipts (your owner scope only).
+
+    With --follow, polls every --interval seconds and prints new receipts as
+    they appear. Without --follow, prints the most recent --limit receipts and
+    exits.
+    """
+    api_key = resolve_api_key()
+    seen_ids: set[str] = set()
+
+    def _coerce_receipts(data: Any) -> list[Any]:
+        if isinstance(data, list):
+            return data
+        click.secho(
+            "Unexpected response shape (expected list of receipts).",
+            fg="red", err=True,
+        )
+        return []
+
+    def _emit(receipts: list[Any]) -> None:
+        # Reverse so the oldest in the page prints first; new receipts appear
+        # at the bottom (typical tail behavior). Within a single --follow loop
+        # we dedup by ID across polls; ordering across polls is best-effort.
+        for r in reversed(receipts):
+            if not isinstance(r, dict):
+                continue
+            rid = str(r.get("id") or "")
+            if not rid or rid in seen_ids:
+                continue
+            seen_ids.add(rid)
+            if json_output:
+                click.echo(render_json(r))
+            else:
+                click.echo(_format_receipt_line(r))
+
+    try:
+        with SiglumeClient(api_key=api_key) as client:
+            try:
+                data, _ = client.list_execution_receipts(
+                    agent_id=agent_id, status=status, limit=limit,
+                )
+            except SiglumeAPIError as exc:
+                click.secho(f"API error: {exc}", fg="red", err=True)
+                raise click.Abort() from exc
+            _emit(_coerce_receipts(data))
+
+            if not follow:
+                return
+
+            click.secho(
+                f"\n[follow mode, polling every {interval}s, Ctrl-C to stop]",
+                fg="cyan", err=True,
+            )
+            while True:
+                time.sleep(interval)
+                try:
+                    data, _ = client.list_execution_receipts(
+                        agent_id=agent_id, status=status, limit=limit,
+                    )
+                except SiglumeAPIError as exc:
+                    click.secho(f"poll error: {exc}", fg="yellow", err=True)
+                    continue
+                _emit(_coerce_receipts(data))
+    except KeyboardInterrupt:
+        # Catches Ctrl-C during initial fetch AND during follow-loop sleep/poll.
+        click.echo("", err=True)
+        click.secho("[interrupted]", fg="cyan", err=True)

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3293,6 +3293,90 @@ class SiglumeClient:
         )
         return _parse_sandbox_session(data, meta)
 
+    # ------------------------------------------------------------------
+    # Publisher dev tools (Phase 1) — observability into marketplace performance
+    # ------------------------------------------------------------------
+
+    def get_gap_report(
+        self,
+        *,
+        days: int = 30,
+        min_occurrences: int = 3,
+        limit: int = 50,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Cross-publisher gap report: capability shapes the planner asked for but no tool matched.
+
+        Anonymized aggregate. Server enforces ``min_occurrences >= 3`` floor as
+        privacy guardrail against singleton fingerprinting. Never includes
+        buyer prompts, agent IDs, or owner IDs.
+        """
+        params: dict[str, Any] = {
+            "days": int(days),
+            "min_occurrences": int(min_occurrences),
+            "limit": int(limit),
+        }
+        return self._request("GET", "/seller/analytics/gap-report", params=params)
+
+    def get_seller_listing_stats(
+        self,
+        listing_id: str,
+        *,
+        days: int = 30,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Per-listing stats — installs, revenue, executions, success and selection rates."""
+        return self._request(
+            "GET",
+            f"/seller/analytics/listings/{listing_id}/stats",
+            params={"days": int(days)},
+        )
+
+    def get_seller_selection_analysis(
+        self,
+        listing_id: str,
+        *,
+        days: int = 30,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Why your listing was a candidate but NOT selected — actionable improvement signal."""
+        return self._request(
+            "GET",
+            f"/seller/analytics/listings/{listing_id}/selection-analysis",
+            params={"days": int(days)},
+        )
+
+    def get_seller_keyword_suggestions(
+        self,
+        listing_id: str,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Keyword suggestions to add to the tool manual to improve discoverability."""
+        return self._request(
+            "GET",
+            f"/seller/analytics/listings/{listing_id}/keyword-suggestions",
+        )
+
+    def list_execution_receipts(
+        self,
+        *,
+        agent_id: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], EnvelopeMeta]:
+        """List recent execution receipts in the caller's owner scope.
+
+        Returns a list of receipt dicts (most recent first). Used by
+        ``siglume dev tail`` to surface live execution activity to publishers
+        debugging their own listing's behavior.
+        """
+        params: dict[str, Any] = {
+            "limit": int(limit),
+            "offset": int(offset),
+        }
+        if agent_id:
+            params["agent_id"] = str(agent_id)
+        if status:
+            params["status"] = str(status)
+        return self._request("GET", "/capability-execution-receipts", params=params)
+
     def get_usage(
         self,
         *,

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -1,0 +1,486 @@
+"""Tests for `siglume dev <subcommand>` publisher dev tools.
+
+Covers all 5 subcommands (gap-report / stats / miss-analysis / keywords / tail)
+plus the registration of `dev` as a CLI group on `main`. SiglumeClient is
+replaced with a FakeClient so tests don't hit the network.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from siglume_api_sdk.cli import main  # noqa: E402
+from siglume_api_sdk.cli.commands import dev_cmd as dev_cmd_module  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# FakeClient — captures call args, returns configurable payloads
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    """Drop-in replacement for SiglumeClient in dev_cmd tests."""
+
+    last_call: tuple[str, dict[str, Any]] | None = None
+
+    def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
+        self.api_key = api_key
+
+    def __enter__(self) -> "FakeClient":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    def get_gap_report(
+        self, *, days: int, min_occurrences: int, limit: int,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "get_gap_report",
+            {"days": days, "min_occurrences": min_occurrences, "limit": limit},
+        )
+        return (
+            {
+                "since": "2026-04-01T00:00:00+00:00",
+                "until": "2026-05-01T00:00:00+00:00",
+                "min_occurrences": min_occurrences,
+                "shape_count": 2,
+                "shapes": [
+                    {
+                        "shape_hash": "abcdef0123456789" * 4,
+                        "sample_words": ["translate", "japanese", "deepl"],
+                        "occurrences": 47,
+                        "top_miss_kind": "no_keyword_match",
+                        "latest_seen_at": "2026-04-30T12:00:00+00:00",
+                    },
+                    {
+                        "shape_hash": "9999999999999999" * 4,
+                        "sample_words": ["notion", "append", "page"],
+                        "occurrences": 12,
+                        "top_miss_kind": "no_keyword_match",
+                        "latest_seen_at": "2026-04-29T08:30:00+00:00",
+                    },
+                ],
+            },
+            None,
+        )
+
+    def get_seller_listing_stats(
+        self, listing_id: str, *, days: int,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "get_seller_listing_stats",
+            {"listing_id": listing_id, "days": days},
+        )
+        return (
+            {
+                "listing_id": listing_id,
+                "period_days": days,
+                "total_bindings": 14,
+                "active_bindings": 11,
+                "period_revenue_minor": 3300,
+                "revenue_currency": "USD",
+                "total_executions": 240,
+                "success_rate_pct": 96.7,
+                "times_candidate": 380,
+                "times_selected": 250,
+                "selection_rate_pct": 65.8,
+                "avg_latency_ms": 380.5,
+                "p95_latency_ms": 920,
+            },
+            None,
+        )
+
+    def get_seller_selection_analysis(
+        self, listing_id: str, *, days: int,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "get_seller_selection_analysis",
+            {"listing_id": listing_id, "days": days},
+        )
+        return (
+            {
+                "listing_id": listing_id,
+                "total_missed": 130,
+                "reasons": [
+                    {
+                        "reason": "missing_trigger_keyword",
+                        "count": 80,
+                        "percentage": 61.5,
+                        "suggestion": "Add 'translate' to usage_hints.",
+                    },
+                ],
+                "top_competing_tools": ["t_translate_winner_a", "t_translate_winner_b"],
+                "suggested_trigger_keywords": ["translate", "english", "japanese"],
+            },
+            None,
+        )
+
+    def get_seller_keyword_suggestions(
+        self, listing_id: str,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "get_seller_keyword_suggestions",
+            {"listing_id": listing_id},
+        )
+        return (
+            {
+                "listing_id": listing_id,
+                "current_keywords": ["alpha", "beta"],
+                "missing_keywords": ["gamma"],
+                "high_frequency_request_words": ["translate", "japanese"],
+                "suggestions": ["gamma", "translate"],
+            },
+            None,
+        )
+
+    def list_execution_receipts(
+        self,
+        *,
+        agent_id: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], Any]:
+        FakeClient.last_call = (
+            "list_execution_receipts",
+            {"agent_id": agent_id, "status": status, "limit": limit, "offset": offset},
+        )
+        return (
+            [
+                {
+                    "id": "receipt_a_0001",
+                    "agent_id": "agent_xyz_0001",
+                    "status": "completed",
+                    "step_count": 3,
+                    "total_latency_ms": 410,
+                    "created_at": "2026-05-01T05:30:00+00:00",
+                },
+                {
+                    "id": "receipt_b_0002",
+                    "agent_id": "agent_xyz_0002",
+                    "status": "failed",
+                    "step_count": 1,
+                    "total_latency_ms": 80,
+                    "created_at": "2026-05-01T05:29:30+00:00",
+                },
+            ],
+            None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_client(monkeypatch) -> None:
+    """Swap SiglumeClient + resolve_api_key in the dev_cmd namespace."""
+    monkeypatch.setattr(dev_cmd_module, "SiglumeClient", FakeClient)
+    monkeypatch.setattr(dev_cmd_module, "resolve_api_key", lambda: "sig_test_key")
+    FakeClient.last_call = None
+
+
+# ---------------------------------------------------------------------------
+# Group registration
+# ---------------------------------------------------------------------------
+
+
+def test_dev_command_is_registered_on_main():
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "--help"])
+    assert result.exit_code == 0
+    # All 5 subcommands listed
+    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail"):
+        assert sub in result.output, f"subcommand {sub!r} missing from `siglume dev --help`"
+
+
+# ---------------------------------------------------------------------------
+# gap-report
+# ---------------------------------------------------------------------------
+
+
+def test_dev_gap_report_default_flags(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "gap-report"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_gap_report",
+        {"days": 30, "min_occurrences": 3, "limit": 50},
+    )
+    # Human-readable output renders shape lines
+    assert "2 unmet shapes" in result.output
+    assert "translate" in result.output
+    assert "47" in result.output
+
+
+def test_dev_gap_report_json_flag(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["dev", "gap-report", "--days", "7", "--limit", "10", "--json"],
+    )
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_gap_report",
+        {"days": 7, "min_occurrences": 3, "limit": 10},
+    )
+    payload = json.loads(result.output)
+    assert payload["shape_count"] == 2
+    assert payload["shapes"][0]["sample_words"] == ["translate", "japanese", "deepl"]
+
+
+def test_dev_gap_report_min_occurrences_below_3_rejected(monkeypatch):
+    """Click IntRange(3, 1000) on --min-occurrences enforces the privacy floor at the CLI layer."""
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "gap-report", "--min-occurrences", "1"])
+    assert result.exit_code != 0
+    assert "Invalid value for '--min-occurrences'" in result.output or "is not in" in result.output
+
+
+# ---------------------------------------------------------------------------
+# stats
+# ---------------------------------------------------------------------------
+
+
+def test_dev_stats_renders_core_fields(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "stats", "listing_abc_123"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_seller_listing_stats",
+        {"listing_id": "listing_abc_123", "days": 30},
+    )
+    assert "listing_abc_123" in result.output
+    assert "Installs:" in result.output
+    assert "Selection:" in result.output
+    assert "65.8" in result.output  # selection_rate_pct
+
+
+def test_dev_stats_json(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["dev", "stats", "listing_abc_123", "--days", "90", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["listing_id"] == "listing_abc_123"
+    assert payload["period_days"] == 90
+    assert FakeClient.last_call == (
+        "get_seller_listing_stats",
+        {"listing_id": "listing_abc_123", "days": 90},
+    )
+
+
+# ---------------------------------------------------------------------------
+# miss-analysis
+# ---------------------------------------------------------------------------
+
+
+def test_dev_miss_analysis_shows_reasons_and_suggestions(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "miss-analysis", "listing_abc_123"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_seller_selection_analysis",
+        {"listing_id": "listing_abc_123", "days": 30},
+    )
+    assert "130 candidate-but-not-selected" in result.output
+    assert "missing_trigger_keyword" in result.output
+    assert "Suggested trigger keywords" in result.output
+    assert "translate" in result.output
+
+
+# ---------------------------------------------------------------------------
+# keywords
+# ---------------------------------------------------------------------------
+
+
+def test_dev_keywords_lists_buckets(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "keywords", "listing_xyz_777"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_seller_keyword_suggestions",
+        {"listing_id": "listing_xyz_777"},
+    )
+    assert "Current (2)" in result.output
+    assert "Missing from manual (1)" in result.output
+    assert "gamma" in result.output
+
+
+# ---------------------------------------------------------------------------
+# tail
+# ---------------------------------------------------------------------------
+
+
+def test_dev_tail_default_one_shot(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "list_execution_receipts",
+        {"agent_id": None, "status": None, "limit": 20, "offset": 0},
+    )
+    # Two receipt lines, oldest-first (ID prefixes shown)
+    assert "receipt_" in result.output
+    assert "completed" in result.output
+    assert "failed" in result.output
+
+
+def test_dev_tail_passes_filters(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["dev", "tail", "--agent-id", "agent_x", "--status", "completed", "--limit", "5"],
+    )
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "list_execution_receipts",
+        {"agent_id": "agent_x", "status": "completed", "limit": 5, "offset": 0},
+    )
+
+
+def test_dev_tail_json_emits_per_receipt(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail", "--json"])
+    assert result.exit_code == 0
+    # Each receipt is a separate JSON object, one per line block
+    lines = [line for line in result.output.split("\n}") if line.strip()]
+    # We don't fully reparse — just assert the shape signal IDs are present
+    assert "receipt_a_0001" in result.output
+    assert "receipt_b_0002" in result.output
+
+
+def test_dev_tail_dedups_within_a_page(monkeypatch):
+    """If a page contains the same receipt twice, dedup suppresses the second."""
+    _patch_client(monkeypatch)
+
+    duplicated_payload = (
+        [
+            {
+                "id": "receipt_dup_0001",
+                "agent_id": "agent_z_0001",
+                "status": "completed",
+                "step_count": 1,
+                "total_latency_ms": 50,
+                "created_at": "2026-05-01T06:00:00+00:00",
+            },
+            {
+                "id": "receipt_dup_0001",  # duplicate ID
+                "agent_id": "agent_z_0001",
+                "status": "completed",
+                "step_count": 1,
+                "total_latency_ms": 50,
+                "created_at": "2026-05-01T06:00:00+00:00",
+            },
+        ],
+        None,
+    )
+
+    def _list_receipts(self, **_kwargs):
+        return duplicated_payload
+
+    monkeypatch.setattr(
+        FakeClient, "list_execution_receipts", _list_receipts,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail"])
+    assert result.exit_code == 0
+    # ID appears only once in the rendered output despite duplicate in page
+    assert result.output.count("receipt_") == 1
+
+
+def test_dev_tail_dedups_across_follow_polls(monkeypatch):
+    """Across multiple --follow polls, the same receipt seen twice is printed only once."""
+    _patch_client(monkeypatch)
+
+    base_receipt = {
+        "id": "receipt_follow_0001",
+        "agent_id": "agent_y",
+        "status": "completed",
+        "step_count": 2,
+        "total_latency_ms": 200,
+        "created_at": "2026-05-01T07:00:00+00:00",
+    }
+
+    poll_count = {"n": 0}
+
+    def _list_receipts(self, **_kwargs):
+        poll_count["n"] += 1
+        # Every poll returns the SAME receipt — dedup must suppress repeats
+        return ([dict(base_receipt)], None)
+
+    monkeypatch.setattr(
+        FakeClient, "list_execution_receipts", _list_receipts,
+    )
+
+    # Break the follow loop after 3 polls by raising KeyboardInterrupt from sleep
+    sleep_calls = {"n": 0}
+
+    def _fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] >= 2:
+            raise KeyboardInterrupt()
+
+    monkeypatch.setattr(dev_cmd_module.time, "sleep", _fake_sleep)
+
+    runner = CliRunner()
+    # Use --json mode so the full ID is in the output (line-renderer truncates IDs to 8 chars)
+    result = runner.invoke(
+        main, ["dev", "tail", "--follow", "--interval", "1", "--json"],
+    )
+    assert result.exit_code == 0
+    # The receipt ID should appear exactly once in stdout despite N polls returning it
+    assert result.output.count("receipt_follow_0001") == 1
+    # And we did poll multiple times (proving the dedup test was meaningful)
+    assert poll_count["n"] >= 2
+
+
+def test_dev_tail_unexpected_response_shape_emits_warning(monkeypatch):
+    """If the API returns a dict instead of a list, the user sees a clear warning."""
+    _patch_client(monkeypatch)
+
+    def _list_receipts(self, **_kwargs):
+        return ({"unexpected": "dict-not-list"}, None)
+
+    monkeypatch.setattr(
+        FakeClient, "list_execution_receipts", _list_receipts,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail"])
+    assert result.exit_code == 0
+    assert "Unexpected response shape" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Help text sanity (no traceback, helpful)
+# ---------------------------------------------------------------------------
+
+
+def test_dev_subcommand_help_renders():
+    runner = CliRunner()
+    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail"):
+        result = runner.invoke(main, ["dev", sub, "--help"])
+        assert result.exit_code == 0, f"`siglume dev {sub} --help` exited {result.exit_code}"
+        assert sub.replace("-", "") in result.output.lower() or "Usage:" in result.output

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -363,9 +363,8 @@ def test_dev_tail_json_emits_per_receipt(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(main, ["dev", "tail", "--json"])
     assert result.exit_code == 0
-    # Each receipt is a separate JSON object, one per line block
-    lines = [line for line in result.output.split("\n}") if line.strip()]
-    # We don't fully reparse — just assert the shape signal IDs are present
+    # Each receipt renders as its own JSON object (one per --json invocation per id);
+    # we assert presence by ID rather than reparsing the full stream.
     assert "receipt_a_0001" in result.output
     assert "receipt_b_0002" in result.output
 


### PR DESCRIPTION
## Summary

Mirrors [taihei-05/siglume#196](https://github.com/taihei-05/siglume/pull/196) (feat(sdk): `siglume dev <subcommand>` publisher dev tools) from the private monorepo's `packages/contracts/sdk/` mirror to this public repo, per `RELEASING.md` mirror rule.

## What's added

A new `siglume dev` CLI group with 5 subcommands wrapping the publisher-side observability surface that just shipped in production (backend PR taihei-05/siglume#193 + migration `0094_unmatched_capability_requests`):

| Subcommand | Purpose |
|---|---|
| `siglume dev gap-report` | Cross-publisher anonymized aggregate of capability shapes the planner asked for but no installed tool matched. `--min-occurrences` floor of 3 enforced both client- and server-side. |
| `siglume dev stats <listing-id>` | Installs / revenue / executions / success rate / selection rate / latency for one of your listings. |
| `siglume dev miss-analysis <listing-id>` | Why your listing was a candidate but not selected, with reasons + suggested trigger keywords. |
| `siglume dev keywords <listing-id>` | Keyword suggestions for the tool manual to improve discoverability. |
| `siglume dev tail [--follow]` | Recent execution receipts (caller's owner scope), with optional live polling and dedup across polls. |

`SiglumeClient` gains 5 matching thin GET methods.

## Why now

Triggered by [#186](https://github.com/taihei-05/siglume-api-sdk/issues/186) (publisher observability gap raised by @sanrishi); tracking [#195](https://github.com/taihei-05/siglume-api-sdk/issues/195).

Backend was merged + deployed earlier today (Migration `0094_unmatched_capability_requests` is live, `GET /v1/seller/analytics/gap-report` is callable now via curl). This PR closes the loop on the SDK side so publishers can drive the new observability from the CLI.

## Privacy invariants (preserved)

- `gap-report` responses contain only sorted unique tokens per shape — never buyer prompts, agent IDs, or owner IDs (server-enforced, SDK passes through unchanged).
- CLI `--min-occurrences` clamped to `IntRange(3, 1000)` so users cannot accidentally request a sub-3 floor that would weaken the singleton-fingerprinting privacy guardrail.
- All per-listing endpoints inherit Q3 server-side (`principal_user_id == current_user.id`); `tail` inherits Q3 on receipts (`owner_user_id == current_user.id`). The SDK does not introduce any path that escapes scope.

## Test plan

- [x] `pytest tests/test_dev_cli.py` — 15/15 pass
- [x] `pytest tests/test_cli.py` — 31/31 pass (no regression)
- [x] `pytest tests/test_client.py` — 50/50 pass (no regression)
- [x] Mirror drift detector now matches: source-of-truth `packages/contracts/sdk/` ↔ this PR ↔ public `taihei-05/siglume-api-sdk` will be in sync after merge.

## Release

No version bump in this PR — `[Unreleased]` section in CHANGELOG only. Next PyPI tag will batch this with other unreleased work, per `RELEASING.md` `## Pre-release checklist` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)