### PR TITLE
chore: sync Phase 2 publisher dev tools (simulate + tail --listing-id) from monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `siglume dev simulate "<offer text>"` (Phase 2) — predict the orchestrator's
+  tool chain for an offer text without executing any dispatches. Calls
+  Anthropic Haiku against the public catalog (top 50 listings, keyword
+  pre-filtered to top 10 candidates). Server-side rate-limited to **10 calls
+  per publisher per UTC day**; the response includes ``quota_used_today`` so
+  you can pace yourself. Use this to test "would my next API be picked for
+  offers like this?" before publishing. `429` quota responses surface a
+  friendly message via `SiglumeAPIError.details` (no stack trace).
+- `siglume dev tail --listing-id <id>` (Phase 2) — tail receipts that touched
+  a listing you own (publisher-scoped Q3 boundary). Returns structural
+  metadata only (status, counts, timing) — agent IDs, owner IDs, summary, and
+  failure_reason are intentionally NOT in the response, so you can monitor
+  inbound traffic on your published listings without seeing identifying buyer
+  detail or other publishers' tool outputs in multi-step chains.
+- `SiglumeClient.simulate_planner` and `SiglumeClient.list_listing_recent_receipts`
+  — matching client methods.
 - New `siglume dev` subcommand group exposing publisher-side observability:
   - `siglume dev gap-report [--days N] [--min-occurrences M] [--limit L]` —
     cross-publisher anonymized aggregate of "what capability shapes the

--- a/siglume_api_sdk/cli/commands/dev_cmd.py
+++ b/siglume_api_sdk/cli/commands/dev_cmd.py
@@ -16,7 +16,6 @@ import time
 from typing import Any
 
 import click
-
 from siglume_api_sdk.cli.project import render_json, resolve_api_key
 from siglume_api_sdk.client import SiglumeAPIError, SiglumeClient
 
@@ -74,7 +73,10 @@ def gap_report_command(
     click.echo(f"min_occurrences floor: {floor}")
     if shape_count == 0:
         click.echo("")
-        click.echo("(No shapes met the threshold yet — instrumentation may need more traffic to accumulate.)")
+        click.echo(
+            "(No shapes met the threshold yet — "
+            "instrumentation may need more traffic to accumulate.)"
+        )
         return
     click.echo("")
     for shape in (data.get("shapes", []) if isinstance(data, dict) else []):
@@ -228,22 +230,38 @@ def keywords_command(listing_id: str, json_output: bool) -> None:
 
 
 def _format_receipt_line(r: dict[str, Any]) -> str:
+    """Render one receipt line. Handles both shapes:
+    - own-agent (has ``id`` + ``agent_id``)
+    - listing-scoped (has ``receipt_id``, NO agent_id by design)
+    """
+    rid = str(r.get("receipt_id") or r.get("id") or "?")
+    agent = r.get("agent_id")
+    agent_part = f"agent={(str(agent))[:8]} " if agent is not None else ""
     return (
         f"{r.get('created_at', '?')} "
-        f"agent={(str(r.get('agent_id') or '?'))[:8]} "
+        f"{agent_part}"
         f"status={str(r.get('status', '?')):<10} "
         f"steps={r.get('step_count', 0)} "
         f"latency={r.get('total_latency_ms', '?')}ms "
-        f"id={(str(r.get('id') or '?'))[:8]}"
+        f"id={rid[:8]}"
     )
 
 
 @dev_command.command("tail")
-@click.option("--agent-id", default=None, help="Filter by agent_id.")
+@click.option(
+    "--listing-id",
+    default=None,
+    help=(
+        "Tail receipts that touched this publisher-owned listing "
+        "(Q3-scoped to listings you own). Without this flag, tails YOUR "
+        "OWN agent's recent receipts (debugging-your-own-agent view)."
+    ),
+)
+@click.option("--agent-id", default=None, help="Filter by agent_id (own-agent mode only).")
 @click.option(
     "--status",
     default=None,
-    help="Filter by status (pending / running / completed / failed).",
+    help="Filter by status (pending / running / completed / failed). Own-agent mode only.",
 )
 @click.option(
     "--limit",
@@ -267,6 +285,7 @@ def _format_receipt_line(r: dict[str, Any]) -> str:
 )
 @click.option("--json", "json_output", is_flag=True)
 def tail_command(
+    listing_id: str | None,
     agent_id: str | None,
     status: str | None,
     limit: int,
@@ -274,12 +293,26 @@ def tail_command(
     interval: int,
     json_output: bool,
 ) -> None:
-    """Tail recent execution receipts (your owner scope only).
+    """Tail recent execution receipts.
 
-    With --follow, polls every --interval seconds and prints new receipts as
-    they appear. Without --follow, prints the most recent --limit receipts and
+    Two modes:
+      - default (no --listing-id): tails YOUR OWN agent's recent receipts
+        (Q3-scoped to current_user.id). Useful for debugging your own
+        agent's tool usage. Filters: --agent-id, --status.
+      - --listing-id <id>: tails receipts that touched a publisher-owned
+        listing you own. Returns structural metadata only (no agent IDs,
+        no summaries, no failure reasons) — privacy-safe across the
+        publisher boundary.
+
+    With --follow, polls every --interval seconds and prints new receipts
+    as they appear. Without --follow, prints the most recent --limit and
     exits.
     """
+    if listing_id and (agent_id or status):
+        click.secho(
+            "Note: --agent-id and --status are ignored in listing-scoped mode.",
+            fg="yellow", err=True,
+        )
     api_key = resolve_api_key()
     seen_ids: set[str] = set()
 
@@ -299,7 +332,8 @@ def tail_command(
         for r in reversed(receipts):
             if not isinstance(r, dict):
                 continue
-            rid = str(r.get("id") or "")
+            # Listing-scoped responses use 'receipt_id'; owner-scoped use 'id'
+            rid = str(r.get("receipt_id") or r.get("id") or "")
             if not rid or rid in seen_ids:
                 continue
             seen_ids.add(rid)
@@ -308,12 +342,19 @@ def tail_command(
             else:
                 click.echo(_format_receipt_line(r))
 
+    def _fetch(client: SiglumeClient) -> Any:
+        if listing_id:
+            data, _ = client.list_listing_recent_receipts(listing_id, limit=limit)
+        else:
+            data, _ = client.list_execution_receipts(
+                agent_id=agent_id, status=status, limit=limit,
+            )
+        return data
+
     try:
         with SiglumeClient(api_key=api_key) as client:
             try:
-                data, _ = client.list_execution_receipts(
-                    agent_id=agent_id, status=status, limit=limit,
-                )
+                data = _fetch(client)
             except SiglumeAPIError as exc:
                 click.secho(f"API error: {exc}", fg="red", err=True)
                 raise click.Abort() from exc
@@ -329,9 +370,7 @@ def tail_command(
             while True:
                 time.sleep(interval)
                 try:
-                    data, _ = client.list_execution_receipts(
-                        agent_id=agent_id, status=status, limit=limit,
-                    )
+                    data = _fetch(client)
                 except SiglumeAPIError as exc:
                     click.secho(f"poll error: {exc}", fg="yellow", err=True)
                     continue
@@ -340,3 +379,106 @@ def tail_command(
         # Catches Ctrl-C during initial fetch AND during follow-loop sleep/poll.
         click.echo("", err=True)
         click.secho("[interrupted]", fg="cyan", err=True)
+
+
+# ---------------------------------------------------------------------------
+# simulate
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("simulate")
+@click.argument("offer_text")
+@click.option(
+    "--max-candidates",
+    default=10,
+    show_default=True,
+    type=click.IntRange(1, 20),
+    help="Cap on how many catalog tools to send to the LLM as candidates.",
+)
+@click.option("--json", "json_output", is_flag=True)
+def simulate_command(
+    offer_text: str, max_candidates: int, json_output: bool,
+) -> None:
+    """Predict the orchestrator's tool chain for an offer text WITHOUT executing it.
+
+    Useful for testing "would my next API be picked for offers like this?"
+    before publishing. Rate-limited server-side at 10 calls / publisher /
+    UTC day; the response includes ``quota_used_today`` so you can pace
+    yourself.
+
+    Example:
+
+        siglume dev simulate "translate english doc to japanese, post to notion"
+    """
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        try:
+            data, _ = client.simulate_planner(
+                offer_text=offer_text, max_candidates=max_candidates,
+            )
+        except SiglumeAPIError as exc:
+            # 429 quota → friendly message
+            if getattr(exc, "status_code", None) == 429:
+                details = getattr(exc, "details", None) or {}
+                quota_used = details.get("quota_used_today", "?")
+                quota_limit = details.get("quota_limit", "?")
+                reset_at = details.get("reset_at", "?")
+                click.secho(
+                    f"Daily simulate quota exceeded ({quota_used}/{quota_limit}). "
+                    f"Resets at {reset_at}.",
+                    fg="yellow", err=True,
+                )
+                raise click.Abort() from exc
+            click.secho(f"API error: {exc}", fg="red", err=True)
+            raise click.Abort() from exc
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    if not isinstance(data, dict):
+        click.secho("Unexpected response shape.", fg="red", err=True)
+        return
+
+    catalog_size = data.get("catalog_size", 0)
+    candidates = data.get("candidates_considered", 0)
+    chain = data.get("predicted_chain") or []
+    quota_used = data.get("quota_used_today", 0)
+    quota_limit = data.get("quota_limit", 0)
+    note = data.get("note")
+    model = data.get("model", "?")
+
+    click.secho(
+        f"Simulated against {catalog_size} catalog listings "
+        f"({candidates} considered) — model={model}",
+        fg="green",
+    )
+    if not chain:
+        click.echo("")
+        click.secho(
+            "Predicted chain: (empty)",
+            fg="yellow",
+        )
+        if note:
+            click.echo(f"  reason: {note}")
+    else:
+        click.echo("")
+        click.echo("Predicted chain:")
+        for i, call in enumerate(chain, 1):
+            if not isinstance(call, dict):
+                continue
+            click.echo(
+                f"  {i}. {call.get('tool_name', '?')} "
+                f"(listing={call.get('listing_id', '?')[:8]}…, "
+                f"title='{call.get('listing_title', '?')}')"
+            )
+            args = call.get("args") or {}
+            if args:
+                arg_summary = ", ".join(f"{k}={v!r}" for k, v in list(args.items())[:3])
+                click.echo(f"     args: {arg_summary}")
+        if note:
+            click.echo("")
+            click.echo(f"note: {note}")
+
+    click.echo("")
+    click.echo(f"Quota: {quota_used}/{quota_limit} used today")

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3377,6 +3377,47 @@ class SiglumeClient:
             params["status"] = str(status)
         return self._request("GET", "/capability-execution-receipts", params=params)
 
+    def list_listing_recent_receipts(
+        self,
+        listing_id: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], EnvelopeMeta]:
+        """Receipts where any step touched this publisher's listing.
+
+        Publisher-scoped (Q3): caller must own the listing. Returns receipts
+        that surface execution metadata only — buyer agent IDs, owner IDs,
+        summary, and failure_reason are intentionally NOT in the response.
+        Used by ``siglume dev tail --listing-id`` to answer "who is calling
+        my listing" without exposing identifying buyer detail.
+        """
+        params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
+        return self._request(
+            "GET",
+            f"/seller/analytics/listings/{listing_id}/recent-receipts",
+            params=params,
+        )
+
+    def simulate_planner(
+        self,
+        *,
+        offer_text: str,
+        max_candidates: int = 10,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Predict the orchestrator's tool chain for an offer text without dispatching.
+
+        Rate-limited server-side (10 calls / publisher / UTC day). Beyond the
+        cap the server returns ``429`` with a ``SIMULATE_QUOTA_EXCEEDED``
+        error code and a ``reset_at`` timestamp. Privacy: never includes
+        buyer prompts or other publishers' tool outputs.
+        """
+        body: dict[str, Any] = {
+            "offer_text": str(offer_text),
+            "max_candidates": int(max_candidates),
+        }
+        return self._request("POST", "/seller/dev/simulate", json_body=body)
+
     def get_usage(
         self,
         *,

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -13,14 +13,12 @@ from typing import Any
 
 from click.testing import CliRunner
 
-
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from siglume_api_sdk.cli import main  # noqa: E402
 from siglume_api_sdk.cli.commands import dev_cmd as dev_cmd_module  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # FakeClient — captures call args, returns configurable payloads
@@ -177,6 +175,70 @@ class FakeClient:
             None,
         )
 
+    def list_listing_recent_receipts(
+        self,
+        listing_id: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], Any]:
+        FakeClient.last_call = (
+            "list_listing_recent_receipts",
+            {"listing_id": listing_id, "limit": limit, "offset": offset},
+        )
+        return (
+            [
+                {
+                    "receipt_id": "rcpt_listing_0001",
+                    "status": "completed",
+                    "step_count": 2,
+                    "total_latency_ms": 240,
+                    "created_at": "2026-05-01T06:00:00+00:00",
+                    "completed_at": "2026-05-01T06:00:01+00:00",
+                },
+            ],
+            None,
+        )
+
+    def simulate_planner(
+        self,
+        *,
+        offer_text: str,
+        max_candidates: int = 10,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "simulate_planner",
+            {"offer_text": offer_text, "max_candidates": max_candidates},
+        )
+        return (
+            {
+                "offer_text": offer_text,
+                "catalog_size": 50,
+                "candidates_considered": 4,
+                "predicted_chain": [
+                    {
+                        "tool_name": "translate_text",
+                        "capability_key": "translate_text",
+                        "listing_id": "lst_translate",
+                        "listing_title": "DeepL Translator",
+                        "args": {"target_lang": "ja", "text": "<offer text>"},
+                    },
+                    {
+                        "tool_name": "notion_append_page",
+                        "capability_key": "notion_append_page",
+                        "listing_id": "lst_notion",
+                        "listing_title": "Notion Page Appender",
+                        "args": {"page_id": "p_x", "content": "<translated>"},
+                    },
+                ],
+                "model": "claude-haiku-4-5-20251001",
+                "quota_used_today": 3,
+                "quota_limit": 10,
+                "note": None,
+            },
+            None,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -199,8 +261,8 @@ def test_dev_command_is_registered_on_main():
     runner = CliRunner()
     result = runner.invoke(main, ["dev", "--help"])
     assert result.exit_code == 0
-    # All 5 subcommands listed
-    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail"):
+    # All 6 subcommands listed (Phase 1: 5 + Phase 2: simulate)
+    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail", "simulate"):
         assert sub in result.output, f"subcommand {sub!r} missing from `siglume dev --help`"
 
 
@@ -479,7 +541,148 @@ def test_dev_tail_unexpected_response_shape_emits_warning(monkeypatch):
 
 def test_dev_subcommand_help_renders():
     runner = CliRunner()
-    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail"):
+    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail", "simulate"):
         result = runner.invoke(main, ["dev", sub, "--help"])
         assert result.exit_code == 0, f"`siglume dev {sub} --help` exited {result.exit_code}"
         assert sub.replace("-", "") in result.output.lower() or "Usage:" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Phase 2 — simulate command
+
+
+def test_dev_simulate_renders_predicted_chain(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "simulate", "translate english to japanese"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "simulate_planner",
+        {"offer_text": "translate english to japanese", "max_candidates": 10},
+    )
+    assert "Simulated against 50 catalog listings" in result.output
+    assert "translate_text" in result.output
+    assert "notion_append_page" in result.output
+    assert "Quota: 3/10 used today" in result.output
+
+
+def test_dev_simulate_json(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["dev", "simulate", "do something", "--max-candidates", "5", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["catalog_size"] == 50
+    assert len(payload["predicted_chain"]) == 2
+    assert FakeClient.last_call == (
+        "simulate_planner",
+        {"offer_text": "do something", "max_candidates": 5},
+    )
+
+
+def test_dev_simulate_max_candidates_above_20_rejected(monkeypatch):
+    """Click IntRange(1, 20) on --max-candidates."""
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["dev", "simulate", "x", "--max-candidates", "999"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--max-candidates'" in result.output or "is not in" in result.output
+
+
+def test_dev_simulate_429_quota_exceeded_friendly_message(monkeypatch):
+    """429 with details emits a tidy quota message, not a stack trace."""
+    _patch_client(monkeypatch)
+    from siglume_api_sdk.client import SiglumeAPIError
+
+    def _raise_429(self, **_kwargs):
+        raise SiglumeAPIError(
+            "Daily simulate quota of 10 reached. Resets at 00:00 UTC.",
+            status_code=429,
+            error_code="SIMULATE_QUOTA_EXCEEDED",
+            details={
+                "quota_used_today": 10,
+                "quota_limit": 10,
+                "reset_at": "2026-05-02T00:00:00+00:00",
+            },
+        )
+
+    monkeypatch.setattr(FakeClient, "simulate_planner", _raise_429)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "simulate", "anything"])
+    assert result.exit_code != 0
+    assert "Daily simulate quota exceeded" in result.output
+    assert "Resets at 2026-05-02" in result.output
+
+
+def test_dev_simulate_empty_chain_shows_note(monkeypatch):
+    _patch_client(monkeypatch)
+
+    def _empty(self, **_kwargs):
+        return (
+            {
+                "offer_text": "weird offer",
+                "catalog_size": 50,
+                "candidates_considered": 4,
+                "predicted_chain": [],
+                "model": "claude-haiku-4-5-20251001",
+                "quota_used_today": 4,
+                "quota_limit": 10,
+                "note": "LLM picked no tools (offer may not match any catalog entry)",
+            },
+            None,
+        )
+
+    monkeypatch.setattr(FakeClient, "simulate_planner", _empty)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "simulate", "weird offer"])
+    assert result.exit_code == 0
+    assert "Predicted chain: (empty)" in result.output
+    assert "LLM picked no tools" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Phase 2 — tail --listing-id (publisher-scoped feed)
+
+
+def test_dev_tail_listing_id_routes_to_listing_endpoint(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail", "--listing-id", "lst_xyz"])
+    assert result.exit_code == 0
+    # Routes to list_listing_recent_receipts, not list_execution_receipts
+    assert FakeClient.last_call == (
+        "list_listing_recent_receipts",
+        {"listing_id": "lst_xyz", "limit": 20, "offset": 0},
+    )
+    assert "rcpt_lis" in result.output  # truncated id from _format_receipt_line
+
+
+def test_dev_tail_listing_id_warns_when_irrelevant_filters_passed(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "dev", "tail",
+            "--listing-id", "lst_xyz",
+            "--agent-id", "agent_x",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Note: --agent-id and --status are ignored" in result.output
+
+
+def test_dev_tail_listing_id_response_has_no_agent_field(monkeypatch):
+    """Listing-scoped responses omit agent_id by design — output line lacks 'agent='."""
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "tail", "--listing-id", "lst_xyz"])
+    assert result.exit_code == 0
+    assert "agent=" not in result.output


### PR DESCRIPTION
## Summary

Mirrors [taihei-05/siglume#199](https://github.com/taihei-05/siglume/pull/199) (SDK Phase 2) from the private monorepo's `packages/contracts/sdk/` to this public repo, per `RELEASING.md` mirror rule.

## What's added

| Subcommand | Purpose |
|---|---|
| `siglume dev simulate "<offer text>"` | Predict the orchestrator's tool chain WITHOUT executing — server-side rate-limited at 10 calls / publisher / UTC day. |
| `siglume dev tail --listing-id <id>` | Publisher-scoped feed of receipts that touched your listing. Privacy-stripped (no agent_id / summary / failure_reason). |

`SiglumeClient` gains `simulate_planner()` and `list_listing_recent_receipts()`.

## Why

Triggered by [#186](https://github.com/taihei-05/siglume-api-sdk/issues/186) (publisher observability gap raised by @sanrishi); tracking [#195](https://github.com/taihei-05/siglume-api-sdk/issues/195).

The publisher-scoped `tail` was promised in the @sanrishi follow-up reply ([comment 4358177084](https://github.com/taihei-05/siglume-api-sdk/issues/186#issuecomment-4358177084)). The `simulate` was unblocked by user insight that rate-limiting collapses the LLM-cost dilemma.

Backend is in [taihei-05/siglume#198](https://github.com/taihei-05/siglume/pull/198) (merged, will deploy after this lands).

## Test plan

- [x] `pytest tests/test_dev_cli.py` — 23/23 pass
- [x] `pytest tests/test_cli.py tests/test_client.py` — 81/81 pass (no regression)
- [x] `ruff check .` clean
- [x] Mirror drift detector: source-of-truth `packages/contracts/sdk/` ↔ this PR ↔ public repo will be in sync after merge.

## Release

`[Unreleased]` only; next PyPI tag will batch this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)