### PR TITLE
fix(codex-review): preserve opaque provider_key + accept documented manifest fields + clarify schema rule + bump README

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v0.10.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v0.10.1 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -280,6 +280,29 @@ paths:
                 dry_run_supported:
                   type: boolean
                   description: Whether the API supports dry-run execution
+                permission_scopes:
+                  type: array
+                  description: |
+                    OAuth-style permission scopes this API requires (e.g.
+                    `["calendar.read", "drive.write"]`). Surfaced on the
+                    buyer-facing detail page so installs can compare scope
+                    asks across competing tools. Optional; mirrors the
+                    listing response shape so a publisher can repeat the
+                    same value at re-register without it being silently
+                    dropped (regression in v0.10.0 / fixed by codex review
+                    on PR #184).
+                  items:
+                    type: string
+                compatibility_tags:
+                  type: array
+                  description: |
+                    Discovery / compatibility tags (e.g. `["en", "ja"]` for
+                    locale, framework names, vertical labels). Used by the
+                    catalog filter and search UI on the buyer side.
+                    Optional; same regression-fix rationale as
+                    `permission_scopes`.
+                  items:
+                    type: string
                 required_connected_accounts:
                   type: array
                   description: Manifest/listing connected-account requirements. Plain strings are API-managed; objects with platform_managed=true require seller OAuth credentials and must match ToolManual.requires_connected_accounts.

--- a/schemas/input-form-spec.schema.json
+++ b/schemas/input-form-spec.schema.json
@@ -18,7 +18,7 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 20,
-      "description": "Form fields. Single-API auto-register accepts all-optional forms; multi-capability / Works composition requires at least one required=true field (validator-enforced; not expressible at the schema level).",
+      "description": "Form fields. Single-API auto-register intentionally accepts all-optional forms (a tool may legitimately want every input optional). Multi-capability / Works composition flows additionally require at least one entry with required=true; that constraint is enforced by the platform's manifest validator at submission time, since whether a given input_form_spec is single-API vs multi-capability is contextual and not knowable from the spec alone. Codex review on PR #190 noted JSON Schema 2020-12's contains/minContains could express the latter check, but applying it here would over-constrain the single-API path; the constraint lives in the validator instead.",
       "items": { "$ref": "#/$defs/field" }
     },
     "sections": {

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -308,6 +308,24 @@ function isPlatformManagedRequirement(value: unknown): boolean {
   return owner === "platform" || owner === "siglume" || owner === "siglume-platform";
 }
 
+/**
+ * Extract the opaque `provider_key` from a requirement entry.
+ *
+ * Returns the value VERBATIM — no lowercasing, no rewriting of
+ * non-alphanumeric characters. `provider_key` is a contract-defined
+ * opaque identifier used for OAuth flow routing; keys such as
+ * `AzureAD_v2`, `microsoft/graph`, `foo.bar` must be transmitted
+ * unchanged so the API contract recognizes them. The earlier
+ * implementation normalized to `[a-z0-9-]+` and silently rewrote any
+ * of those into `azuread-v2` / `microsoft-graph` / `foo-bar`, breaking
+ * the contract-driven OAuth flow.
+ *
+ * Codex review on PR #194 surfaced the regression; mirrors the
+ * Python-side fix in `siglume_api_sdk/cli/project.py`. Owner-field
+ * normalization for the platform-managed-vs-third-party check happens
+ * in `isPlatformManagedRequirement` and is unrelated to this opaque
+ * provider_key value.
+ */
 function oauthProviderKeyFromRequirement(value: unknown): string | null {
   if (isRecord(value)) {
     for (const key of ["provider_key", "provider", "account_type", "name"]) {
@@ -316,9 +334,8 @@ function oauthProviderKeyFromRequirement(value: unknown): string | null {
     }
     return null;
   }
-  const raw = String(value ?? "").trim().toLowerCase().replaceAll("_", "-");
-  if (!raw) return null;
-  return raw.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || null;
+  const raw = String(value ?? "").trim();
+  return raw || null;
 }
 
 function requiredOauthProviders(requirements: unknown[] | undefined): string[] {

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -6,7 +6,6 @@ import importlib.util
 import inspect
 import json
 import os
-import re
 import sys
 import textwrap
 import tomllib

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -307,16 +307,30 @@ def _is_platform_managed_requirement(value: Any) -> bool:
 
 
 def _oauth_provider_key_from_requirement(value: Any) -> str | None:
+    """Extract the opaque ``provider_key`` from a requirement entry.
+
+    Returns the value VERBATIM — no lowercasing, no re-mapping of
+    non-alphanumeric characters. ``provider_key`` is a contract-defined
+    opaque identifier used for OAuth flow routing; keys such as
+    ``AzureAD_v2``, ``microsoft/graph``, ``foo.bar`` must be
+    transmitted unchanged so the API contract recognizes them. The
+    earlier implementation normalized to ``[a-z0-9-]+`` which silently
+    rewrote any of those into ``azuread-v2`` / ``microsoft-graph`` /
+    ``foo-bar`` and broke the new contract-driven OAuth flow.
+
+    Codex review on PR #194 surfaced the regression. Owner-field
+    normalization for the platform-managed-vs-third-party check
+    happens in ``_is_platform_managed_requirement`` and is unrelated
+    to the opaque provider_key value.
+    """
     if isinstance(value, dict):
         for key in ("provider_key", "provider", "account_type", "name"):
             provider_key = _oauth_provider_key_from_requirement(value.get(key))
             if provider_key:
                 return provider_key
         return None
-    raw = str(value or "").strip().lower().replace("_", "-")
-    if not raw:
-        return None
-    return re.sub(r"[^a-z0-9]+", "-", raw).strip("-") or None
+    raw = str(value or "").strip()
+    return raw or None
 
 
 def _required_oauth_providers(requirements: list[Any] | tuple[Any, ...] | None) -> list[str]:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -68,7 +68,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v0.10.0 (beta)**" in readme
+    assert "This is **v0.10.1 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Why

Batch fix for `chatgpt-codex-connector[bot]` findings across 4 already-merged PRs. PR #192's finding was already addressed by the `throw` added in PR #194's hardening pass — verified Py and TS both raise on the missing-key path now. No work needed there.

## P1 fixes

### 1. #194 — provider_key opacity (Py + TS)

`_oauth_provider_key_from_requirement` (Py) and `oauthProviderKeyFromRequirement` (TS) lowercased and rewrote non-alphanumeric chars to `-`. The contract documents `provider_key` as opaque; keys like `AzureAD_v2`, `microsoft/graph`, `foo.bar` were silently mutated to `azuread-v2` / `microsoft-graph` / `foo-bar`, breaking OAuth-flow recognition.

**Fix:** removed the normalization. Owner-field normalization for the platform-managed-vs-third-party check stays in `_is_platform_managed_requirement` / `isPlatformManagedRequirement` — that's a separate concern.

### 2. #184 — auto-register schema rejects documented fields

`openapi/developer-surface.yaml` schema declares `additionalProperties: false` but the description text claims `permission_scopes` and `compatibility_tags` are buyer-facing fields. Since they weren't in `properties`, repeating them at re-register would fail with `INVALID_PAYLOAD`.

**Fix:** added both as top-level `array<string>` properties.

## P2 fixes

### 3. #188 — README v0.10.0 → v0.10.1 callout

The "Project status" footer still said `v0.10.0 (beta)` even though `pyproject.toml` and `siglume-api-sdk-ts/package.json` both shipped 0.10.1. Bumped to `v0.10.1`; `test_docs_contract` pin moved in lockstep.

### 4. #190 — input_form_spec schema rule clarity

Codex flagged that the description claimed "at least one required:true field" was "not expressible at the schema level" when JSON Schema 2020-12's `contains`/`minContains` can express it. Codex was right that it's expressible — but the rule is context-specific (single-API auto-register intentionally accepts all-optional forms; only multi-capability / Works-composition flows require it). Adding it at the top-level schema would over-constrain the single-API path.

**Fix:** reworded the description to make the conditional nature unambiguous and point at the validator as the enforcement layer.

## Tests

- 328 Python + 333 TypeScript = **661 total, all passing**
- No new tests added — the existing test_docs_contract pin moves with the README bump; the other fixes are documented behavior changes verified against the existing suite.

## Out of scope (#192)

PR #192's finding was already closed when PR #194 added the `throw` on missing `provider_key`. Verified both Py and TS now raise. No additional work.