### PR TITLE
docs: address codex review on PR #201 — clarify minimum grade B (not B+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ When a buyer's agent receives a request, the platform decides whether to call yo
 
 `tool_manual_validator` and `dev_simulator` are designed to run locally before you `siglume register`. They serve **two different questions**:
 
-**(1) Will I pass the publish gate (grade B+)?** — offline grading, no API key needed:
+**(1) Will I pass the publish gate (minimum grade B)?** — offline grading, no API key needed:
 
 ```bash
 pip install siglume-agent-core         # no extras needed for the scorer
@@ -363,7 +363,8 @@ from siglume_agent_core.tool_manual_validator import score_manual_quality
 
 quality = score_manual_quality(my_tool_manual)
 print(f"Grade {quality.grade} ({quality.overall_score}/100)")
-# Same scorer that decides if you pass the publish gate (B+).
+# Same scorer that decides if you pass the publish gate.
+# Minimum grade B is required (A or B both publish; C/D/F are blocked).
 ```
 
 **(2) Will the planner actually pick my API once published?** — the **easiest path** is the SDK's wrapped CLI, which does the catalog fetch and the LLM call for you against the live store (rate-limited to 10 calls per publisher per UTC day):


### PR DESCRIPTION
## Summary

Follow-up to #201 (docs cross-link to `siglume-agent-core`). Codex bot flagged that the new "How your API gets selected" section used the phrase "publish gate (B+)" in two places, which would mislead publishers into over-correcting manuals that would already pass registration.

The actual platform rule is **minimum grade B** — A and B both publish; C/D/F are blocked. The earlier sections of this README and `GETTING_STARTED.md` already use "minimum B" wording, so this aligns the new section back to that.

## Why a follow-up PR

The fix was prepared during the original PR #201 review cycle, but the local commit hit a permission-hook block on direct push to the (then-still-open) `docs/agent-core-cross-link` branch. PR #201 was then merged after resolving the codex review thread without the wording change; this follow-up applies the actual fix on a fresh branch from main, where the hook permits push normally.

## Test plan

- [x] No behaviour change; docs only
- [x] No version bump
- [x] All other content from PR #201 already on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)