### PR TITLE
docs: clarify which Tool Manual fields actually drive selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,10 @@ for call in result.predicted_chain:
     print(call.tool_name, call.listing_title)
 ```
 
-If the planner picks your API for the offers your target buyers would write, you're publish-ready. If not, your Tool Manual's `trigger_conditions` / `summary_for_model` need work — `tool_selector` scores those fields against the buyer's request text, so be specific.
+If the planner picks your API for the offers your target buyers would write, you're publish-ready. If not, improve the Tool Manual fields the selection pipeline actually reads:
+
+- `tool_selector` runs a keyword-based hard filter (stage 2 in the diagram above) over your `capability_key`, `display_name`, `description`, and `usage_hints`. If none of those overlap the buyer's request, the LLM never even sees your API as a candidate. Make these four fields concrete and request-shaped.
+- Once your API *is* in the candidate set, the LLM reads a short tool-description string while picking between candidates. That string is sourced from your manual via the fallback chain `tool_prompt_compact` → `compact_prompt` → `description` → `summary_for_model` → listing description / title / `capability_key`. In practice the LLM almost always sees `tool_prompt_compact` (or `compact_prompt`), so polish that field first; `summary_for_model` and the others are only fallbacks if the earlier sources are empty. `trigger_conditions` is captured in the schema for the publish gate's quality check but is not threaded into the LLM-visible tool description today — keep it accurate, but don't expect it to move the planner directly.
 
 This pipeline is the substrate behind both the [Acceptance bar](#acceptance-bar) (the scorer at stage "pre-publish") and the [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed) reality (stages 1–5 at runtime). The acceptance bar tells you whether you can list; the runtime pipeline decides whether you actually get *picked* once listed.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #201 / #202. The "Pre-publish dry run with agent-core" section in `README.md` (around line 415) told publishers their `trigger_conditions` / `summary_for_model` need work because `tool_selector` scores those fields. That claim is wrong on two counts:

1. `tool_selector.extract_trigger_words()` reads only `capability_key`, `display_name`, `description`, and `usage_hints`. Neither `trigger_conditions` nor `summary_for_model` is consumed by the keyword scorer at all.
2. Even on the LLM side, `summary_for_model` is the **fourth fallback** in `build_tool_def`'s source chain (`tool_prompt_compact` → `compact_prompt` → `description` → `summary_for_model` → listing description / title / `capability_key`). The field the LLM actually sees in production is `tool_prompt_compact`. A publisher who polishes `summary_for_model` while leaving `tool_prompt_compact` truncated will see no behavior change.

This PR replaces the one-line incorrect claim with a two-bullet explanation:

- **Bullet 1:** the keyword-filter stage and the four fields it reads (`capability_key` / `display_name` / `description` / `usage_hints`) — get into the candidate set.
- **Bullet 2:** the LLM-arbitration stage and the actual fallback chain, with `tool_prompt_compact` called out as the field that almost always wins. `trigger_conditions` is correctly framed as a publish-gate quality signal that does not flow into the LLM-visible tool description today.

## Why this matters

A reviewer found this discrepancy by tracing `extract_trigger_words` (`siglume-agent-core/siglume_agent_core/tool_selector.py:252-271`) and the `build_tool_def` fallback chain (`siglume-agent-core/siglume_agent_core/dev_simulator.py:357-365`). The same misallocation of effort recently caused a multi-hour debug session against `tool_prompt_compact` truncation, so getting publishers pointed at the right field matters.

## Verification

- `pytest tests/test_dev_cli.py tests/test_cli.py tests/test_client.py -q` — 104 passed in 7s
- README-only diff, 4 insertions / 1 deletion
- Reviewer subagent verified the field lists against current `tool_selector.py` and `dev_simulator.py`

## Test plan

- [x] Local pytest green
- [x] Reviewer-verified against agent-core source
- [ ] CI green (4 jobs: contract-sync, test py3.11, test py3.12, typescript)
- [ ] Reverse-sync to monorepo mirror after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)