### PR TITLE
feat(dev): add siglume dev market-vitals command (#199)

### DIFF
--- a/siglume_api_sdk/cli/commands/dev_cmd.py
+++ b/siglume_api_sdk/cli/commands/dev_cmd.py
@@ -5,6 +5,7 @@ so publishers can inspect their API's marketplace performance from the CLI.
 
 Subcommands:
 - ``siglume dev gap-report``      : cross-publisher unmet-demand shapes
+- ``siglume dev market-vitals``   : publisher market vitals overview
 - ``siglume dev stats``           : per-listing install / revenue / execution stats
 - ``siglume dev miss-analysis``   : why your listing was candidate-but-not-selected
 - ``siglume dev keywords``        : keyword suggestions for the tool manual
@@ -90,6 +91,60 @@ def gap_report_command(
             f"hash={shape_hash[:12]}…  "
             f"words=[{words}]"
         )
+
+
+# ---------------------------------------------------------------------------
+# market-vitals
+# ---------------------------------------------------------------------------
+
+
+@dev_command.command("market-vitals")
+@click.option("--days", default=7, show_default=True, type=click.IntRange(1, 90))
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+def market_vitals_command(days: int, json_output: bool) -> None:
+    """Publisher market vitals overview."""
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        try:
+            data, _ = client.get_market_vitals(days=days)
+        except SiglumeAPIError as exc:
+            click.secho(f"API error: {exc}", fg="red", err=True)
+            raise click.Abort() from exc
+
+    if json_output:
+        click.echo(render_json(data))
+        return
+
+    if not isinstance(data, dict):
+        click.secho("Unexpected response shape.", fg="red", err=True)
+        return
+
+    period_days = data.get("period_days", days)
+    intents_total = data.get("intents_total", 0)
+    intents_per_day_avg = data.get("intents_per_day_avg", 0)
+    receipts_total = data.get("receipts_total", 0)
+    receipts_succeeded = data.get("receipts_succeeded", 0)
+    approval_gated_count = data.get("approval_gated_count", 0)
+    top_capabilities = data.get("top_capabilities") or []
+
+    click.secho(f"Market Vitals  (last {period_days} days)", fg="green")
+    click.echo("-" * 29)
+    click.echo("")
+    click.echo(f"Intents        {intents_total}  ({float(intents_per_day_avg):.2f}/day avg)")
+    click.echo(
+        f"Receipts       {receipts_total}  dispatched, {receipts_succeeded} succeeded"
+    )
+    click.echo(f"Approval-gated {approval_gated_count}")
+
+    if top_capabilities:
+        click.echo("")
+        click.echo("Top capabilities")
+        for i, capability in enumerate(top_capabilities[:3], 1):
+            if not isinstance(capability, dict):
+                continue
+            key = str(capability.get("capability_key", "?"))
+            selections = capability.get("selection_count", 0)
+            click.echo(f"  #{i}  {key:<34} {selections} selections")
 
 
 # ---------------------------------------------------------------------------

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -3317,6 +3317,18 @@ class SiglumeClient:
         }
         return self._request("GET", "/seller/analytics/gap-report", params=params)
 
+    def get_market_vitals(
+        self,
+        *,
+        days: int = 7,
+    ) -> tuple[dict[str, Any], EnvelopeMeta]:
+        """Publisher market vitals overview for the requested time window."""
+        return self._request(
+            "GET",
+            "/seller/analytics/market-vitals",
+            params={"days": int(days)},
+        )
+
     def get_seller_listing_stats(
         self,
         listing_id: str,

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -72,6 +72,42 @@ class FakeClient:
             None,
         )
 
+    def get_market_vitals(
+        self, *, days: int,
+    ) -> tuple[dict[str, Any], Any]:
+        FakeClient.last_call = (
+            "get_market_vitals",
+            {"days": days},
+        )
+        return (
+            {
+                "since": "2026-04-24T00:00:00+00:00",
+                "until": "2026-05-01T00:00:00+00:00",
+                "period_days": days,
+                "intents_total": 32,
+                "intents_per_day_avg": 4.57 if days == 7 else 1.07,
+                "receipts_total": 27,
+                "receipts_succeeded": 0,
+                "approval_gated_count": 18,
+                "top_capabilities_min_count": 3,
+                "top_capabilities": [
+                    {
+                        "capability_key": "growpost-daily-theme-x-poster",
+                        "selection_count": 14,
+                    },
+                    {
+                        "capability_key": "ecb-fx-converter",
+                        "selection_count": 5,
+                    },
+                    {
+                        "capability_key": "cisa-kev-checker",
+                        "selection_count": 3,
+                    },
+                ],
+            },
+            None,
+        )
+
     def get_seller_listing_stats(
         self, listing_id: str, *, days: int,
     ) -> tuple[dict[str, Any], Any]:
@@ -261,8 +297,16 @@ def test_dev_command_is_registered_on_main():
     runner = CliRunner()
     result = runner.invoke(main, ["dev", "--help"])
     assert result.exit_code == 0
-    # All 6 subcommands listed (Phase 1: 5 + Phase 2: simulate)
-    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail", "simulate"):
+    # All 7 subcommands listed (Phase 1: 5 + Phase 2: simulate + market-vitals)
+    for sub in (
+        "gap-report",
+        "market-vitals",
+        "stats",
+        "miss-analysis",
+        "keywords",
+        "tail",
+        "simulate",
+    ):
         assert sub in result.output, f"subcommand {sub!r} missing from `siglume dev --help`"
 
 
@@ -309,6 +353,42 @@ def test_dev_gap_report_min_occurrences_below_3_rejected(monkeypatch):
     result = runner.invoke(main, ["dev", "gap-report", "--min-occurrences", "1"])
     assert result.exit_code != 0
     assert "Invalid value for '--min-occurrences'" in result.output or "is not in" in result.output
+
+
+# ---------------------------------------------------------------------------
+# market-vitals
+# ---------------------------------------------------------------------------
+
+
+def test_dev_market_vitals_renders_summary(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "market-vitals"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_market_vitals",
+        {"days": 7},
+    )
+    assert "Market Vitals  (last 7 days)" in result.output
+    assert "-----------------------------" in result.output
+    assert "Intents        32  (4.57/day avg)" in result.output
+    assert "Receipts       27  dispatched, 0 succeeded" in result.output
+    assert "Approval-gated 18" in result.output
+    assert "#1  growpost-daily-theme-x-poster" in result.output
+
+
+def test_dev_market_vitals_json(monkeypatch):
+    _patch_client(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(main, ["dev", "market-vitals", "--days", "30", "--json"])
+    assert result.exit_code == 0
+    assert FakeClient.last_call == (
+        "get_market_vitals",
+        {"days": 30},
+    )
+    payload = json.loads(result.output)
+    assert payload["period_days"] == 30
+    assert payload["top_capabilities"][0]["capability_key"] == "growpost-daily-theme-x-poster"
 
 
 # ---------------------------------------------------------------------------
@@ -541,7 +621,7 @@ def test_dev_tail_unexpected_response_shape_emits_warning(monkeypatch):
 
 def test_dev_subcommand_help_renders():
     runner = CliRunner()
-    for sub in ("gap-report", "stats", "miss-analysis", "keywords", "tail", "simulate"):
+    for sub in ("gap-report", "market-vitals", "stats", "miss-analysis", "keywords", "tail", "simulate"):
         result = runner.invoke(main, ["dev", sub, "--help"])
         assert result.exit_code == 0, f"`siglume dev {sub} --help` exited {result.exit_code}"
         assert sub.replace("-", "") in result.output.lower() or "Usage:" in result.output


### PR DESCRIPTION
Closes #199 
## Changes

  - Add `siglume dev market-vitals` to the SDK CLI.
  - Add `SiglumeClient.get_market_vitals(days=...)` for `GET /v1/seller/analytics/market-vitals`.
  - Support `--days` and `--json`.
  - Render formatted terminal output by default and raw JSON with `--json`.

<!-- Describe what this PR changes in the SDK -->

## Checklist

- [x] Tests pass locally
- [x] Code formatted with black/ruff
- [x] Documentation updated if needed

> **Note:** This repo is for SDK improvements only.
> To publish your own API, use the auto-register endpoint — see [GETTING_STARTED.md](GETTING_STARTED.md).

 
