### PR TITLE
release: prepare v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-05-05
+
 ### Changed
 
 - **Documentation cross-links to `siglume-agent-core`** — README,
@@ -51,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `min_occurrences >= 3` floor as singleton-fingerprinting privacy
     guardrail). High-occurrence shapes are unmet demand a publisher can
     target.
+  - `siglume dev market-vitals [--days N] [--json]` — aggregate daily
+    orchestrator traffic, dispatch receipt, approval-gated, and top selected
+    capability counts so publishers can distinguish "not selected" from "no
+    matching market traffic yet."
   - `siglume dev stats <listing-id> [--days N]` — installs / revenue /
     executions / success and selection rates for one of your listings.
   - `siglume dev miss-analysis <listing-id> [--days N]` — why your listing
@@ -62,15 +68,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `siglume dev tail [--agent-id …] [--status …] [--follow] [--interval S]`
     — recent execution receipts in the caller's owner scope; `--follow`
     polls live with dedup across polls. `Ctrl-C` exits gracefully.
-- `SiglumeClient` gains five matching methods (`get_gap_report`,
-  `get_seller_listing_stats`, `get_seller_selection_analysis`,
-  `get_seller_keyword_suggestions`, `list_execution_receipts`). All are
-  thin GET wrappers; buyer prompts, agent IDs, and owner IDs are never
-  in any response payload.
+- `SiglumeClient` gains six matching methods (`get_gap_report`,
+  `get_market_vitals`, `get_seller_listing_stats`,
+  `get_seller_selection_analysis`, `get_seller_keyword_suggestions`,
+  `list_execution_receipts`). All are thin GET wrappers; buyer prompts, agent
+  IDs, and owner IDs are never in any response payload.
 
 Triggered by [`siglume-api-sdk#186`](https://github.com/taihei-05/siglume-api-sdk/issues/186)
 (publisher observability gap raised by @sanrishi); tracking
-[`siglume-api-sdk#195`](https://github.com/taihei-05/siglume-api-sdk/issues/195).
+[`siglume-api-sdk#195`](https://github.com/taihei-05/siglume-api-sdk/issues/195)
+and [`siglume-api-sdk#199`](https://github.com/taihei-05/siglume-api-sdk/issues/199).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v0.10.1.** Python and TypeScript are version-aligned and
+> **Current release: v0.10.2.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, seller-owned connected-account OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
 > long-form buyer-facing `description`, and platform-controlled release semver
-> via `version_bump`. v0.10.1 is a documentation / metadata catch-up over
-> v0.10.0 — runtime behavior is byte-equivalent.
+> via `version_bump`. v0.10.2 adds publisher observability commands under
+> `siglume dev`, including planner simulation, execution receipt tailing,
+> gap reports, listing stats, and market-vitals traffic snapshots.
 > See [CHANGELOG.md](./CHANGELOG.md),
-> [RELEASE_NOTES_v0.10.1.md](./RELEASE_NOTES_v0.10.1.md), and
-> [RELEASE_NOTES_v0.10.0.md](./RELEASE_NOTES_v0.10.0.md) for the current
+> [RELEASE_NOTES_v0.10.2.md](./RELEASE_NOTES_v0.10.2.md), and
+> [RELEASE_NOTES_v0.10.1.md](./RELEASE_NOTES_v0.10.1.md) for the current
 > release line.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
@@ -671,7 +672,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v0.10.1 (beta)** — the platform is launched on Polygon mainnet
+This is **v0.10.2 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v0.10.2.md
+++ b/RELEASE_NOTES_v0.10.2.md
@@ -1,0 +1,44 @@
+# Siglume API SDK v0.10.2
+
+v0.10.2 is a publisher-observability release. It keeps the registration and
+runtime contracts compatible with v0.10.1 while making it easier for API
+publishers to understand whether their API is getting market traffic, being
+selected, or missing demand.
+
+## Highlights
+
+- Adds `siglume dev market-vitals [--days N] [--json]`, backed by
+  `SiglumeClient.get_market_vitals(days=...)`, for aggregate orchestrator
+  traffic and dispatch snapshots.
+- Ships the broader `siglume dev` observability surface: planner simulation,
+  gap reports, listing stats, miss analysis, keyword suggestions, and execution
+  receipt tailing.
+- Cross-links the public SDK docs to `siglume-agent-core`, so publishers can
+  inspect the open-source selection logic behind scoring and simulation.
+- Keeps Python and TypeScript package versions aligned at `0.10.2`.
+
+## Compatibility
+
+This is an additive patch release. Existing v0.10.x SDK users do not need code
+changes unless they want to use the new `siglume dev` commands or the matching
+client methods.
+
+## Quick Start
+
+```bash
+pip install --upgrade siglume-api-sdk==0.10.2
+siglume dev market-vitals --days 7
+siglume dev market-vitals --days 30 --json
+```
+
+For TypeScript:
+
+```bash
+npm install @siglume/api-sdk@0.10.2
+```
+
+## Notes
+
+The market-vitals output is aggregate publisher-facing telemetry. It does not
+expose buyer prompts, agent IDs, owner IDs, or other publishers' private tool
+outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.10.1"
+version = "0.10.2"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.7.6",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.7.6",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.10.1";
+export const SDK_VERSION = "0.10.2";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.10.1"
+SDK_VERSION = "0.10.2"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -53,7 +53,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.10.1"
+    assert python_version == "0.10.2"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -68,7 +68,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v0.10.1 (beta)**" in readme
+    assert "This is **v0.10.2 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary

- bump Python and TypeScript SDK versions to 0.10.2
- move the current publisher-observability changes into the 0.10.2 changelog section
- add v0.10.2 release notes and update README release callouts
- update release contract tests for the new version

## Verification

- `py -3.11 -m pytest tests/test_dev_cli.py tests/test_cli.py tests/test_client.py -q` — 106 passed
- `py -3.11 scripts/contract_sync.py` — passed
- `py -3.11 -m pytest -q` — 333 passed
- `npm ci`
- `npm test -- --coverage.enabled=false` — 333 passed
- `npm run build`
- `npm run pack:check` — packed `@siglume/api-sdk@0.10.2`
- `py -3.11 -m build`
- `py -3.11 -m twine check dist\*` — passed