### PR TITLE
ci: opt into Node 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -47,7 +50,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install TypeScript dependencies
         working-directory: siglume-api-sdk-ts

--- a/.github/workflows/contract-sync.yml
+++ b/.github/workflows/contract-sync.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "17 18 * * *"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   contract-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Job 1: validate the tag ref and build artifacts. No id-token perm.
   # A compromised build dep here CANNOT mint an OIDC token.


### PR DESCRIPTION
## Summary
- set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 across CI, contract-sync, and release workflows
- run the TypeScript CI job on Node 24 to match the release workflow

## Verification
- git diff --check
- GitHub Actions PR checks