### PR TITLE
Document Game API Store placement tags

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -216,6 +216,27 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `seller_homepage_url` | Optional official seller/company homepage, separate from `docs_url`. | `"https://your-domain.com"` |
 | `seller_social_url` | Optional official seller social/profile URL, separate from `docs_url`. | `"https://x.com/your_account"` |
 
+### Game API Store placement
+
+If your API is built for game developers or game runtime use cases, use the
+normal publishing flow and add explicit game-oriented `compatibility_tags` to
+the manifest. This is what makes the listing eligible for the dedicated Game
+API Store entry point.
+
+```python
+compatibility_tags=[
+    "game",
+    "unity",
+    "realtime",
+    "npc",
+]
+```
+
+Good tags are concrete buyer signals such as `game`, `unity`, `unreal`,
+`godot`, `npc`, `matchmaking`, `multiplayer`, `realtime`, `ugc`, or
+`narrative`. Do not rely on arbitrary registration `metadata` for placement;
+use manifest fields that are validated and carried through by the SDK.
+
 ### How buyer inquiries reach you
 
 Buyers do **not** click through to your `support_contact` value directly. The

--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ upgrade before publishing. If the upgrade adds a new
 platform-managed seller-side OAuth provider, the local Git-ignored `oauth_credentials.json` must
 already include that provider or the upgrade is rejected.
 
+#### Game API Store placement
+
+Game APIs use the same `siglume register` / `auto-register` flow as every other
+Agent API Store listing. There is no separate public registration route.
+
+To make a listing eligible for the dedicated Game API Store entry point, mark
+the manifest with explicit game-oriented `compatibility_tags`:
+
+```python
+compatibility_tags=[
+    "game",
+    "unity",
+    "realtime",
+    "npc",
+]
+```
+
+Use tags that describe the real buyer context, for example `game`, `unity`,
+`unreal`, `godot`, `npc`, `matchmaking`, `multiplayer`, `realtime`, `ugc`, or
+`narrative`. Do not send arbitrary `metadata` in the registration payload for
+store placement; the public SDK contract keeps listing placement hints in the
+manifest fields and Tool Manual inputs that `siglume register` already reads.
+
 **You do not submit a PR to this repo.** You register directly on the platform.
 No permission needed. No issue to claim. Just build and register.
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -196,6 +196,11 @@ preflight errors before calling `auto-register`.
   - `jurisdiction`
   - optional `seller_homepage_url` / `seller_social_url` for the seller's
     official website or SNS profile. These are separate from `docs_url`.
+  - optional `compatibility_tags`. For game APIs, include explicit game
+    placement tags such as `game`, `unity`, `unreal`, `godot`, `npc`,
+    `matchmaking`, `multiplayer`, `realtime`, `ugc`, or `narrative`. These
+    tags are the public SDK path for eligibility in the dedicated Game API
+    Store entry point; do not send arbitrary `metadata` for placement.
 - A Tool Manual / agent contract that scores **A** or **B**
   - canonical schema: `schemas/tool-manual.schema.json`
   - required core fields include `input_schema`, `output_schema`,

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -82,3 +82,10 @@ non-material upgrade when checks pass. The server-side publish gate
 includes runtime checks, contract checks, seller OAuth checks, pricing / payout
 rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.
+
+Game APIs use the same publishing flow. To make a listing eligible for the
+dedicated Game API Store entry point, include explicit game-oriented
+`compatibility_tags` in the manifest, for example `["game", "unity",
+"realtime", "npc"]`. Use concrete tags such as `game`, `unity`, `unreal`,
+`godot`, `npc`, `matchmaking`, `multiplayer`, `realtime`, `ugc`, or
+`narrative`; do not send arbitrary registration `metadata` for store placement.


### PR DESCRIPTION
## Summary
- Document that Game API Store placement uses the normal `siglume register` / `auto-register` flow
- Tell publishers to add explicit game-oriented `compatibility_tags` such as `game`, `unity`, `unreal`, `godot`, `npc`, `matchmaking`, `multiplayer`, `realtime`, `ugc`, or `narrative`
- Clarify that arbitrary registration `metadata` should not be used for public store placement

## Validation
- `py -3.11 -m pytest -q tests/test_docs_contract.py`
- `git diff --check`