### PR TITLE
Add company publisher support

### DIFF
--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -259,6 +259,16 @@ paths:
                 seller_social_url:
                   type: string
                   description: Optional official seller social/profile URL, separate from docs_url
+                publisher_type:
+                  type: string
+                  enum: [user, company]
+                  description: Publishing subject. Use `company` with `company_id` to publish under a Siglume company name.
+                company_id:
+                  type: string
+                  description: Siglume company id to publish under when publisher_type is `company`.
+                publisher_company_id:
+                  type: string
+                  description: Alias for company_id.
                 store_vertical:
                   type: string
                   enum: [api, game]

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -205,6 +205,19 @@
       "format": "uri",
       "description": "Optional official seller social/profile URL. This is separate from docs_url."
     },
+    "publisher_type": {
+      "type": "string",
+      "enum": ["user", "company"],
+      "description": "Publishing subject. Omit or use 'user' for individual publishing; use 'company' with company_id to publish under a Siglume company name."
+    },
+    "company_id": {
+      "type": "string",
+      "description": "Siglume company id to publish under when publisher_type is 'company'."
+    },
+    "publisher_company_id": {
+      "type": "string",
+      "description": "Alias for company_id."
+    },
     "store_vertical": {
       "type": "string",
       "enum": [

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -268,11 +268,13 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
     .option("--confirm", "explicitly confirm the registration; this is the default unless --draft-only is set", false)
     .option("--draft-only", "create or refresh the draft without confirming publication", false)
     .option("--submit-review", "legacy alias: publish immediately if your environment still routes through submit-review", false)
+    .option("--company <companyId>", "publish under a Siglume company name; revenue is split equally among active members", "")
+    .option("--company-slug <slug>", "publish under a Siglume company by matching the slugified company name", "")
     .option("--json", "emit machine-readable JSON", false)
     .argument("[path]", ".", "project path")
     .action(async (
       path: string,
-      options: { confirm?: boolean; draftOnly?: boolean; submitReview?: boolean; json?: boolean; ["draft-only"]?: boolean; ["submit-review"]?: boolean },
+      options: { confirm?: boolean; draftOnly?: boolean; submitReview?: boolean; company?: string; companySlug?: string; json?: boolean; ["draft-only"]?: boolean; ["submit-review"]?: boolean; ["company-slug"]?: string },
     ) => {
       const draftOnly = Boolean(options.draftOnly);
       if (draftOnly && options.confirm) {
@@ -282,7 +284,13 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
         throw new SiglumeProjectError("--draft-only cannot be combined with --submit-review.");
       }
       const shouldConfirm = Boolean(options.confirm) || (!draftOnly && !options.submitReview);
-      const report = await runRegistration(path, { confirm: shouldConfirm, draft_only: draftOnly, submit_review: options.submitReview }, deps);
+      const report = await runRegistration(path, {
+        confirm: shouldConfirm,
+        draft_only: draftOnly,
+        submit_review: options.submitReview,
+        company_id: options.company,
+        company_slug: options.companySlug,
+      }, deps);
       if (options.json) {
         emit(stdout, renderJson(report));
       } else {

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -693,29 +693,101 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
   return preflight;
 }
 
+function companyNameSlug(value: string): string {
+  return value
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 export async function runRegistration(
   path = ".",
-  options: { confirm?: boolean; draft_only?: boolean; submit_review?: boolean } = {},
+  options: { confirm?: boolean; draft_only?: boolean; submit_review?: boolean; company_id?: string; company_slug?: string } = {},
   deps: CliProjectDependencies = {},
 ): Promise<Record<string, unknown>> {
   const project = await loadProject(path);
+  let requestedCompanyId = String(options.company_id ?? "").trim();
+  const requestedCompanySlug = String(options.company_slug ?? "").trim();
+  let companyPublisherCandidates: Array<{ company_id: string; name: string; settlement_wallet_ready?: boolean }> | null = null;
+  if (requestedCompanySlug) {
+    if (requestedCompanyId) {
+      throw new SiglumeProjectError("--company and --company-slug cannot be combined.");
+    }
+    const slug = companyNameSlug(requestedCompanySlug);
+    if (!slug && requestedCompanySlug !== requestedCompanyId) {
+      throw new SiglumeProjectError(`Company slug ${requestedCompanySlug} is not slug-compatible; use --company <company_id> instead.`);
+    }
+  }
+  if (requestedCompanyId) {
+    project.manifest = {
+      ...project.manifest,
+      publisher_type: "company",
+      company_id: requestedCompanyId,
+      publisher_company_id: requestedCompanyId,
+    };
+  }
   ensureExplicitToolManual(project);
   ensureManifestPublisherIdentity(project);
   ensureRuntimeValidationReady(project);
   ensureRequiredOauthCredentials(project);
   const canonicalOauthCredentials = canonicalOauthCredentialsPayload(project.oauth_credentials);
   const client = await createClient(deps);
+  if (requestedCompanySlug) {
+    const slug = companyNameSlug(requestedCompanySlug);
+    companyPublisherCandidates = await client.list_company_publishers();
+    const matches = companyPublisherCandidates.filter(
+      (item) => companyNameSlug(item.name || item.company_id) === slug || item.company_id === requestedCompanySlug,
+    );
+    if (matches.length === 0) {
+      throw new SiglumeProjectError(`Company slug ${requestedCompanySlug} is not available to this API key.`);
+    }
+    if (matches.length > 1) {
+      throw new SiglumeProjectError(`Company slug ${requestedCompanySlug} is ambiguous; use --company <company_id> instead.`);
+    }
+    const match = matches[0];
+    if (!match) {
+      throw new SiglumeProjectError(`Company slug ${requestedCompanySlug} is not available to this API key.`);
+    }
+    requestedCompanyId = match.company_id;
+    project.manifest = {
+      ...project.manifest,
+      publisher_type: "company",
+      company_id: requestedCompanyId,
+      publisher_company_id: requestedCompanyId,
+    };
+  }
   const preflight = await registrationPreflight(project, client);
   let developerPortalPreflight: unknown = null;
   if (String(project.manifest.price_model ?? "free").toLowerCase() !== "free") {
-    const portal = await client.get_developer_portal();
-    const verifiedDestination = portal.payout_readiness?.verified_destination;
-    if (verifiedDestination !== true) {
-      throw new SiglumeProjectError(
-        "Paid API registration requires a verified Polygon payout destination. Open https://siglume.com/owner/credits/payout and confirm the embedded-wallet payout token, or call GET /v1/market/developer/portal until payout_readiness.verified_destination is true.",
-      );
+    const companyId = String(project.manifest.company_id ?? "").trim()
+      || String(project.manifest.publisher_company_id ?? "").trim();
+    const publisherType = String(project.manifest.publisher_type ?? (companyId ? "company" : "user")).toLowerCase();
+    if (publisherType === "company") {
+      if (!companyId) {
+        throw new SiglumeProjectError("Paid company registration requires --company <company_id> or manifest.company_id.");
+      }
+      const companies = companyPublisherCandidates ?? await client.list_company_publishers();
+      const company = companies.find((item) => item.company_id === companyId);
+      if (!company) {
+        throw new SiglumeProjectError(`Company ${companyId} is not available to this API key.`);
+      }
+      if (company.settlement_wallet_ready !== true) {
+        throw new SiglumeProjectError(
+          `Paid company registration requires a verified company settlement wallet for ${company.name}. Open the company settings and complete settlement readiness before registering.`,
+        );
+      }
+      developerPortalPreflight = { company_publisher: toJsonable(company) };
+    } else {
+      const portal = await client.get_developer_portal();
+      const verifiedDestination = portal.payout_readiness?.verified_destination;
+      if (verifiedDestination !== true) {
+        throw new SiglumeProjectError(
+          "Paid API registration requires a verified Polygon payout destination. Open https://siglume.com/owner/credits/payout and confirm the embedded-wallet payout token, or call GET /v1/market/developer/portal until payout_readiness.verified_destination is true.",
+        );
+      }
+      developerPortalPreflight = toJsonable(portal);
     }
-    developerPortalPreflight = toJsonable(portal);
   }
   const receipt = await client.auto_register(project.manifest, project.tool_manual, {
     runtime_validation: project.runtime_validation,

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -21,6 +21,7 @@ import type {
   AgentTopicSubscription,
   AppListingRecord,
   AppManifest,
+  CompanyPublisherRecord,
   ApprovalPolicy,
   BundleListingRecord,
   BundleMember,
@@ -220,6 +221,12 @@ export interface SiglumeClientShape {
   submit_review(listing_id: string): Promise<AppListingRecord>;
   list_my_listings(options?: { status?: string; limit?: number; cursor?: string }): Promise<CursorPage<AppListingRecord>>;
   get_listing(listing_id: string): Promise<AppListingRecord>;
+  list_company_publishers(): Promise<CompanyPublisherRecord[]>;
+  request_company_publish_approval(listing_id: string, note?: string): Promise<AppListingRecord>;
+  decide_company_publish_approval(
+    listing_id: string,
+    options: { decision: "approve" | "reject"; reason?: string },
+  ): Promise<AppListingRecord>;
   get_capability_state(capability_key: string, save_key?: string): Promise<CapabilitySaveStateRecord>;
   put_capability_state(
     capability_key: string,
@@ -878,6 +885,12 @@ function parseListing(data: Record<string, unknown>): AppListingRecord {
     seller_display_name: stringOrNull(data.seller_display_name),
     seller_homepage_url: stringOrNull(data.seller_homepage_url),
     seller_social_url: stringOrNull(data.seller_social_url),
+    publisher_type: stringOrNull(data.publisher_type),
+    publisher_company_id: stringOrNull(data.publisher_company_id),
+    company_id: stringOrNull(data.company_id),
+    company_name: stringOrNull(data.company_name),
+    company_publish_status: stringOrNull(data.company_publish_status),
+    company_terms_version: stringOrNull(data.company_terms_version),
     review_status: stringOrNull(data.review_status),
     review_note: stringOrNull(data.review_note),
     submission_blockers: Array.isArray(data.submission_blockers)
@@ -886,6 +899,28 @@ function parseListing(data: Record<string, unknown>): AppListingRecord {
     persistence: { ...persistence },
     created_at: stringOrNull(data.created_at),
     updated_at: stringOrNull(data.updated_at),
+    raw: { ...data },
+  };
+}
+
+function parseCompanyPublisher(data: Record<string, unknown>): CompanyPublisherRecord {
+  const wallets = Array.isArray(data.settlement_wallets)
+    ? data.settlement_wallets.filter((item): item is Record<string, unknown> => isRecord(item))
+    : [];
+  return {
+    company_id: String(data.company_id ?? data.id ?? ""),
+    name: String(data.name ?? ""),
+    status: String(data.status ?? ""),
+    description: stringOrNull(data.description),
+    is_founder: Boolean(data.is_founder ?? false),
+    membership_role: stringOrNull(data.membership_role),
+    can_publish: Boolean(data.can_publish ?? true),
+    can_approve: Boolean(data.can_approve ?? false),
+    company_terms_version: stringOrNull(data.company_terms_version),
+    active_listing_count: Number(data.active_listing_count ?? 0),
+    pending_approval_count: Number(data.pending_approval_count ?? 0),
+    settlement_wallet_ready: Boolean(data.settlement_wallet_ready ?? false),
+    settlement_wallets: wallets.map((item) => ({ ...item })),
     raw: { ...data },
   };
 }
@@ -2230,6 +2265,9 @@ export class SiglumeClient implements SiglumeClientShape {
       "support_contact",
       "seller_homepage_url",
       "seller_social_url",
+      "publisher_type",
+      "company_id",
+      "publisher_company_id",
       "store_vertical",
       "jurisdiction",
       "price_model",
@@ -2282,6 +2320,25 @@ export class SiglumeClient implements SiglumeClientShape {
           `AppManifest.free_trial_duration_days must be between 1 and 90 when allow_free_trial=true, got: ${duration}.`,
         );
       }
+    }
+    const explicitPublisherType = payload.publisher_type !== undefined && payload.publisher_type !== null;
+    const companyId = String(payload.company_id ?? "").trim() || String(payload.publisher_company_id ?? "").trim();
+    const publisherType = String(payload.publisher_type ?? (companyId ? "company" : "user")).trim().toLowerCase();
+    if (publisherType !== "user" && publisherType !== "company") {
+      throw new SiglumeClientError("AppManifest.publisher_type must be 'user' or 'company'.");
+    }
+    if (publisherType === "company" && !companyId) {
+      throw new SiglumeClientError("AppManifest.company_id is required when publisher_type='company'.");
+    }
+    if (publisherType === "user" && companyId) {
+      throw new SiglumeClientError("AppManifest.company_id cannot be combined with publisher_type='user'.");
+    }
+    if (explicitPublisherType || companyId) {
+      payload.publisher_type = publisherType;
+    }
+    if (companyId) {
+      payload.company_id = companyId;
+      payload.publisher_company_id = companyId;
     }
     validateManifestPersistenceContract(payload);
     // Strip `version` from the embedded manifest sub-dict too so the
@@ -2422,6 +2479,33 @@ export class SiglumeClient implements SiglumeClientShape {
 
   async get_listing(listing_id: string): Promise<AppListingRecord> {
     const [data] = await this.request("GET", `/market/capabilities/${listing_id}`);
+    return parseListing(data);
+  }
+
+  async list_company_publishers(): Promise<CompanyPublisherRecord[]> {
+    const [data] = await this.request("GET", "/market/company-publishers");
+    return Array.isArray(data.items)
+      ? data.items.filter((item): item is Record<string, unknown> => isRecord(item)).map(parseCompanyPublisher)
+      : [];
+  }
+
+  async request_company_publish_approval(listing_id: string, note?: string): Promise<AppListingRecord> {
+    const [data] = await this.request("POST", `/market/capabilities/${listing_id}/company-publish-approval`, {
+      json_body: note ? { note } : {},
+    });
+    return parseListing(data);
+  }
+
+  async decide_company_publish_approval(
+    listing_id: string,
+    options: { decision: "approve" | "reject"; reason?: string },
+  ): Promise<AppListingRecord> {
+    const [data] = await this.request("POST", `/market/capabilities/${listing_id}/company-publish-approval/decision`, {
+      json_body: {
+        decision: options.decision,
+        ...(options.reason ? { reason: options.reason } : {}),
+      },
+    });
     return parseListing(data);
   }
 

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -138,6 +138,9 @@ export interface AppManifest {
   support_contact?: string;
   seller_homepage_url?: string;
   seller_social_url?: string;
+  publisher_type?: "user" | "company";
+  company_id?: string;
+  publisher_company_id?: string;
   store_vertical: StoreVertical;
   compatibility_tags?: string[];
   example_prompts?: string[];
@@ -323,12 +326,35 @@ export interface AppListingRecord {
   seller_display_name?: string | null;
   seller_homepage_url?: string | null;
   seller_social_url?: string | null;
+  publisher_type?: string | null;
+  publisher_company_id?: string | null;
+  company_id?: string | null;
+  company_name?: string | null;
+  company_publish_status?: string | null;
+  company_terms_version?: string | null;
   review_status?: string | null;
   review_note?: string | null;
   submission_blockers: string[];
   persistence: Record<string, unknown>;
   created_at?: string | null;
   updated_at?: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface CompanyPublisherRecord {
+  company_id: string;
+  name: string;
+  status: string;
+  description?: string | null;
+  is_founder: boolean;
+  membership_role?: string | null;
+  can_publish: boolean;
+  can_approve: boolean;
+  company_terms_version?: string | null;
+  active_listing_count: number;
+  pending_approval_count: number;
+  settlement_wallet_ready: boolean;
+  settlement_wallets: Array<Record<string, unknown>>;
   raw: Record<string, unknown>;
 }
 

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -541,6 +541,59 @@ describe("SiglumeClient", () => {
     );
   });
 
+  it("forwards company publisher identifiers when company_id is present", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        if (url.pathname === "/v1/market/capabilities/auto-register") {
+          const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+          expect(body.publisher_type).toBe("company");
+          expect(body.company_id).toBe("co_123");
+          expect(body.publisher_company_id).toBe("co_123");
+          return new Response(
+            JSON.stringify(envelope({ listing_id: "lst_company", status: "draft", auto_manifest: {}, confidence: {} })),
+            { status: 201 },
+          );
+        }
+        return new Response("{}", { status: 500 });
+      },
+    });
+
+    await client.auto_register(
+      {
+        ...buildManifest(),
+        company_id: "",
+        publisher_company_id: "co_123",
+      },
+      buildToolManual(),
+      { runtime_validation: buildRuntimeValidation() },
+    );
+  });
+
+  it("rejects user publisher manifests with company identifiers", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async () => {
+        throw new Error("auto_register should fail before transport");
+      },
+    });
+
+    await expect(
+      client.auto_register(
+        {
+          ...buildManifest(),
+          publisher_type: "user",
+          company_id: "co_123",
+        },
+        buildToolManual(),
+        { runtime_validation: buildRuntimeValidation() },
+      ),
+    ).rejects.toThrow("AppManifest.company_id cannot be combined with publisher_type='user'.");
+  });
+
   it("forwards JPY as the listing currency for auto_register", async () => {
     const client = new SiglumeClient({
       api_key: "sig_test_key",

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -617,6 +617,53 @@ describe("cli project helpers", () => {
     expect(autoRegisterCalled).toBe(true);
   });
 
+  it("treats publisher_company_id as a company publisher during paid preflight", async () => {
+    const projectDir = await createObjectProject({
+      manifest: {
+        ...manifestBase(),
+        price_model: PriceModel.SUBSCRIPTION,
+        price_value_minor: 1200,
+        company_id: "",
+        publisher_company_id: "co_123",
+      },
+    });
+    let listCompanyPublishersCalled = false;
+    let personalPortalCalled = false;
+
+    const report = await runRegistration(
+      projectDir,
+      {},
+      {
+        env: { SIGLUME_API_KEY: "sig_test_key" },
+        client_factory: () =>
+          ({
+            async preview_quality_score() {
+              return publishableQualityReport();
+            },
+            async list_company_publishers() {
+              listCompanyPublishersCalled = true;
+              return [{ company_id: "co_123", name: "Acme Labs", settlement_wallet_ready: true }];
+            },
+            async get_developer_portal() {
+              personalPortalCalled = true;
+              throw new Error("personal payout preflight should not run");
+            },
+            async auto_register(manifest: Record<string, unknown>) {
+              expect(manifest.publisher_company_id).toBe("co_123");
+              return { listing_id: "lst_company_alias", status: "draft", auto_manifest: {}, confidence: {} };
+            },
+            async confirm_registration(listing_id: string) {
+              return confirmedRegistration(listing_id);
+            },
+          }) as unknown as SiglumeClientShape,
+      },
+    );
+
+    expect((report.receipt as { listing_id: string }).listing_id).toBe("lst_company_alias");
+    expect(listCompanyPublishersCalled).toBe(true);
+    expect(personalPortalCalled).toBe(false);
+  });
+
   it("covers registration, support, and usage helper branches", async () => {
     const projectDir = await createObjectProject();
     const usageCapture = { api_key: undefined as string | undefined, usage_calls: 0 };

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -219,6 +219,9 @@ class AppManifest:
     support_contact: str = ""              # real support email address or public support URL
     seller_homepage_url: str = ""          # optional official seller homepage, separate from docs_url
     seller_social_url: str = ""            # optional official seller social/profile URL
+    publisher_type: str | None = None      # "user" (default) or "company"
+    company_id: str | None = None          # required when publisher_type is "company"
+    publisher_company_id: str | None = None  # alias accepted by the platform
     store_vertical: StoreVertical | None = None  # REQUIRED: "api" for normal API Store, "game" for API games
     compatibility_tags: list[str] = field(default_factory=list)
     latency_tier: str = "normal"           # fast, normal, slow
@@ -271,6 +274,16 @@ class AppManifest:
             )
         self.store_vertical = StoreVertical(vertical)
         self._validate_persistence_contract()
+
+        company_id = (self.company_id or self.publisher_company_id or "").strip()
+        publisher_type = (self.publisher_type or ("company" if company_id else "user")).strip().lower()
+        if publisher_type not in {"user", "company"}:
+            raise ValueError("AppManifest.publisher_type must be 'user' or 'company'.")
+        if publisher_type == "company" and not company_id:
+            raise ValueError("AppManifest.company_id is required when publisher_type='company'.")
+        self.publisher_type = publisher_type
+        self.company_id = company_id or None
+        self.publisher_company_id = company_id or None
 
         if not self.jurisdiction:
             raise ValueError(

--- a/siglume_api_sdk/__init__.py
+++ b/siglume_api_sdk/__init__.py
@@ -90,6 +90,7 @@ from .client import (  # noqa: E402, F401
     BudgetPolicy,
     CapabilityBindingRecord,
     CapabilitySaveStateRecord,
+    CompanyPublisherRecord,
     ConnectedAccountLifecycleResult,
     ConnectedAccountOAuthStart,
     ConnectedAccountRecord,

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -127,12 +127,36 @@ class AppListingRecord:
     seller_display_name: str | None = None
     seller_homepage_url: str | None = None
     seller_social_url: str | None = None
+    publisher_type: str | None = None
+    publisher_company_id: str | None = None
+    company_id: str | None = None
+    company_name: str | None = None
+    company_publish_status: str | None = None
+    company_terms_version: str | None = None
     review_status: str | None = None
     review_note: str | None = None
     submission_blockers: list[str] = field(default_factory=list)
     persistence: dict[str, Any] = field(default_factory=dict)
     created_at: str | None = None
     updated_at: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class CompanyPublisherRecord:
+    company_id: str
+    name: str
+    status: str
+    description: str | None = None
+    is_founder: bool = False
+    membership_role: str | None = None
+    can_publish: bool = True
+    can_approve: bool = False
+    company_terms_version: str | None = None
+    active_listing_count: int = 0
+    pending_approval_count: int = 0
+    settlement_wallet_ready: bool = False
+    settlement_wallets: list[dict[str, Any]] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
 
 
@@ -1425,6 +1449,9 @@ def _build_auto_register_request(
         "support_contact",
         "seller_homepage_url",
         "seller_social_url",
+        "publisher_type",
+        "company_id",
+        "publisher_company_id",
         "store_vertical",
         "jurisdiction",
         "price_model",
@@ -1475,6 +1502,20 @@ def _build_auto_register_request(
                 "AppManifest.free_trial_duration_days must be between 1 and 90 when "
                 f"allow_free_trial=True, got: {duration}."
             )
+    explicit_publisher_type = payload.get("publisher_type") is not None
+    company_id = str(payload.get("company_id") or payload.get("publisher_company_id") or "").strip()
+    publisher_type = str(payload.get("publisher_type") or ("company" if company_id else "user")).strip().lower()
+    if publisher_type not in {"user", "company"}:
+        raise SiglumeClientError("AppManifest.publisher_type must be 'user' or 'company'.")
+    if publisher_type == "company" and not company_id:
+        raise SiglumeClientError("AppManifest.company_id is required when publisher_type='company'.")
+    if publisher_type == "user" and company_id:
+        raise SiglumeClientError("AppManifest.company_id cannot be combined with publisher_type='user'.")
+    if explicit_publisher_type or company_id:
+        payload["publisher_type"] = publisher_type
+    if company_id:
+        payload["company_id"] = company_id
+        payload["publisher_company_id"] = company_id
     _validate_manifest_persistence_contract(payload)
 
     # Strip ``version`` from the embedded manifest sub-dict too so the
@@ -1586,6 +1627,12 @@ def _parse_listing(data: Mapping[str, Any]) -> AppListingRecord:
         seller_display_name=_string_or_none(data.get("seller_display_name")),
         seller_homepage_url=_string_or_none(data.get("seller_homepage_url")),
         seller_social_url=_string_or_none(data.get("seller_social_url")),
+        publisher_type=_string_or_none(data.get("publisher_type")),
+        publisher_company_id=_string_or_none(data.get("publisher_company_id")),
+        company_id=_string_or_none(data.get("company_id")),
+        company_name=_string_or_none(data.get("company_name")),
+        company_publish_status=_string_or_none(data.get("company_publish_status")),
+        company_terms_version=_string_or_none(data.get("company_terms_version")),
         review_status=_string_or_none(data.get("review_status")),
         review_note=_string_or_none(data.get("review_note")),
         submission_blockers=[
@@ -1594,6 +1641,26 @@ def _parse_listing(data: Mapping[str, Any]) -> AppListingRecord:
         persistence=dict(persistence) if isinstance(persistence, Mapping) else {},
         created_at=_string_or_none(data.get("created_at")),
         updated_at=_string_or_none(data.get("updated_at")),
+        raw=dict(data),
+    )
+
+
+def _parse_company_publisher(data: Mapping[str, Any]) -> CompanyPublisherRecord:
+    wallets = data.get("settlement_wallets") if isinstance(data.get("settlement_wallets"), list) else []
+    return CompanyPublisherRecord(
+        company_id=str(data.get("company_id") or data.get("id") or ""),
+        name=str(data.get("name") or ""),
+        status=str(data.get("status") or ""),
+        description=_string_or_none(data.get("description")),
+        is_founder=bool(data.get("is_founder") or False),
+        membership_role=_string_or_none(data.get("membership_role")),
+        can_publish=bool(data.get("can_publish") if data.get("can_publish") is not None else True),
+        can_approve=bool(data.get("can_approve") or False),
+        company_terms_version=_string_or_none(data.get("company_terms_version")),
+        active_listing_count=int(data.get("active_listing_count") or 0),
+        pending_approval_count=int(data.get("pending_approval_count") or 0),
+        settlement_wallet_ready=bool(data.get("settlement_wallet_ready") or False),
+        settlement_wallets=[dict(item) for item in wallets if isinstance(item, Mapping)],
         raw=dict(data),
     )
 
@@ -3137,6 +3204,37 @@ class SiglumeClient:
 
     def get_listing(self, listing_id: str) -> AppListingRecord:
         data, _meta = self._request("GET", f"/market/capabilities/{listing_id}")
+        return _parse_listing(data)
+
+    def list_company_publishers(self) -> list[CompanyPublisherRecord]:
+        data, _meta = self._request("GET", "/market/company-publishers")
+        items = data.get("items") if isinstance(data.get("items"), list) else []
+        return [_parse_company_publisher(item) for item in items if isinstance(item, Mapping)]
+
+    def request_company_publish_approval(self, listing_id: str, note: str | None = None) -> AppListingRecord:
+        payload = {"note": note} if note else {}
+        data, _meta = self._request(
+            "POST",
+            f"/market/capabilities/{listing_id}/company-publish-approval",
+            json_body=payload,
+        )
+        return _parse_listing(data)
+
+    def decide_company_publish_approval(
+        self,
+        listing_id: str,
+        *,
+        decision: str,
+        reason: str | None = None,
+    ) -> AppListingRecord:
+        data, _meta = self._request(
+            "POST",
+            f"/market/capabilities/{listing_id}/company-publish-approval/decision",
+            json_body={
+                "decision": decision,
+                **({"reason": reason} if reason else {}),
+            },
+        )
         return _parse_listing(data)
 
     def get_capability_state(self, capability_key: str, save_key: str = "default") -> CapabilitySaveStateRecord:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -674,6 +675,54 @@ def test_auto_register_hoists_input_form_spec_from_tool_manual() -> None:
         )
 
     assert receipt.listing_id == "lst_form"
+
+
+def test_auto_register_forwards_company_publisher_identifiers() -> None:
+    manifest = asdict(build_manifest())
+    manifest.pop("publisher_type", None)
+    manifest["company_id"] = ""
+    manifest["publisher_company_id"] = "co_123"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/market/capabilities/auto-register"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["publisher_type"] == "company"
+        assert payload["company_id"] == "co_123"
+        assert payload["publisher_company_id"] == "co_123"
+        return httpx.Response(
+            201,
+            json=envelope(
+                {
+                    "listing_id": "lst_company",
+                    "status": "draft",
+                    "auto_manifest": {"capability_key": manifest["capability_key"]},
+                    "confidence": {},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        receipt = client.auto_register(
+            manifest,
+            build_tool_manual(),
+            runtime_validation=build_runtime_validation(),
+        )
+
+    assert receipt.listing_id == "lst_company"
+
+
+def test_auto_register_rejects_user_publisher_with_company_identifiers() -> None:
+    manifest = asdict(build_manifest())
+    manifest["publisher_type"] = "user"
+    manifest["company_id"] = "co_123"
+
+    with build_client(lambda request: pytest.fail("auto_register should fail before transport")) as client:
+        with pytest.raises(SiglumeClientError, match="cannot be combined with publisher_type='user'"):
+            client.auto_register(
+                manifest,
+                build_tool_manual(),
+                runtime_validation=build_runtime_validation(),
+            )
 
 
 def test_cursor_pages_follow_next_cursor_for_listings_and_usage() -> None:


### PR DESCRIPTION
## Summary
- Adds company publisher fields to the developer surface schema/OpenAPI contracts.
- Adds Python/TypeScript SDK support for company-named capability publishing without changing the default user-publisher request shape.
- Adds CLI flags for company publishing during `siglume register`.

## Verification
- `npm run test -- --coverage.enabled=false`
- `npm run typecheck`
- `py -3.11 -m pytest`
- `py -3.11 -m pytest tests\test_contract_sync.py tests\test_docs_contract.py -q`
- GitHub Actions: `contract-sync`, `test (3.11)`, `test (3.12)`, `typescript` passed
