### PR TITLE
Add company publisher registration support

### DIFF
--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -488,6 +488,31 @@ paths:
                     type: string
                     description: Dashboard URL where the seller can inspect the receipt before publishing.
 
+  /market/company-publishers:
+    get:
+      operationId: listCompanyPublishers
+      summary: List companies available for company-name publishing
+      description: |
+        Returns active companies where the authenticated user can publish API
+        Store or Game API Store listings under the company name. Paid company
+        registrations must use a company with `settlement_wallet_ready=true`;
+        resulting net seller revenue is split equally among active formal
+        members captured at revenue-confirmation time.
+      tags: [Capabilities]
+      responses:
+        '200':
+          description: Company publisher candidates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanyPublisherPageEnvelope'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /market/capabilities/{listingId}/confirm-auto-register:
     post:
       operationId: confirmAutoRegister
@@ -579,6 +604,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConfirmAutoRegisterEnvelope'
+
+  /market/capabilities/{listingId}/company-publish-approval:
+    post:
+      operationId: requestCompanyPublishApproval
+      summary: Request founder approval for a company listing
+      description: |
+        Used by a responsible company member after auto-register creates or
+        updates a company-name listing. Founder users are approved immediately;
+        other active members move the listing to `approval_required` and notify
+        the founder before public publish can continue.
+      tags: [Capabilities]
+      parameters:
+        - name: listingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompanyPublishApprovalRequest'
+      responses:
+        '200':
+          description: Updated listing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppListingEnvelope'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /market/capabilities/{listingId}/company-publish-approval/decision:
+    post:
+      operationId: decideCompanyPublishApproval
+      summary: Approve or reject company listing publication
+      description: |
+        Founder-only decision endpoint for company-name API Store and Game API
+        Store listings. Approved listings may proceed through the normal
+        self-serve publish gate; rejected listings keep the reason so the
+        responsible publisher can reapply.
+      tags: [Capabilities]
+      parameters:
+        - name: listingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompanyPublishApprovalDecisionRequest'
+      responses:
+        '200':
+          description: Updated listing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppListingEnvelope'
+        '403':
+          description: Founder required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
 
   /market/tool-manuals/preview-quality:
     post:
@@ -1756,6 +1853,10 @@ components:
         support_contact: { type: string, description: "Real support email address or public support URL." }
         seller_homepage_url: { type: string, description: "Optional official seller homepage, separate from docs_url." }
         seller_social_url: { type: string, description: "Optional official seller social/profile URL, separate from docs_url." }
+        publisher_type: { type: string, enum: [user, company], description: "Publishing subject. Use company with company_id for company-name listings." }
+        company_id: { type: string, description: "Siglume company id when publisher_type is company." }
+        publisher_company_id: { type: string, description: "Alias for company_id." }
+        store_vertical: { type: string, enum: [api, game], description: "Store surface: api for API Store or game for Game API Store." }
         jurisdiction: { type: string, description: Governing ISO 3166-1 alpha-2 country code for the API }
         input_shape_summary: { type: string }
         output_shape_summary: { type: string }
@@ -1787,6 +1888,74 @@ components:
         sandbox_support: { type: string }
         status: { type: string }
         visibility: { type: string }
+
+    CompanyPublisher:
+      type: object
+      properties:
+        company_id: { type: string }
+        id: { type: string }
+        name: { type: string }
+        description: { type: string, nullable: true }
+        status: { type: string }
+        icon_image_url: { type: string, nullable: true }
+        is_founder: { type: boolean }
+        membership_role: { type: string, nullable: true }
+        can_publish: { type: boolean }
+        can_approve: { type: boolean }
+        company_terms_version: { type: string }
+        active_listing_count: { type: integer }
+        pending_approval_count: { type: integer }
+        settlement_wallet_ready:
+          type: boolean
+          description: True when a verified company settlement wallet exists for paid company listings.
+        settlement_wallets:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    CompanyPublisherPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyPublisher'
+        company_terms_version: { type: string }
+
+    CompanyPublisherPageEnvelope:
+      type: object
+      required: [data, meta, error]
+      properties:
+        data:
+          $ref: '#/components/schemas/CompanyPublisherPage'
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          anyOf:
+            - $ref: '#/components/schemas/ErrorResponse'
+            - type: 'null'
+
+    CompanyPublishApprovalRequest:
+      type: object
+      properties:
+        note:
+          type: string
+          description: Optional note shown in the company event log.
+
+    CompanyPublishApprovalDecisionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approve, approved, reject, rejected]
+        reason:
+          type: string
+          description: Required by product policy when rejecting, shown to the responsible publisher.
+        note:
+          type: string
+          description: Alias for reason.
 
     AppListingPage:
       type: object
@@ -1838,6 +2007,23 @@ components:
         seller_display_name: { type: string, nullable: true }
         seller_homepage_url: { type: string, nullable: true }
         seller_social_url: { type: string, nullable: true }
+        publisher_type: { type: string, enum: [user, company], nullable: true }
+        seller_type: { type: string, enum: [user, company], nullable: true }
+        publisher_company_id: { type: string, nullable: true }
+        company_id: { type: string, nullable: true }
+        publisher_company_name: { type: string, nullable: true }
+        company_name: { type: string, nullable: true }
+        company_publish_status:
+          type: string
+          nullable: true
+          enum: [not_required, approval_required, approval_requested, approved, rejected]
+        company_publish_rejection_reason: { type: string, nullable: true }
+        company_terms_version: { type: string, nullable: true }
+        store_revenue_total_net_minor:
+          type: integer
+          nullable: true
+          description: Lifetime company store net revenue after platform/payment/refund/adjustment deductions.
+        store_revenue_last_confirmed_at: { type: string, format: date-time, nullable: true }
         required_connected_accounts:
           type: array
           items:

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -6,6 +6,7 @@ import {
   createSupportCaseReport,
   diffJsonFiles,
   getUsageReport,
+  listCompanyPublishersReport,
   listOperationCatalog,
   runPreflight,
   runHarness,
@@ -33,6 +34,25 @@ function renderOperationTable(operations: Array<Record<string, unknown>>): strin
     String(item.summary ?? ""),
   ]);
   const headers = ["operation_key", "permission_class", "summary"];
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  return [
+    headers.map((header, index) => header.padEnd(widths[index] ?? header.length)).join("  "),
+    widths.map((width) => "-".repeat(width)).join("  "),
+    ...rows.map((row) => row.map((cell, index) => cell.padEnd(widths[index] ?? cell.length)).join("  ")),
+  ];
+}
+
+function renderCompanyTable(companies: Array<Record<string, unknown>>): string[] {
+  const rows = companies.map((item) => [
+    String(item.company_id ?? item.id ?? ""),
+    String(item.name ?? ""),
+    String(item.membership_role ?? (item.is_founder ? "founder" : "")),
+    String(item.settlement_wallet_ready === true ? "ready" : "not_ready"),
+    String(item.pending_approval_count ?? 0),
+  ]);
+  const headers = ["company_id", "name", "role", "settlement", "pending"];
   const widths = headers.map((header, index) =>
     Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
   );
@@ -261,6 +281,27 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
       }
       if (report.runtime_validation_path) emit(stdout, `runtime_validation_path: ${String(report.runtime_validation_path)}`);
       if (report.oauth_credentials_path) emit(stdout, `oauth_credentials_path: ${String(report.oauth_credentials_path)}`);
+    });
+
+  program
+    .command("companies")
+    .description("List Siglume companies available for company-name publishing.")
+    .option("--json", "emit machine-readable JSON", false)
+    .action(async (options: { json?: boolean }) => {
+      const report = await listCompanyPublishersReport(deps);
+      if (options.json) {
+        emit(stdout, renderJson(report));
+        return;
+      }
+      const companies = Array.isArray(report.companies)
+        ? report.companies.filter((item: unknown): item is Record<string, unknown> => Boolean(item && typeof item === "object"))
+        : [];
+      if (companies.length === 0) {
+        emit(stdout, "No company publishers available for this API key.");
+        return;
+      }
+      emit(stdout, "Company publishers");
+      renderCompanyTable(companies).forEach((line) => emit(stdout, line));
     });
 
   program

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -873,6 +873,17 @@ export async function getUsageReport(
   };
 }
 
+export async function listCompanyPublishersReport(
+  deps: CliProjectDependencies = {},
+): Promise<Record<string, unknown>> {
+  const client = await createClient(deps);
+  const companies = await client.list_company_publishers();
+  return {
+    companies: companies.map((item) => toJsonable(item)),
+    count: companies.length,
+  };
+}
+
 export async function diffJsonFiles(
   oldPath: string,
   newPath: string,

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -84,6 +84,19 @@ function createMockClient() {
         raw: {},
       };
     },
+    async list_company_publishers() {
+      return [
+        {
+          company_id: "co_123",
+          name: "Northwind AI",
+          membership_role: "founder",
+          is_founder: true,
+          settlement_wallet_ready: true,
+          pending_approval_count: 2,
+          raw: {},
+        },
+      ];
+    },
     async list_operations() {
       return [
         {
@@ -560,6 +573,186 @@ describe("siglume CLI", () => {
     expect(seen.trace_id).toBe("trc_123");
   });
 
+  it("lists company publishers for company-name registration", async () => {
+    const jsonLines: string[] = [];
+    const tableLines: string[] = [];
+
+    const jsonExit = await runCli(["companies", "--json"], {
+      client_factory: () => createMockClient() as unknown as SiglumeClientShape,
+      stdout: (line) => jsonLines.push(line),
+    });
+    const tableExit = await runCli(["companies"], {
+      client_factory: () => createMockClient() as unknown as SiglumeClientShape,
+      stdout: (line) => tableLines.push(line),
+    });
+    const payload = JSON.parse(jsonLines.join("\n"));
+
+    expect(jsonExit).toBe(0);
+    expect(tableExit).toBe(0);
+    expect(payload.companies[0].company_id).toBe("co_123");
+    expect(tableLines.join("\n")).toContain("Northwind AI");
+    expect(tableLines.join("\n")).toContain("ready");
+  });
+
+  it("prints an empty company publisher state", async () => {
+    const lines: string[] = [];
+    const exit = await runCli(["companies"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async list_company_publishers() {
+          return [];
+        },
+      }) as unknown as SiglumeClientShape,
+      stdout: (line) => lines.push(line),
+    });
+
+    expect(exit).toBe(0);
+    expect(lines.join("\n")).toContain("No company publishers available for this API key.");
+  });
+
+  it("prints company publishers without founder role or settlement readiness", async () => {
+    const lines: string[] = [];
+    const exit = await runCli(["companies"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async list_company_publishers() {
+          return [
+            {
+              company_id: "co_wait",
+              name: "Waiting Co",
+              is_founder: false,
+              settlement_wallet_ready: false,
+              pending_approval_count: 0,
+              raw: {},
+            },
+          ];
+        },
+      }) as unknown as SiglumeClientShape,
+      stdout: (line) => lines.push(line),
+    });
+
+    expect(exit).toBe(0);
+    expect(lines.join("\n")).toContain("Waiting Co");
+    expect(lines.join("\n")).toContain("not_ready");
+  });
+
+  it("registers a draft under an explicit company publisher", async () => {
+    const projectDir = await createTestProject();
+    const captured: { manifest?: Record<string, unknown> } = {};
+    const stdout: string[] = [];
+
+    const exit = await runCli(["register", projectDir, "--company", "co_123", "--draft-only", "--json"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async auto_register(manifest: Record<string, unknown>) {
+          captured.manifest = manifest;
+          return createMockClient().auto_register();
+        },
+      }) as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stdout: (line) => stdout.push(line),
+    });
+
+    expect(exit).toBe(0);
+    expect(captured.manifest?.publisher_type).toBe("company");
+    expect(captured.manifest?.company_id).toBe("co_123");
+    expect(captured.manifest?.publisher_company_id).toBe("co_123");
+    expect(JSON.parse(stdout.join("\n")).receipt.listing_id).toBe("lst_123");
+  });
+
+  it("registers a draft under a company resolved by slug", async () => {
+    const projectDir = await createTestProject();
+    const captured: { manifest?: Record<string, unknown> } = {};
+
+    const exit = await runCli(["register", projectDir, "--company-slug", "northwind-ai", "--draft-only"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async auto_register(manifest: Record<string, unknown>) {
+          captured.manifest = manifest;
+          return createMockClient().auto_register();
+        },
+      }) as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(exit).toBe(0);
+    expect(captured.manifest?.publisher_type).toBe("company");
+    expect(captured.manifest?.company_id).toBe("co_123");
+  });
+
+  it("rejects invalid company publisher selectors", async () => {
+    const projectDir = await createTestProject();
+    const stderr: string[] = [];
+    const combinedExit = await runCli(["register", projectDir, "--company", "co_123", "--company-slug", "northwind-ai"], {
+      client_factory: () => createMockClient() as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stderr: (line) => stderr.push(line),
+    });
+    const missingExit = await runCli(["register", projectDir, "--company-slug", "missing-company"], {
+      client_factory: () => createMockClient() as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stderr: (line) => stderr.push(line),
+    });
+    const invalidExit = await runCli(["register", projectDir, "--company-slug", "!!!"], {
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stderr: (line) => stderr.push(line),
+    });
+
+    expect(combinedExit).toBe(1);
+    expect(missingExit).toBe(1);
+    expect(invalidExit).toBe(1);
+    expect(stderr.join("\n")).toContain("--company and --company-slug cannot be combined.");
+    expect(stderr.join("\n")).toContain("Company slug missing-company is not available to this API key.");
+    expect(stderr.join("\n")).toContain("Company slug !!! is not slug-compatible; use --company <company_id> instead.");
+  });
+
+  it("prints registration mode specific human-readable status messages", async () => {
+    const projectDir = await createTestProject();
+    const acceptedLines: string[] = [];
+    const refreshedLines: string[] = [];
+    const createdLines: string[] = [];
+    const acceptedExit = await runCli(["register", projectDir], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async auto_register() {
+          const receipt = await createMockClient().auto_register();
+          return { ...receipt, registration_mode: "create" };
+        },
+      }) as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stdout: (line) => acceptedLines.push(line),
+    });
+    const refreshedExit = await runCli(["register", projectDir, "--draft-only"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async auto_register() {
+          const receipt = await createMockClient().auto_register();
+          return { ...receipt, registration_mode: "refresh" };
+        },
+      }) as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stdout: (line) => refreshedLines.push(line),
+    });
+    const createdExit = await runCli(["register", projectDir, "--draft-only"], {
+      client_factory: () => ({
+        ...createMockClient(),
+        async auto_register() {
+          const receipt = await createMockClient().auto_register();
+          return { ...receipt, registration_mode: undefined };
+        },
+      }) as unknown as SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+      stdout: (line) => createdLines.push(line),
+    });
+
+    expect(acceptedExit).toBe(0);
+    expect(refreshedExit).toBe(0);
+    expect(createdExit).toBe(0);
+    expect(acceptedLines.join("\n")).toContain("Registration accepted.");
+    expect(refreshedLines.join("\n")).toContain("Draft refreshed.");
+    expect(createdLines.join("\n")).toContain("Draft listing created.");
+  });
+
   it("prints register review metadata in human-readable mode", async () => {
     const projectDir = await createTestProject();
     const stdout: string[] = [];
@@ -650,6 +843,73 @@ describe("siglume CLI", () => {
     expect(payload.ok).toBe(true);
     expect(payload.registration_preflight).toBeTruthy();
     expect(autoRegisterCalled).toBe(false);
+  });
+
+  it("prints preflight metadata in human-readable mode", async () => {
+    const projectDir = await createTestProject();
+    const stdout: string[] = [];
+
+    const preflightExit = await runCli(["preflight", projectDir], {
+      stdout: (line) => stdout.push(line),
+      client_factory: (() => createMockClient()) as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(preflightExit).toBe(0);
+    expect(stdout.join("\n")).toContain("Preflight passed.");
+    expect(stdout.join("\n")).toContain("preflight_quality: A (92/100)");
+    expect(stdout.join("\n")).toContain("runtime_validation_path:");
+  });
+
+  it("prints harness failure metadata in human-readable mode", async () => {
+    const projectDir = await createTestProject();
+    const importHref = pathToFileURL(join(process.cwd(), "src", "index.ts")).href;
+    await writeFile(
+      join(projectDir, "adapter.ts"),
+      [
+        `import { AppAdapter, AppCategory, ApprovalMode, PermissionClass, PriceModel } from "${importHref}";`,
+        "",
+        "export default class FailingPaymentQuoteApp extends AppAdapter {",
+        "  manifest() {",
+        "    return {",
+        "      capability_key: \"payment-quote\",",
+        "      name: \"Payment Quote\",",
+        "      job_to_be_done: \"Quote a USD charge and complete the payment only after owner approval.\",",
+        "      category: AppCategory.FINANCE,",
+        "      store_vertical: 'api' as const,",
+        "      permission_class: PermissionClass.PAYMENT,",
+        "      approval_mode: ApprovalMode.ALWAYS_ASK,",
+        "      dry_run_supported: true,",
+        "      required_connected_accounts: [],",
+        "      price_model: PriceModel.FREE,",
+        "      jurisdiction: \"US\",",
+        "      short_description: \"Preview, quote, and complete a USD payment flow with explicit approval.\",",
+        "      example_prompts: [\"Quote the charge for this premium report purchase.\"],",
+        "    };",
+        "  }",
+        "  async execute(ctx) {",
+        "    return { success: false, execution_kind: ctx.execution_kind, output: { summary: \"failed\" } };",
+        "  }",
+        "  supported_task_types() {",
+        "    return [\"quote_payment\", \"charge_payment\"];",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const testExit = await runCli(["test", projectDir], {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    });
+
+    expect(testExit).toBe(1);
+    expect(stdout.join("\n")).toContain("Harness failed.");
+    expect(stdout.join("\n")).toContain("Adapter:");
+    expect(stderr.join("\n")).toContain("Harness failed.");
   });
 
   it("prints legacy submit-review publish wording in human-readable mode", async () => {

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -281,6 +281,8 @@ class AppManifest:
             raise ValueError("AppManifest.publisher_type must be 'user' or 'company'.")
         if publisher_type == "company" and not company_id:
             raise ValueError("AppManifest.company_id is required when publisher_type='company'.")
+        if publisher_type == "user" and company_id:
+            raise ValueError("AppManifest.company_id cannot be combined with publisher_type='user'.")
         self.publisher_type = publisher_type
         self.company_id = company_id or None
         self.publisher_company_id = company_id or None

--- a/siglume_api_sdk/cli/__init__.py
+++ b/siglume_api_sdk/cli/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import click
 
 from siglume_api_sdk.cli.commands.dev_cmd import dev_command
@@ -13,11 +15,55 @@ from siglume_api_sdk.cli.commands.support_cmd import support_command
 from siglume_api_sdk.cli.commands.test_cmd import test_command
 from siglume_api_sdk.cli.commands.usage_cmd import usage_command
 from siglume_api_sdk.cli.commands.validate_cmd import validate_command
+from siglume_api_sdk.cli.project import list_company_publishers_report, render_json
 
 
 @click.group()
 def main() -> None:
     """Siglume developer CLI."""
+
+
+def _render_company_table(companies: list[dict[str, Any]]) -> list[str]:
+    rows = [
+        [
+            str(item.get("company_id") or item.get("id") or ""),
+            str(item.get("name") or ""),
+            str(item.get("membership_role") or ("founder" if item.get("is_founder") else "")),
+            "ready" if item.get("settlement_wallet_ready") is True else "not_ready",
+            str(item.get("pending_approval_count") or 0),
+        ]
+        for item in companies
+    ]
+    headers = ["company_id", "name", "role", "settlement", "pending"]
+    widths = [
+        max([len(header), *(len(row[index]) for row in rows)])
+        for index, header in enumerate(headers)
+    ]
+    return [
+        "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)),
+        "  ".join("-" * width for width in widths),
+        *["  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row)) for row in rows],
+    ]
+
+
+@click.command("companies")
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+def companies_command(json_output: bool) -> None:
+    """List Siglume companies available for company-name publishing."""
+    report = list_company_publishers_report()
+    if json_output:
+        click.echo(render_json(report))
+        return
+    companies = [
+        item for item in report.get("companies", [])
+        if isinstance(item, dict)
+    ]
+    if not companies:
+        click.echo("No company publishers available for this API key.")
+        return
+    click.echo("Company publishers")
+    for line in _render_company_table(companies):
+        click.echo(line)
 
 
 main.add_command(init_command)
@@ -26,6 +72,7 @@ main.add_command(validate_command)
 main.add_command(test_command)
 main.add_command(score_command)
 main.add_command(preflight_command)
+main.add_command(companies_command)
 main.add_command(register_command)
 main.add_command(scan_command)
 main.add_command(support_command)

--- a/siglume_api_sdk/cli/commands/register_cmd.py
+++ b/siglume_api_sdk/cli/commands/register_cmd.py
@@ -11,9 +11,20 @@ from siglume_api_sdk.cli.project import render_json, run_registration
 @click.option("--draft-only", is_flag=True, help="Create or refresh the draft without confirming publication.")
 @click.option("--submit-review", is_flag=True, help="Legacy alias: publish immediately if your environment still routes through submit-review.")
 @click.option("--yes", is_flag=True, help="Skip local scan confirmation prompts.")
+@click.option("--company", "company_id", default="", help="Publish under a Siglume company name; revenue is split equally among active members.")
+@click.option("--company-slug", default="", help="Publish under a Siglume company by matching the slugified company name.")
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
 @click.argument("path", required=False, default=".")
-def register_command(confirm: bool, draft_only: bool, submit_review: bool, yes: bool, json_output: bool, path: str) -> None:
+def register_command(
+    confirm: bool,
+    draft_only: bool,
+    submit_review: bool,
+    yes: bool,
+    company_id: str,
+    company_slug: str,
+    json_output: bool,
+    path: str,
+) -> None:
     if draft_only and confirm:
         raise click.ClickException("--draft-only cannot be combined with --confirm.")
     if draft_only and submit_review:
@@ -35,7 +46,13 @@ def register_command(confirm: bool, draft_only: bool, submit_review: bool, yes: 
         for pattern in scan_result["matched_patterns"]:
             click.echo(f"- {pattern}")
         click.confirm("Continue publishing anyway?", abort=True)
-    result = run_registration(path, confirm=should_confirm, submit_review=submit_review)
+    result = run_registration(
+        path,
+        confirm=should_confirm,
+        submit_review=submit_review,
+        company_id=company_id,
+        company_slug=company_slug,
+    )
     result["local_prompt_injection_scan"] = scan_result
     if json_output:
         click.echo(render_json(result))

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -6,6 +6,7 @@ import importlib.util
 import inspect
 import json
 import os
+import re
 import sys
 import textwrap
 import tomllib
@@ -1362,9 +1363,50 @@ def _manifest_price_model(manifest: AppManifest) -> str:
     return str(to_jsonable(manifest.price_model) or "free").strip().lower()
 
 
-def _ensure_paid_payout_ready(project: LoadedProject, client: SiglumeClient) -> dict[str, Any] | None:
+def _company_name_slug(value: str) -> str:
+    return re.sub(r"^-+|-+$", "", re.sub(r"[^a-z0-9]+", "-", value.strip().lower()))
+
+
+def _manifest_company_id(manifest: AppManifest) -> str:
+    payload = to_jsonable(manifest)
+    return str(payload.get("company_id") or payload.get("publisher_company_id") or "").strip()
+
+
+def _manifest_publisher_type(manifest: AppManifest) -> str:
+    company_id = _manifest_company_id(manifest)
+    payload = to_jsonable(manifest)
+    return str(payload.get("publisher_type") or ("company" if company_id else "user")).strip().lower()
+
+
+def _set_manifest_company(project: LoadedProject, company_id: str) -> None:
+    normalized = company_id.strip()
+    project.manifest.publisher_type = "company"
+    project.manifest.company_id = normalized
+    project.manifest.publisher_company_id = normalized
+
+
+def _ensure_paid_payout_ready(
+    project: LoadedProject,
+    client: SiglumeClient,
+    company_publishers: list[Any] | None = None,
+) -> dict[str, Any] | None:
     if _manifest_price_model(project.manifest) == "free":
         return None
+    if _manifest_publisher_type(project.manifest) == "company":
+        company_id = _manifest_company_id(project.manifest)
+        if not company_id:
+            raise click.ClickException("Paid company registration requires --company <company_id> or manifest.company_id.")
+        companies = company_publishers if company_publishers is not None else client.list_company_publishers()
+        company = next((item for item in companies if getattr(item, "company_id", "") == company_id), None)
+        if company is None:
+            raise click.ClickException(f"Company {company_id} is not available to this API key.")
+        if getattr(company, "settlement_wallet_ready", False) is not True:
+            name = getattr(company, "name", company_id)
+            raise click.ClickException(
+                f"Paid company registration requires a verified company settlement wallet for {name}. "
+                "Open the company settings and complete settlement readiness before registering."
+            )
+        return {"company_publisher": to_jsonable(company)}
     portal = client.get_developer_portal()
     readiness = dict(portal.payout_readiness or {})
     if readiness.get("verified_destination") is not True:
@@ -1559,8 +1601,25 @@ def _registration_preflight(project: LoadedProject, client: SiglumeClient) -> di
     return preflight
 
 
-def run_registration(path: str | Path, *, confirm: bool, submit_review: bool) -> dict[str, Any]:
+def run_registration(
+    path: str | Path,
+    *,
+    confirm: bool,
+    submit_review: bool,
+    company_id: str | None = None,
+    company_slug: str | None = None,
+) -> dict[str, Any]:
     project = load_project(path)
+    requested_company_id = str(company_id or "").strip()
+    requested_company_slug = str(company_slug or "").strip()
+    if requested_company_id and requested_company_slug:
+        raise click.ClickException("--company and --company-slug cannot be combined.")
+    if requested_company_slug:
+        slug = _company_name_slug(requested_company_slug)
+        if not slug:
+            raise click.ClickException(f"Company slug {requested_company_slug} is not slug-compatible; use --company <company_id> instead.")
+    if requested_company_id:
+        _set_manifest_company(project, requested_company_id)
     _ensure_explicit_tool_manual(project)
     _ensure_manifest_publisher_identity(project)
     _ensure_runtime_validation_ready(project)
@@ -1568,8 +1627,23 @@ def run_registration(path: str | Path, *, confirm: bool, submit_review: bool) ->
     canonical_oauth_credentials = _canonical_oauth_credentials_payload(project.oauth_credentials)
     api_key = resolve_api_key()
     with SiglumeClient(api_key=api_key) as client:
+        company_publishers = None
+        if requested_company_slug:
+            company_publishers = client.list_company_publishers()
+            slug = _company_name_slug(requested_company_slug)
+            matches = [
+                item
+                for item in company_publishers
+                if _company_name_slug(getattr(item, "name", "") or getattr(item, "company_id", "")) == slug
+                or getattr(item, "company_id", "") == requested_company_slug
+            ]
+            if not matches:
+                raise click.ClickException(f"Company slug {requested_company_slug} is not available to this API key.")
+            if len(matches) > 1:
+                raise click.ClickException(f"Company slug {requested_company_slug} is ambiguous; use --company <company_id> instead.")
+            _set_manifest_company(project, str(getattr(matches[0], "company_id", "")))
         registration_preflight = _registration_preflight(project, client)
-        portal_preflight = _ensure_paid_payout_ready(project, client)
+        portal_preflight = _ensure_paid_payout_ready(project, client, company_publishers)
         receipt = client.auto_register(
             project.manifest,
             project.tool_manual,
@@ -1615,6 +1689,16 @@ def run_preflight(path: str | Path) -> dict[str, Any]:
     if portal_preflight is not None:
         result["developer_portal_preflight"] = portal_preflight
     return result
+
+
+def list_company_publishers_report() -> dict[str, Any]:
+    api_key = resolve_api_key()
+    with SiglumeClient(api_key=api_key) as client:
+        companies = client.list_company_publishers()
+    return {
+        "companies": [to_jsonable(company) for company in companies],
+        "count": len(companies),
+    }
 
 
 def create_support_case_report(


### PR DESCRIPTION
## Summary
- expose company publisher discovery in the OpenAPI developer surface
- add Python and TypeScript CLI support for listing company publishers and registering under `--company` / `--company-slug`
- enforce paid company registration settlement readiness and add TS CLI coverage for company publisher flows

## Verification
- `py -3.11 -m pytest -q`
- `npm --prefix siglume-api-sdk-ts run typecheck`
- `npm --prefix siglume-api-sdk-ts test`
- `py -3.11 packages\contracts\sdk\scripts\check_public_sdk_sync.py --peer-dir C:\tmp\siglume-api-sdk-phase2-20260520145013` from the main repo