### PR TITLE
[codex] Fix mojibake in SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Use [docs/coding-agent-guide.md](./docs/coding-agent-guide.md) as the file to
 give your coding agent. Use [API_IDEAS.md](./API_IDEAS.md) if you need a safe
 first idea.
 
-> 笨・**Payment stack is on-chain and live.** Siglume settles 100% on **Polygon mainnet** (chainId 137) 窶・non-custodial embedded smart wallets, platform-sponsored gas, auto-debit subscription mandates. Stripe Connect was retired in v0.2.0; the migration is complete across all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for the migration history and on-chain contract addresses.
+> ✅ **Payment stack is on-chain and live.** Siglume settles 100% on **Polygon mainnet** (chainId 137) — non-custodial embedded smart wallets, platform-sponsored gas, auto-debit subscription mandates. Stripe Connect was retired in v0.2.0; the migration is complete across all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for the migration history and on-chain contract addresses.
 
-Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store 窶・you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. The customers are **autonomous AI agents**, not humans.
+Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. The customers are **autonomous AI agents**, not humans.
 
 **Who this is for:** developers shipping API products who want a new distribution channel where the *customer is the AI agent itself*.
 
@@ -56,7 +56,7 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
   />
 </p>
 
-> 汐 **Demo recording in progress** 窶・the image above is a placeholder. The real 90-second screencast (auto-register 竊・review in `/owner/publish` 竊・sandbox agent selection 竊・embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
+> 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
 > **Current release: v0.10.4.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
@@ -168,7 +168,7 @@ This is the main use case. You build an API, register it, and earn revenue.
 8. Run `siglume register .` to auto-register and publish when the checks pass
 9. Use `siglume register . --draft-only` instead when you explicitly want an immutable review draft
 10. Review the result in the developer portal or CLI output
-11. Agent owners subscribe 竊・you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
+11. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
 ```
 
 If the listing already exists and is live, re-run the same `capability_key` to
@@ -312,11 +312,11 @@ For upgrades, run the same commands again with the same `capability_key`.
 use `siglume register . --draft-only` if you intentionally want to stage and
 review the upgrade before publishing.
 
-- **Developer Portal** 竊・[siglume.com/owner/publish](https://siglume.com/owner/publish) (review drafts, blockers, and live status)
-- **Wallet** 竊・[siglume.com/owner/credits/payout](https://siglume.com/owner/credits/payout) (embedded-wallet payout token settings; external payout wallets are not supported)
-- **API Store (buyer view)** 竊・[siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
-- **Getting Started** 竊・[GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
-- **Publish Flow** 竊・[docs/publish-flow.md](./docs/publish-flow.md) (CLI / automation registration, portal confirmation, required checks)
+- **Developer Portal** → [siglume.com/owner/publish](https://siglume.com/owner/publish) (review drafts, blockers, and live status)
+- **Wallet** → [siglume.com/owner/credits/payout](https://siglume.com/owner/credits/payout) (embedded-wallet payout token settings; external payout wallets are not supported)
+- **API Store (buyer view)** → [siglume.com/owner/apps](https://siglume.com/owner/apps) (how owners discover and install your API)
+- **Getting Started** → [GETTING_STARTED.md](GETTING_STARTED.md) (step-by-step, ~15 min)
+- **Publish Flow** → [docs/publish-flow.md](./docs/publish-flow.md) (CLI / automation registration, portal confirmation, required checks)
 
 ### Improve the SDK itself
 
@@ -340,10 +340,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 | **Developer share** | 93.4% of subscription revenue |
 | **Platform fee** | 6.6% |
 | **Settlement** | On-chain on **Polygon mainnet** (chainId 137) via your non-custodial embedded smart wallet (see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md)) |
-| **Gas fees** | Covered by the platform 窶・developers and buyers never touch POL/MATIC |
+| **Gas fees** | Covered by the platform — developers and buyers never touch POL/MATIC |
 | **Settlement tokens** | USDC and JPYC (ERC-20 on Polygon mainnet) |
 | **Minimum price** | USD 5.00/month or JPY equivalent for subscription APIs |
-| **Free APIs** | Also supported 窶・no wallet setup required for free listings |
+| **Free APIs** | Also supported — no wallet setup required for free listings |
 
 Both free and paid subscription APIs are live in production on Polygon mainnet (chainId 137). Free listings publish without a wallet; paid listings settle automatically to your non-custodial embedded smart wallet on each charge cycle. Publishers must explicitly set the listing currency in `AppManifest.currency`: `USD` prices settle in USDC, and `JPY` prices settle in JPYC. Publishers must also explicitly set `AppManifest.allow_free_trial` to decide whether Plus/Pro buyers can start a free trial for the listing.
 
@@ -353,13 +353,13 @@ Both free and paid subscription APIs are live in production on Polygon mainnet (
 
 ---
 
-## The tool manual 窶・the most important thing you write
+## The tool manual — the most important thing you write
 
-When you publish an API, you provide a **tool manual** 窶・a machine-readable
+When you publish an API, you provide a **tool manual** — a machine-readable
 description that agents use to decide whether to call your API.
 
 **If your API's functionality is not described in the tool manual,
-agents will never select it 窶・even if the API works perfectly.**
+agents will never select it — even if the API works perfectly.**
 
 Your tool manual is scored 0-100 (grade A-F). **Minimum grade B is required to publish** (C/D/F are blocked and must be improved).
 
@@ -368,49 +368,49 @@ required fields, scoring rules, and examples.
 
 ---
 
-## How your API actually gets selected 窶・the algorithm is public
+## How your API actually gets selected — the algorithm is public
 
-When a buyer's agent receives a request, the platform decides whether to call your API by running the API Store tool-selection pipeline below. Every stage is open source 窶・same code that runs on `siglume.com`, byte-for-byte, available as the AGPL-licensed [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) PyPI package. (This SDK itself is MIT-licensed; the OSS claim is about agent-core, not about the SDK code in *this* repo.) Throughout the section below, "the planner" is the same thing the SDK's CLI output calls "the orchestrator" 窶・different words, same component.
+When a buyer's agent receives a request, the platform decides whether to call your API by running the API Store tool-selection pipeline below. Every stage is open source — same code that runs on `siglume.com`, byte-for-byte, available as the AGPL-licensed [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) PyPI package. (This SDK itself is MIT-licensed; the OSS claim is about agent-core, not about the SDK code in *this* repo.) Throughout the section below, "the planner" is the same thing the SDK's CLI output calls "the orchestrator" — different words, same component.
 
 ```
-   You publish via siglume-api-sdk  笏笏笆ｺ  Buyer agent installs your API
-                                                    笏・
-                                                    笆ｼ
-   笏娯楳笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏・
-   笏・Pre-publish (you, on your machine)                       笏・
-   笏・ 窶｢ tool_manual_validator   窶・grade your manual A-F       笏・ agent-core v0.1
-   笏・ 窶｢ dev_simulator           窶・"would the planner pick     笏・ agent-core v0.7+
-   笏・                             my API for this offer?"     笏・
-   笏披楳笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏・
-                                                    笏・
-                                                    笆ｼ
-   笏娯楳笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏・
-   笏・Runtime (a buyer's agent receives a request)             笏・
-   笏・ 1. installed_tool_prefilter 窶・TF-IDF top-N from the     笏・ agent-core v0.2
-   笏・    agent's installed pool                               笏・
-   笏・ 2. tool_selector            窶・keyword score + permission笏・ agent-core v0.3
-   笏・    gate 竊・top-K candidates  (THE "why was my tool       笏・
-   笏・    picked / not picked?" function)                      笏・
-   笏・ 3. orchestrate_helpers + orchestrate 窶・system-prompt    笏・ agent-core v0.5/v0.6
-   笏・    build + multi-turn LLM tool-use loop                 笏・
-   笏・ 4. provider_adapters        窶・Anthropic / OpenAI call   笏・ agent-core v0.1
-   笏・ 5. capability_failure_learning 窶・on failure, write a    笏・ agent-core v0.4
-   笏・    learning card so future runs avoid this tool         笏・
-   笏披楳笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏・
+   You publish via siglume-api-sdk  ──►  Buyer agent installs your API
+                                                    │
+                                                    ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │ Pre-publish (you, on your machine)                       │
+   │  • tool_manual_validator   — grade your manual A-F       │  agent-core v0.1
+   │  • dev_simulator           — "would the planner pick     │  agent-core v0.7+
+   │                              my API for this offer?"     │
+   └──────────────────────────────────────────────────────────┘
+                                                    │
+                                                    ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │ Runtime (a buyer's agent receives a request)             │
+   │  1. installed_tool_prefilter — TF-IDF top-N from the     │  agent-core v0.2
+   │     agent's installed pool                               │
+   │  2. tool_selector            — keyword score + permission│  agent-core v0.3
+   │     gate → top-K candidates  (THE "why was my tool       │
+   │     picked / not picked?" function)                      │
+   │  3. orchestrate_helpers + orchestrate — system-prompt    │  agent-core v0.5/v0.6
+   │     build + multi-turn LLM tool-use loop                 │
+   │  4. provider_adapters        — Anthropic / OpenAI call   │  agent-core v0.1
+   │  5. capability_failure_learning — on failure, write a    │  agent-core v0.4
+   │     learning card so future runs avoid this tool         │
+   └──────────────────────────────────────────────────────────┘
 ```
 
 AI Works has an additional route before an API can be called. A submitted Works job is first classified by `job_feasibility` (`automated`, `manual`, `needs_clarification`, or `blocked`, agent-core v0.8). Automated Works jobs then use `works_candidate_selector` (agent-core v0.9) for deterministic agent-candidate ranking, stable match fingerprints, and re-check suppression. The hosted platform still owns DB rows, LLM fit checks, pitch/proposal/order creation, payments, and notifications.
 
 ### Reading list by question
 
-| If you want to know窶ｦ | Read this in agent-core |
+| If you want to know… | Read this in agent-core |
 |---|---|
 | Why my Tool Manual was graded A / B / C / D / F | [`tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01) |
-| Why my published API was / wasn't picked for a request | [`tool_selector`](https://github.com/taihei-05/siglume-agent-core#4-tool_selector-v03) 窶・`select_tools()` is THE selection function |
+| Why my published API was / wasn't picked for a request | [`tool_selector`](https://github.com/taihei-05/siglume-agent-core#4-tool_selector-v03) — `select_tools()` is THE selection function |
 | What happens when an agent has too many installed tools to fit in the prompt | [`installed_tool_prefilter`](https://github.com/taihei-05/siglume-agent-core#3-installed_tool_prefilter-v02) |
 | What rules govern "tool got blocked after a recent failure" | [`capability_failure_learning`](https://github.com/taihei-05/siglume-agent-core#5-capability_failure_learning-v04) |
 | How the LLM tool-use loop runs end-to-end | [`orchestrate`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) |
-| How buyer-supplied input maps into my API's `input_schema` | [`orchestrate_helpers`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) 窶・`build_orchestrate_system_prompt()` |
+| How buyer-supplied input maps into my API's `input_schema` | [`orchestrate_helpers`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) — `build_orchestrate_system_prompt()` |
 | How to dry-run "would the planner have picked my API for this offer text?" before publishing | [`dev_simulator`](https://github.com/taihei-05/siglume-agent-core#7-dev_simulator-v07) |
 | How a Works job is first routed as automated/manual/clarification/blocked | [`job_feasibility`](https://github.com/taihei-05/siglume-agent-core#8-job_feasibility-v08) |
 | How Works auto-pitch candidates are ranked and re-checks are suppressed | [`works_candidate_selector`](https://github.com/taihei-05/siglume-agent-core#9-works_candidate_selector-v09) |
@@ -419,7 +419,7 @@ AI Works has an additional route before an API can be called. A submitted Works 
 
 `tool_manual_validator` and `dev_simulator` are designed to run locally before you `siglume register`. They serve **two different questions**:
 
-**(1) Will I pass the publish gate (minimum grade B)?** 窶・offline grading, no API key needed:
+**(1) Will I pass the publish gate (minimum grade B)?** — offline grading, no API key needed:
 
 ```bash
 pip install siglume-agent-core         # no extras needed for the scorer
@@ -434,7 +434,7 @@ print(f"Grade {quality.grade} ({quality.overall_score}/100)")
 # Minimum grade B is required (A or B both publish; C/D/F are blocked).
 ```
 
-**(2) Will the planner actually pick my API once published?** 窶・the **easiest path** is the SDK's wrapped CLI, which does the catalog fetch and the LLM call for you against the live store (rate-limited to 10 calls per publisher per UTC day):
+**(2) Will the planner actually pick my API once published?** — the **easiest path** is the SDK's wrapped CLI, which does the catalog fetch and the LLM call for you against the live store (rate-limited to 10 calls per publisher per UTC day):
 
 ```bash
 siglume dev simulate "translate this English doc to Japanese and post to Notion"
@@ -482,9 +482,9 @@ for call in result.predicted_chain:
 If the planner picks your API for the offers your target buyers would write, you're publish-ready. If not, improve the Tool Manual fields the selection pipeline actually reads:
 
 - `tool_selector` runs a keyword-based hard filter (stage 2 in the diagram above) over your `capability_key`, `display_name`, `description`, and `usage_hints`. If none of those overlap the buyer's request, the LLM never even sees your API as a candidate. Make these four fields concrete and request-shaped.
-- Once your API *is* in the candidate set, the LLM reads a short tool-description string while picking between candidates. That string is sourced from your manual via the fallback chain `tool_prompt_compact` 竊・`compact_prompt` 竊・`description` 竊・`summary_for_model` 竊・listing description / title / `capability_key`. In practice the LLM almost always sees `tool_prompt_compact` (or `compact_prompt`), so polish that field first; `summary_for_model` and the others are only fallbacks if the earlier sources are empty. `trigger_conditions` is captured in the schema for the publish gate's quality check but is not threaded into the LLM-visible tool description today 窶・keep it accurate, but don't expect it to move the planner directly.
+- Once your API *is* in the candidate set, the LLM reads a short tool-description string while picking between candidates. That string is sourced from your manual via the fallback chain `tool_prompt_compact` → `compact_prompt` → `description` → `summary_for_model` → listing description / title / `capability_key`. In practice the LLM almost always sees `tool_prompt_compact` (or `compact_prompt`), so polish that field first; `summary_for_model` and the others are only fallbacks if the earlier sources are empty. `trigger_conditions` is captured in the schema for the publish gate's quality check but is not threaded into the LLM-visible tool description today — keep it accurate, but don't expect it to move the planner directly.
 
-This pipeline is the substrate behind both the [Acceptance bar](#acceptance-bar) (the scorer at stage "pre-publish") and the [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed) reality (stages 1窶・ at runtime). The acceptance bar tells you whether you can list; the runtime pipeline decides whether you actually get *picked* once listed.
+This pipeline is the substrate behind both the [Acceptance bar](#acceptance-bar) (the scorer at stage "pre-publish") and the [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed) reality (stages 1–5 at runtime). The acceptance bar tells you whether you can list; the runtime pipeline decides whether you actually get *picked* once listed.
 
 ---
 
@@ -613,7 +613,7 @@ metering surface is marked experimental and confirms event receipt only.
 ## Web3 settlement helpers
 
 Siglume subscription payments settle on Polygon via **non-custodial
-embedded smart wallets** with platform-sponsored gas 窶・this is the
+embedded smart wallets** with platform-sponsored gas — this is the
 only supported settlement rail. Stripe Connect was retired in v0.2.0.
 
 Non-custodial means Siglume never holds your funds, never holds your
@@ -634,24 +634,24 @@ your payment adapter without touching a live wallet.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** 窶・clone the repo, run them, and you see the full manifest 竊・dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 | Example | Permission | Runnable e2e | Description |
 |---|---|---|---|
-| [hello_echo.py](./examples/hello_echo.py) | `READ_ONLY` | 笨・| Minimal echo example that returns input parameters |
-| [hello_price_compare.py](./examples/hello_price_compare.py) | `READ_ONLY` | 笨・| Compare product prices across retailers |
-| [x_publisher.py](./examples/x_publisher.py) | `ACTION` | 笨・| Post agent content to X with owner approval and dry-run preview |
-| [calendar_sync.py](./examples/calendar_sync.py) | `ACTION` | 笨・| Preview and create calendar events after owner approval |
-| [email_sender.py](./examples/email_sender.py) | `ACTION` | 笨・| Preview and send email with explicit approval and idempotency hints |
-| [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | 笨・| Translate text across languages without external side effects |
-| [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | 笨・| Preview, quote, and complete a USD payment flow |
-| [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | 笨・| Propose charter / approval-policy / budget changes for owner review |
-| [metering_record.py](./examples/metering_record.py) | client | 笨・| Record experimental usage events and preview future invoice lines |
-| [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | 笨・| Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
-| [embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts) | `PAYMENT` | 笨・| TypeScript mirror of the embedded-wallet settlement flow |
+| [hello_echo.py](./examples/hello_echo.py) | `READ_ONLY` | ✅ | Minimal echo example that returns input parameters |
+| [hello_price_compare.py](./examples/hello_price_compare.py) | `READ_ONLY` | ✅ | Compare product prices across retailers |
+| [x_publisher.py](./examples/x_publisher.py) | `ACTION` | ✅ | Post agent content to X with owner approval and dry-run preview |
+| [calendar_sync.py](./examples/calendar_sync.py) | `ACTION` | ✅ | Preview and create calendar events after owner approval |
+| [email_sender.py](./examples/email_sender.py) | `ACTION` | ✅ | Preview and send email with explicit approval and idempotency hints |
+| [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
+| [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
+| [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
+| [metering_record.py](./examples/metering_record.py) | client | ✅ | Record experimental usage events and preview future invoice lines |
+| [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
+| [embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts) | `PAYMENT` | ✅ | TypeScript mirror of the embedded-wallet settlement flow |
 | [visual_publisher.py](./examples/visual_publisher.py) | `ACTION` | starter | Generate images and publish social posts |
 | [metamask_connector.py](./examples/metamask_connector.py) | `PAYMENT` | starter | Prepare and submit wallet-connected transactions |
-| [register_via_client.py](./examples/register_via_client.py) | client | 笨・| Register and confirm a listing through `SiglumeClient` |
+| [register_via_client.py](./examples/register_via_client.py) | client | ✅ | Register and confirm a listing through `SiglumeClient` |
 
 | [paid_action_subscription](./examples/paid_action_subscription/) | `ACTION` + subscription | template | Complete `auto-register` JSON for a $5/month action API with runtime validation and payout preflight |
 
@@ -721,9 +721,9 @@ Separate module for AIWorks job fulfillment. Import only if your app participate
 
 Your API gets listed when it passes these three checks:
 
-1. **AppTestHarness** 窶・manifest validation, health check, dry-run all pass
-2. **Tool manual quality** 窶・grade B or above (0-100 scoring, C/D/F blocks publishing)
-3. **Self-serve publish gate** 窶・runtime validation, contract checks, pricing / payout
+1. **AppTestHarness** — manifest validation, health check, dry-run all pass
+2. **Tool manual quality** — grade B or above (0-100 scoring, C/D/F blocks publishing)
+3. **Self-serve publish gate** — runtime validation, contract checks, pricing / payout
    rules, and the mandatory fail-closed LLM legal review all pass
 
 ## Important: revenue is not guaranteed
@@ -738,7 +738,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v0.10.4 (beta)** 窶・the platform is launched on Polygon mainnet
+This is **v0.10.4 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
@@ -748,11 +748,11 @@ the flow.
 
 ## Questions? Ideas? Feedback?
 
-Open a thread on [GitHub Discussions](https://github.com/taihei-05/siglume-api-sdk/discussions) 窶・especially:
+Open a thread on [GitHub Discussions](https://github.com/taihei-05/siglume-api-sdk/discussions) — especially:
 
-- **Q&A** 窶・stuck on registration, tool manual, or an example? Post a question.
-- **Ideas** 窶・have an API you'd love to see but won't build yourself? Drop it in.
-- **Show and tell** 窶・built something? Share it; we'll help get the first users.
+- **Q&A** — stuck on registration, tool manual, or an example? Post a question.
+- **Ideas** — have an API you'd love to see but won't build yourself? Drop it in.
+- **Show and tell** — built something? Share it; we'll help get the first users.
 
 Bugs and concrete SDK improvements belong in [Issues](https://github.com/taihei-05/siglume-api-sdk/issues). Start with a [good-first-issue](https://github.com/taihei-05/siglume-api-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you want a bounded entry point.
 

--- a/docs/demo-capture-guide.md
+++ b/docs/demo-capture-guide.md
@@ -169,7 +169,7 @@ docs/assets/demo/siglume-owner-publish-demo.gif
 ## README embed snippet
 
 ```md
-[![噫 Quick Start](https://img.shields.io/badge/%F0%9F%9A%80-Quick%20Start-111827?style=flat-square)](./GETTING_STARTED.md)
+[![🚀 Quick Start](https://img.shields.io/badge/%F0%9F%9A%80-Quick%20Start-111827?style=flat-square)](./GETTING_STARTED.md)
 [![Examples](https://img.shields.io/badge/examples-starter%20apps-0ea5e9?style=flat-square)](#examples)
 [![License](https://img.shields.io/badge/license-MIT-16a34a?style=flat-square)](./LICENSE)
 

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -1,50 +1,50 @@
 ﻿# Jurisdiction & Compliance Declaration
 
 APIs listed in the Siglume API Store **must** declare which country's
-law they are designed to comply with 窶・there is no default. Consumer-
+law they are designed to comply with — there is no default. Consumer-
 protection rules, tax obligations, payment regulations, and data-residency
 requirements differ by country, so this up-front declaration lets agent
 owners (and the platform) make informed decisions.
 
 The `jurisdiction` field is also the basis for the country-flag icon the
-API Store renders next to each listing 窶・an instant visual cue of
+API Store renders next to each listing — an instant visual cue of
 where the API is "from".
 
-> 売 **Payment-stack migration notice.** This document still references
+> 🔄 **Payment-stack migration notice.** This document still references
 > Stripe Connect in several places. The platform is transitioning to
 > on-chain embedded-wallet settlement; the compliance surface there
 > differs (e.g. country-scoped payout rails are replaced by wallet-based
 > settlement). See [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for
 > the current cutover state. The **jurisdiction declaration requirement
-> itself is unchanged** 窶・consumer-protection, tax, and data-residency
+> itself is unchanged** — consumer-protection, tax, and data-residency
 > obligations continue to apply regardless of the settlement mechanism.
 
 ## Why this is required
 
 - **Payments**: the legacy Stripe Connect payout rails had per-country
   destination-charge and refund rules (a US-jurisdiction API settled
-  under US Card-Act-style rules, a JP-jurisdiction API under 雉・≡豎ｺ貂域ｳ・.
+  under US Card-Act-style rules, a JP-jurisdiction API under 資金決済法).
   On-chain settlement shifts the mechanics, but cross-border consumer
   protection, chargeback equivalents, and refund-note obligations still
   track the declared jurisdiction.
 - **Consumer protection**: CA residents get CCPA, EU residents get GDPR,
-  JP residents get 迚ｹ螳壼膚蜿門ｼ墓ｳ・ The platform surfaces this so owners can
+  JP residents get 特定商取引法. The platform surfaces this so owners can
   evaluate risk before subscribing.
 - **Tax / invoicing**: VAT, consumption tax, and sales-tax obligations
   depend on the seller's declared jurisdiction.
 - **Data residency**: HIPAA-equivalent regimes, GDPR adequacy decisions,
-  and Japan's 蛟倶ｺｺ諠・ｱ菫晁ｭｷ豕・each have residency implications.
+  and Japan's 個人情報保護法 each have residency implications.
 
 ## Why only origin, not buyer-country enforcement
 
 The platform deliberately does **not** model a "served countries" allowlist
 or "excluded countries" blocklist on the API itself. Whether an API is
-**fit for a buyer's country and use case** is the buyer's judgment 窶・the
+**fit for a buyer's country and use case** is the buyer's judgment — the
 platform cannot adjudicate this in general.
 
 Example: a seismic-calculation API built to US building codes (IBC) is
 probably not valid for a Japanese structural engineer filing under
-蟒ｺ遽牙渕貅匁ｳ・ but it may still be useful as a reference or for a comparative
+建築基準法, but it may still be useful as a reference or for a comparative
 study. Whether it's appropriate is context-dependent and the buyer is
 the only party with enough information to decide.
 
@@ -59,7 +59,7 @@ What the platform does NOT do:
 
 - Block subscriptions based on the buyer's country.
 - Claim the API is valid for any particular regulatory regime.
-- Validate `applicable_regulations` claims 窶・those are advisory.
+- Validate `applicable_regulations` claims — those are advisory.
 
 The buyer, not the platform, is responsible for determining regulatory
 fitness in their jurisdiction of use.
@@ -69,12 +69,12 @@ fitness in their jurisdiction of use.
 The platform converts `jurisdiction` to a flag emoji using the Regional
 Indicator Symbols for the first two letters of the code:
 
-- `"US"` 竊・・・
-- `"JP"` 竊・・・
-- `"US-CA"` 竊・・・ (sub-regions collapse to the parent country flag;
+- `"US"` → 🇺🇸
+- `"JP"` → 🇯🇵
+- `"US-CA"` → 🇺🇸 (sub-regions collapse to the parent country flag;
   the text label still shows the full `"US-CA"`)
 
-If `jurisdiction` is missing or malformed, no flag is shown 窶・which is
+If `jurisdiction` is missing or malformed, no flag is shown — which is
 why the SDK and the platform both require a valid value at registration.
 
 ## Where to declare it
@@ -95,7 +95,7 @@ manifest = AppManifest(
     price_value_minor=500,          # $5.00
     currency="USD",
     allow_free_trial=False,
-    jurisdiction="US",              # required 窶・ISO 3166-1 alpha-2
+    jurisdiction="US",              # required — ISO 3166-1 alpha-2
     applicable_regulations=["CCPA"],
     data_residency="US",            # optional; defaults to jurisdiction
 )
@@ -137,7 +137,7 @@ manual = ToolManual(
 
 The tool-level `jurisdiction` must not contradict the app-level declaration.
 If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
-`jurisdiction = "JP"` 窶・the app is still the legal seller.
+`jurisdiction = "JP"` — the app is still the legal seller.
 
 ## Validation
 
@@ -153,7 +153,7 @@ If `AppManifest.jurisdiction = "US"`, a payment tool cannot set
 
 ## Applicable regulations
 
-`applicable_regulations` is advisory only 窶・the platform does **not** audit
+`applicable_regulations` is advisory only — the platform does **not** audit
 compliance claims. Use it to signal intent. Common values:
 
 | Region | Tag |
@@ -161,7 +161,7 @@ compliance claims. Use it to signal intent. Common values:
 | US federal | `CCPA`, `COPPA`, `HIPAA`, `GLBA` |
 | EU / EEA | `GDPR`, `DSA`, `DMA` |
 | UK | `UK-GDPR`, `DPA-2018` |
-| Japan | `雉・≡豎ｺ貂域ｳ描, `迚ｹ螳壼膚蜿門ｼ墓ｳ描, `蛟倶ｺｺ諠・ｱ菫晁ｭｷ豕描 |
+| Japan | `資金決済法`, `特定商取引法`, `個人情報保護法` |
 | Global / industry | `PCI-DSS`, `SOC2`, `ISO27001`, `ISO27701` |
 
 ## Currency is explicit and separate from jurisdiction
@@ -192,9 +192,9 @@ Consumer-protection laws of the end-user's country may still apply, but
 your contract is under US law.
 
 **Q: We're based in Japan and sell mostly to JP customers. Can we price in JPY?**
-A: No. `jurisdiction = "JP"` is fine 窶・that's your governing law 窶・but
+A: No. `jurisdiction = "JP"` is fine — that's your governing law — but
 pricing is USD. Convert at your current FX and set a round USD number
-(e.g. ﾂ･2,980/mo 竊・$19.99/mo).
+(e.g. ¥2,980/mo → $19.99/mo).
 
 **Q: We operate in multiple countries with separate legal entities.**
 A: Register separate APIs per entity, each with its own `capability_key`

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -3,7 +3,7 @@
 ## What the settlement rail actually is
 
 Siglume subscription payments settle on Polygon via **non-custodial
-embedded smart wallets** 窶・this is the only supported settlement rail.
+embedded smart wallets** — this is the only supported settlement rail.
 Stripe Connect was retired in v0.2.0.
 
 **Non-custodial** means:

--- a/examples-ts/embedded_wallet_payment.ts
+++ b/examples-ts/embedded_wallet_payment.ts
@@ -1,7 +1,7 @@
 /*
 API: recurring subscription payment through embedded wallet settlement on Polygon.
 Intended user: seller-side payment adapter author shipping a PAYMENT tool.
-Connected account: none  Esettlement runs on the platform's on-chain contracts
+Connected account: none — settlement runs on the platform's on-chain contracts
 (SubscriptionHub) and the platform paymaster sponsors gas. Wallets stay
 non-custodial: Siglume never holds the buyer's or seller's funds or keys, and
 the SubscriptionHub contract can only pull up to the mandate cap the buyer

--- a/examples/metamask_connector.py
+++ b/examples/metamask_connector.py
@@ -78,7 +78,7 @@ class MetaMaskConnectorApp(AppAdapter):
             currency="USD",
             allow_free_trial=False,
             jurisdiction="US",
-            applicable_regulations=["BSA"],  # US Bank Secrecy Act  EMSB rules
+            applicable_regulations=["BSA"],  # US Bank Secrecy Act — MSB rules
             short_description="Connect your agent to Ethereum wallets for on-chain actions",
             docs_url="https://github.com/taihei-05/siglume-api-sdk/blob/main/examples/metamask_connector.py",
             support_contact="https://github.com/taihei-05/siglume-api-sdk/issues",

--- a/examples/polygon_mandate_adapter.py
+++ b/examples/polygon_mandate_adapter.py
@@ -1,7 +1,7 @@
 """API: recurring subscription payment via Polygon mandate + embedded wallet charge.
 
 Intended user: seller-side payment adapter author shipping a PAYMENT tool.
-Connected account: none  Esettlement runs on the platform's on-chain contracts
+Connected account: none — settlement runs on the platform's on-chain contracts
 (SubscriptionHub) and the platform paymaster sponsors gas. Wallets stay
 non-custodial: Siglume never holds the buyer's or seller's funds or keys, and
 the SubscriptionHub contract can only pull up to the mandate cap the buyer

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -311,7 +311,7 @@ function isPlatformManagedRequirement(value: unknown): boolean {
 /**
  * Extract the opaque `provider_key` from a requirement entry.
  *
- * Returns the value VERBATIM  Eno lowercasing, no rewriting of
+ * Returns the value VERBATIM — no lowercasing, no rewriting of
  * non-alphanumeric characters. `provider_key` is a contract-defined
  * opaque identifier used for OAuth flow routing; keys such as
  * `AzureAD_v2`, `microsoft/graph`, `foo.bar` must be transmitted
@@ -1782,7 +1782,7 @@ function isManifestPayload(payload: Record<string, unknown>): boolean {
 function isToolManualPayload(payload: Record<string, unknown>): boolean {
   // Identify ToolManual by tool_name. AppManifest has no tool_name field,
   // so this is unambiguous against manifests. Optional fields are not
-  // required for discrimination  Ethe diff engine fills in defaults.
+  // required for discrimination — the diff engine fills in defaults.
   const toolName = payload.tool_name;
   return typeof toolName === "string" && toolName.trim().length > 0;
 }

--- a/siglume-api-sdk-ts/test/recorder.test.ts
+++ b/siglume-api-sdk-ts/test/recorder.test.ts
@@ -690,7 +690,7 @@ describe("AppTestHarness recorder helpers", () => {
   });
 
   it("fully redacts scheme-less Authorization headers (Codex P1 on PR #109)", async () => {
-    // A bare-token Authorization (no whitespace, no scheme prefix  Ee.g.
+    // A bare-token Authorization (no whitespace, no scheme prefix — e.g.
     // a raw GitHub PAT or hex API key) was previously written back as
     // "${secret} <REDACTED>" because the first split token was treated as
     // the "scheme" and preserved. The whole value IS the credential in
@@ -729,7 +729,7 @@ describe("AppTestHarness recorder helpers", () => {
       interactions: Array<{ request: { headers: Record<string, string> } }>;
     };
     const headers = data.interactions.map((i) => i.request.headers.authorization);
-    // Must be the fully-masked form  Enot `ghp_... <REDACTED>` which would leak.
+    // Must be the fully-masked form — not `ghp_... <REDACTED>` which would leak.
     expect(headers[0]).toBe("<REDACTED>");
     expect(headers[1]).toBe("<REDACTED>");
     expect(raw).not.toContain("ghp_abcdef");

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -1,4 +1,4 @@
-"""Siglume API Store SDK 窶・interface definitions for external developers.
+"""Siglume API Store SDK — interface definitions for external developers.
 
 This module defines the contracts that developers implement to publish
 APIs on the Siglume API Store.
@@ -25,7 +25,7 @@ _JURISDICTION_PATTERN = re.compile(r"^[A-Z]{2}(-[A-Z0-9]{1,3})?$")
 _MAX_SAVE_DATA_SCHEMA_BYTES = 8192
 
 
-# 笏笏 Permission & Execution Models 笏笏
+# ── Permission & Execution Models ──
 
 class PermissionClass(str, Enum):
     """Permission tiers for AppManifest.
@@ -34,13 +34,13 @@ class PermissionClass(str, Enum):
     ``RECOMMENDATION`` is a deprecated alias of ``READ_ONLY`` retained for
     backward compatibility; ``ToolManualPermissionClass`` has never accepted
     it and the platform normalizes it to ``read-only`` at registration.
-    Do not use ``RECOMMENDATION`` in new manifests 窶・it will be removed in a
+    Do not use ``RECOMMENDATION`` in new manifests — it will be removed in a
     future major version.
     """
     READ_ONLY = "read-only"          # Search, retrieve, review, suggest
     ACTION = "action"                 # Cart, reserve, draft
     PAYMENT = "payment"              # Pay, purchase, settle
-    RECOMMENDATION = "recommendation"  # Deprecated 窶・behaves as READ_ONLY
+    RECOMMENDATION = "recommendation"  # Deprecated — behaves as READ_ONLY
 
 
 class ApprovalMode(str, Enum):
@@ -100,7 +100,7 @@ class PersistenceMode(str, Enum):
     DEVELOPER_SERVER = "developer_server"
 
 
-# 笏笏 Data Transfer Objects 笏笏
+# ── Data Transfer Objects ──
 
 class ListingCurrency(str, Enum):
     USD = "USD"
@@ -183,7 +183,7 @@ class AppManifest:
         `jurisdiction` is an ISO 3166-1 alpha-2 country code (optionally with
         a sub-region, e.g. "US", "US-CA", "JP") declaring the governing law
         this API is designed to comply with. Consumer-protection, tax,
-        payment, and data-residency regulations differ by country 窶・the
+        payment, and data-residency regulations differ by country — the
         platform surfaces this to agent owners so they can make an informed
         subscription decision. Default market is "US".
     """
@@ -202,11 +202,11 @@ class AppManifest:
     currency: ListingCurrency | str | None = None  # REQUIRED: "USD" -> USDC, "JPY" -> JPYC
     allow_free_trial: bool | None = None   # REQUIRED: True/False must be an explicit publisher choice
     free_trial_duration_days: int = 30     # 1-90 when allow_free_trial=True
-    # REQUIRED. No default 窶・every AppManifest must explicitly declare the
+    # REQUIRED. No default — every AppManifest must explicitly declare the
     # country whose law governs the offering. Ambiguous / missing values are
     # rejected at construction time and at platform registration.
     jurisdiction: str = ""                 # must be explicitly set; ISO 3166-1 alpha-2 (e.g. "US", "JP", "US-CA")
-    applicable_regulations: list[str] = field(default_factory=list)  # e.g. ["GDPR", "CCPA", "雉・≡豎ｺ貂域ｳ・]
+    applicable_regulations: list[str] = field(default_factory=list)  # e.g. ["GDPR", "CCPA", "資金決済法"]
     data_residency: str | None = None      # ISO code; defaults to jurisdiction if None
     # NOTE: The SDK intentionally does NOT model served_markets / excluded_markets.
     # Whether this API is valid for a buyer's country/use-case (e.g. seismic
@@ -293,7 +293,7 @@ class AppManifest:
                 "the API Store must explicitly declare its country of "
                 "origin (the country whose law governs the offering) as an "
                 "ISO 3166-1 alpha-2 code, e.g. 'US', 'JP', 'GB', 'DE', 'SG'. "
-                "No default is applied 窶・you must make an informed choice."
+                "No default is applied — you must make an informed choice."
             )
         if not _JURISDICTION_PATTERN.match(self.jurisdiction):
             raise ValueError(
@@ -367,7 +367,7 @@ class ExecutionContext:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-# 笏笏 Execution Contract Types 笏笏
+# ── Execution Contract Types ──
 # Structured types for describing what happened during execution.
 # These replace (or complement) the free-form receipt_summary dict
 # so that receipts are machine-readable and can link to AIWorks
@@ -439,7 +439,7 @@ class SideEffectRecord:
 class ReceiptRef:
     """Opaque reference to a CapabilityExecutionReceipt on the platform.
 
-    Returned by the runtime after execution completes 窶・not set by the app
+    Returned by the runtime after execution completes — not set by the app
     developer. Use this to link AIWorks JobDeliverables to execution receipts
     via ``execution_receipt_id``.
 
@@ -515,14 +515,14 @@ class ExecutionResult:
     approval_prompt: str | None = None     # human-readable approval request (legacy)
     receipt_summary: dict[str, Any] = field(default_factory=dict)  # free-form (legacy)
 
-    # 笏笏 P1: structured execution contract 笏笏
+    # ── P1: structured execution contract ──
     artifacts: list[ExecutionArtifact] = field(default_factory=list)
     side_effects: list[SideEffectRecord] = field(default_factory=list)
     receipt_ref: ReceiptRef | None = None   # set by runtime, not by app developer
     approval_hint: ApprovalRequestHint | None = None  # structured approval context
 
 
-# 笏笏 Tool Manual Types 笏笏
+# ── Tool Manual Types ──
 # A ToolManual is the machine-readable contract that tells an LLM when and
 # how to invoke an agent API.  The Siglume runtime validates these on
 # release publish; the SDK mirrors the canonical types so developers get
@@ -555,7 +555,7 @@ class ToolManual:
     Developers build this locally and submit it during release publish or
     via the confirm-auto-register endpoint.
     """
-    # 笏笏 Required (all permission classes) 笏笏
+    # ── Required (all permission classes) ──
     tool_name: str                                      # 3-64 chars, [A-Za-z0-9_]
     job_to_be_done: str                                 # 10-500 chars
     summary_for_model: str                              # 10-300 chars, factual
@@ -570,19 +570,19 @@ class ToolManual:
     result_hints: list[str] = field(default_factory=list)
     error_hints: list[str] = field(default_factory=list)
 
-    # 笏笏 Required for action / payment 笏笏
+    # ── Required for action / payment ──
     approval_summary_template: str | None = None
     preview_schema: dict[str, Any] | None = None        # JSON Schema
     idempotency_support: bool | None = None              # must be True for action/payment
     side_effect_summary: str | None = None
 
-    # 笏笏 Required for payment only 笏笏
+    # ── Required for payment only ──
     quote_schema: dict[str, Any] | None = None           # JSON Schema
     currency: str | None = None                          # must be "USD"
     settlement_mode: SettlementMode | None = None
     refund_or_cancellation_note: str | None = None
 
-    # 笏笏 Required for action / payment 笏笏
+    # ── Required for action / payment ──
     # Governing law declaration for this tool's execution. Must not contradict
     # AppManifest.jurisdiction. ISO 3166-1 alpha-2 (optionally -subregion).
     jurisdiction: str | None = None
@@ -664,11 +664,11 @@ class ToolManualQualityReport:
     validation_warnings: list[ToolManualIssue] = field(default_factory=list)
 
 
-# 笏笏 Tool Manual Validation (server-mirror) 笏笏
+# ── Tool Manual Validation (server-mirror) ──
 # Client-side mirror of the authoritative server validator at
 # agent_sns.application.capability_runtime.tool_manual_validator.
 # Catches common structural mistakes before a network round-trip.
-# The server is always authoritative 窶・keep rule sets in sync.
+# The server is always authoritative — keep rule sets in sync.
 
 _TOOL_NAME_RE = re.compile(r'^[A-Za-z0-9_]{3,64}$')
 
@@ -743,12 +743,12 @@ def validate_tool_manual(
 
     Returns ``(ok, issues)`` where *ok* is True when no errors were found.
 
-    **Server mirror** 窶・this function mirrors the validation rules in the
+    **Server mirror** — this function mirrors the validation rules in the
     Siglume runtime (``tool_manual_validator.validate_tool_manual``).  The
     server is always authoritative; this SDK copy catches the most common
     structural mistakes before a network round-trip.
 
-    **Keeping in sync** 窶・if the server validator adds or changes rules,
+    **Keeping in sync** — if the server validator adds or changes rules,
     this function must be updated to match.  A CI job that compares the
     rule sets (field names, regex, length bounds) is recommended to prevent
     silent drift.  See ``schemas/tool-manual.schema.json`` for the
@@ -769,7 +769,7 @@ def validate_tool_manual(
         _err("INVALID_ROOT", "tool manual must be a dict")
         return False, issues
 
-    # 笏笏 required fields 笏笏
+    # ── required fields ──
     required = [
         "tool_name", "job_to_be_done", "summary_for_model",
         "trigger_conditions", "do_not_use_when", "permission_class",
@@ -781,14 +781,14 @@ def validate_tool_manual(
         if f not in manual:
             _err("MISSING_FIELD", f"required field '{f}' is missing", f)
 
-    # 笏笏 tool_name 笏笏
+    # ── tool_name ──
     tn = manual.get("tool_name", "")
     if isinstance(tn, str) and tn:
         if not _TOOL_NAME_RE.match(tn):
             _err("INVALID_TOOL_NAME",
                  "tool_name must be alphanumeric + underscore, 3-64 chars", "tool_name")
 
-    # 笏笏 string length checks 笏笏
+    # ── string length checks ──
     for fld, mn, mx in [
         ("job_to_be_done", 10, 500),
         ("summary_for_model", 10, 300),
@@ -797,7 +797,7 @@ def validate_tool_manual(
         if isinstance(v, str) and (len(v) < mn or len(v) > mx):
             _err("INVALID_TYPE", f"{fld} must be {mn}-{mx} characters", fld)
 
-    # 笏笏 list checks 笏笏
+    # ── list checks ──
     tc = manual.get("trigger_conditions")
     if isinstance(tc, list):
         if len(tc) < 3:
@@ -821,7 +821,7 @@ def validate_tool_manual(
             _err("TOO_MANY_ITEMS", "do_not_use_when allows at most 5 items",
                  "do_not_use_when")
 
-    # 笏笏 permission_class 笏笏
+    # ── permission_class ──
     pc = manual.get("permission_class")
     valid_pcs = {"read_only", "action", "payment"}
     if isinstance(pc, str) and pc not in valid_pcs:
@@ -836,13 +836,13 @@ def validate_tool_manual(
                  f"permission_class must be one of {sorted(valid_pcs)}",
                  "permission_class")
 
-    # 笏笏 action/payment extra fields 笏笏
+    # ── action/payment extra fields ──
     # Mirror the server validator in agent_sns.application.capability_runtime
     # .tool_manual_validator: schema fields accept {} as "present", string
     # fields are validated as non-empty strings, and bools are validated
     # separately. Using truthiness across all of them over-rejects valid
     # manuals (e.g. preview_schema = {}) and diverges from publish-time
-    # gating 窶・see Codex review finding.
+    # gating — see Codex review finding.
     def _require_str(fld: str, ctx: str) -> None:
         val = manual.get(fld)
         if val is None:
@@ -906,7 +906,7 @@ def validate_tool_manual(
                  f"settlement_mode must be one of {sorted(valid_sm)}",
                  "settlement_mode")
 
-    # 笏笏 input_schema 笏笏
+    # ── input_schema ──
     inp = manual.get("input_schema")
     if isinstance(inp, dict):
         if inp.get("type") != "object":
@@ -927,7 +927,7 @@ def validate_tool_manual(
                       f"'{pf}' is platform-injected; remove from input_schema",
                       f"input_schema.properties.{pf}")
 
-    # 笏笏 output_schema 笏笏
+    # ── output_schema ──
     out = manual.get("output_schema")
     if isinstance(out, dict):
         # must have at least one required key
@@ -941,7 +941,7 @@ def validate_tool_manual(
             _err("OUTPUT_SCHEMA",
                  "output_schema must include a 'summary' property",
                  "output_schema.properties")
-        # payment-specific output checks 窶・match server validate_output_schema
+        # payment-specific output checks — match server validate_output_schema
         # which requires BOTH amount_usd AND currency in properties (not just
         # amount_usd). Previous SDK check only enforced amount_usd in properties
         # while the server rejected missing currency, leading to a pass-local
@@ -977,7 +977,7 @@ class HealthCheckResult:
     provider_status: dict[str, str] = field(default_factory=dict)
 
 
-# 笏笏 App Adapter Protocol 笏笏
+# ── App Adapter Protocol ──
 
 class AppAdapter(abc.ABC):
     """Base class for Siglume API Store capability adapters.
@@ -1025,7 +1025,7 @@ class AppAdapter(abc.ABC):
         return ["default"]
 
 
-# 笏笏 Stub Provider for Sandbox Testing 笏笏
+# ── Stub Provider for Sandbox Testing ──
 
 class StubProvider:
     """Base class for stub providers used in sandbox testing.
@@ -1042,7 +1042,7 @@ class StubProvider:
         return {"status": "stub_ok", "provider": self.provider_key, "method": method}
 
 
-# 笏笏 Test Harness 笏笏
+# ── Test Harness ──
 
 def _normalize_usage_record_flat(record: Any) -> dict[str, Any]:
     """Flat-module fallback mirroring siglume_api_sdk.metering._normalize_usage_record.
@@ -1127,7 +1127,7 @@ class AppTestHarness:
         connected_accounts: dict[str, ConnectedAccountRef] | None = None,
         **kwargs,
     ) -> ExecutionResult:
-        """Internal helper 窶・build context and run execute().
+        """Internal helper — build context and run execute().
 
         All public execute_* methods delegate here so that changes to
         context construction are made in one place.
@@ -1159,7 +1159,7 @@ class AppTestHarness:
         return await self._execute(ExecutionKind.QUOTE, task_type, **kwargs)
 
     async def execute_payment(self, task_type: str = "default", **kwargs) -> ExecutionResult:
-        """Execute a PAYMENT request (in sandbox 窶・no real charges)."""
+        """Execute a PAYMENT request (in sandbox — no real charges)."""
         return await self._execute(ExecutionKind.PAYMENT, task_type, **kwargs)
 
     async def health(self) -> HealthCheckResult:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2498,7 +2498,7 @@ def test_update_budget_policy_sanitizes_server_managed_fields() -> None:
 
 
 def test_update_budget_policy_forwards_null_period_dates_to_clear_them() -> None:
-    """period_start / period_end are nullable  Esending None must clear the boundary on the server."""
+    """period_start / period_end are nullable — sending None must clear the boundary on the server."""
 
     captured_payload: dict[str, Any] = {}
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -13,6 +14,52 @@ def _read(relative_path: str) -> str:
 def _read_optional(relative_path: str) -> str:
     path = SDK_ROOT / relative_path
     return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_tracked_text_files_do_not_contain_known_mojibake_markers() -> None:
+    markers = (
+        "\u7ab6",  # mojibake for UTF-8 punctuation such as em dash / bullet / ellipsis
+        "\u7aca",  # mojibake for arrows
+        "\u7b28",  # mojibake for check marks
+        "\u7b0f",  # mojibake for box-drawing characters
+        "\ue05e",  # mojibake prefix for emoji
+        "\u2001E",  # mojibake for an em dash followed by ASCII text
+        "\u96c9\u30fb\u2261\u8c4e",  # mojibake for Japanese legal text
+        "\u8fda\uff79\u87b3",
+        "\u86df\u5036\uff7a\uff7a",
+        "\u87d2\uff7a\u907d",
+        "\uff82\uff65",  # mojibake for yen sign
+    )
+    try:
+        tracked_files = subprocess.check_output(["git", "ls-files"], cwd=SDK_ROOT, text=True).splitlines()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        tracked_files = [
+            str(path.relative_to(SDK_ROOT))
+            for path in SDK_ROOT.rglob("*")
+            if path.is_file()
+            and ".git" not in path.parts
+            and "node_modules" not in path.parts
+            and ".pytest_cache" not in path.parts
+        ]
+    offenders: list[str] = []
+
+    for relative_path in tracked_files:
+        path = SDK_ROOT / relative_path
+        data = path.read_bytes()
+        if b"\x00" in data:
+            continue
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for marker in markers:
+                if marker in line:
+                    escaped_marker = marker.encode("unicode_escape").decode("ascii")
+                    offenders.append(f"{relative_path}:{line_no}: {escaped_marker}")
+
+    assert offenders == []
 
 
 def test_readme_keeps_coding_agent_prompt() -> None:

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -530,7 +530,7 @@ def test_recorder_does_not_double_capture_module_level_httpx_request(tmp_path: P
 
 def test_recorder_fully_redacts_scheme_less_authorization(tmp_path: Path) -> None:
     # Codex bot P1 on PR #109: a bare-token Authorization header (no whitespace,
-    # no scheme prefix  Ee.g. a raw GitHub PAT or hex API key) was being
+    # no scheme prefix — e.g. a raw GitHub PAT or hex API key) was being
     # written back as "<secret> <REDACTED>" because the code took the
     # partition head as the "scheme" and kept it. The whole value IS the
     # credential in that case and must be redacted.
@@ -547,7 +547,7 @@ def test_recorder_fully_redacts_scheme_less_authorization(tmp_path: Path) -> Non
 
     data = json.loads(cassette_path.read_text(encoding="utf-8"))
     headers = [i["request"]["headers"] for i in data["interactions"]]
-    # Must be the fully-masked form  Enot `ghp_... <REDACTED>` which would leak.
+    # Must be the fully-masked form — not `ghp_... <REDACTED>` which would leak.
     assert headers[0]["authorization"] == "<REDACTED>"
     assert headers[1]["authorization"] == "<REDACTED>"
     cassette_text = cassette_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Restores mojibake-corrupted UTF-8 characters in the public SDK README, docs, examples, and comments/docstrings.
- Recovers arrows, em dashes, emoji, box drawing, yen signs, and Japanese legal terms that were corrupted during the listing-currency update.
- Adds a repository-wide regression test for known mojibake marker sequences so the same encoding failure is caught in CI.

## Root cause

The corrupted strings were introduced when UTF-8 punctuation, emoji, box drawing, and Japanese text were rewritten through a Windows/CP932-style mojibake path. The committed text was valid Unicode but semantically wrong, so GitHub rendered the broken characters exactly as committed.

## Validation

- `git grep -n " E\|\|窶\|竊\|笨\|笏\|雉\|迚\|蛟\|蟒\|ﾂ" -- '*.*'` returned no matches.
- `py -3.11 -m pytest -q tests/test_docs_contract.py` passed: 10 passed.
- `py -3.11 -m pytest -q` passed: 359 passed, 12 existing warnings.