### PR TITLE
[codex] Release v0.10.8 mojibake fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.8] - 2026-05-28
+
+### Fixed
+
+- Restored UTF-8 punctuation, emoji, box-drawing characters, yen signs, and
+  Japanese legal terms that were committed as mojibake in public SDK docs,
+  examples, comments, and docstrings.
+- Added a repository-wide regression test that scans tracked UTF-8 text files
+  for known mojibake marker sequences.
+
 ## [0.10.7] - 2026-05-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v0.10.4.** Python and TypeScript are version-aligned and
+> **Current release: v0.10.8.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, seller-owned connected-account OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
 > long-form buyer-facing `description`, and platform-controlled release semver
-> via `version_bump`. v0.10.4 keeps the publisher observability commands under
+> via `version_bump`. v0.10.8 restores the public docs and package metadata
+> after a Windows encoding regression, and keeps the publisher observability commands under
 > `siglume dev`, including planner simulation, execution receipt tailing,
 > gap reports, listing stats, and market-vitals traffic snapshots, and aligns
 > the public agent-core references with Works routing and candidate selection.
 > See [CHANGELOG.md](./CHANGELOG.md),
-> [RELEASE_NOTES_v0.10.4.md](./RELEASE_NOTES_v0.10.4.md), and
+> [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md), and
 > [RELEASE_NOTES_v0.10.1.md](./RELEASE_NOTES_v0.10.1.md) for the current
 > release line.
 >
@@ -738,7 +739,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v0.10.4 (beta)** — the platform is launched on Polygon mainnet
+This is **v0.10.8 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v0.10.8.md
+++ b/RELEASE_NOTES_v0.10.8.md
@@ -1,0 +1,24 @@
+# v0.10.8 - UTF-8 documentation repair
+
+This patch release restores the public SDK documentation and package metadata
+after a Windows encoding regression committed mojibake into README, docs,
+examples, comments, and docstrings.
+
+## Fixed
+
+- Restored UTF-8 arrows, em dashes, emoji, box-drawing characters, yen signs,
+  and Japanese legal terms.
+- Repaired README rendering on GitHub and in the PyPI long description.
+- Added a tracked-text regression test for known mojibake marker sequences.
+
+## Compatibility
+
+- No runtime API behavior changes.
+- Python and TypeScript package versions remain aligned.
+- Existing `siglume` CLI behavior is unchanged.
+
+## Validation
+
+- `git grep` for the known mojibake marker set returns no matches.
+- `py -3.11 -m pytest -q tests/test_docs_contract.py`
+- `py -3.11 -m pytest -q`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "0.10.7"
+version = "0.10.8"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "0.10.7";
+export const SDK_VERSION = "0.10.8";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "0.10.7"
+SDK_VERSION = "0.10.8"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -100,7 +100,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "0.10.7"
+    assert python_version == "0.10.8"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -115,7 +115,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v0.10.4 (beta)**" in readme
+    assert "This is **v0.10.8 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary

- Bumps Python and TypeScript SDK versions to `0.10.8`.
- Adds `CHANGELOG.md` and `RELEASE_NOTES_v0.10.8.md` entries for the mojibake repair.
- Updates README release badges/callouts so the current release no longer points at stale `v0.10.4` text.

## Why

The GitHub `main` branch now renders correctly, but package consumers still need a new PyPI/npm release because `README.md` is also used as the PyPI long description and both packages carry versioned metadata.

## Validation

- `git grep` for known mojibake marker set returned no matches.
- `py -3.11 -m pytest -q` passed: 359 passed, 12 existing warnings.
- `npm ci` completed.
- `npm test -- --coverage.enabled=false` passed: 363 passed.
- `npm run build` passed.
- `py -3.11 -m build` built `siglume_api_sdk-0.10.8` wheel and sdist.
- `py -3.11 -m twine check dist\*` passed.
- `npm run pack:check` packed `@siglume/api-sdk@0.10.8`.