### PR TITLE
Sync operation pricing plan support

### DIFF
--- a/API_IDEAS.md
+++ b/API_IDEAS.md
@@ -17,8 +17,8 @@ the "Good first APIs" section below.
 
 ## How developers earn revenue
 
-The API Store is open to any developer. When an agent owner subscribes to your
-API, you receive 93.4% of the subscription revenue. The platform fee is 6.6%.
+The API Store is open to any developer. When an agent owner pays for your API,
+you receive 93.4% of the paid API revenue. The platform fee is 6.6%.
 
 ```text
 Agent owner subscribes to your API ($9.99/month equivalent)
@@ -29,9 +29,11 @@ Agent owner subscribes to your API ($9.99/month equivalent)
 This is not a contract or outsourcing arrangement. You earn revenue when real
 users choose to install and subscribe to your API. Better APIs earn more.
 
-Both free and subscription APIs are supported. Use `price_model="free"` for your
-first API. Move to `price_model="subscription"` only after the first version is
-working and the API is useful enough for owners to pay for monthly access.
+Free, subscription, `usage_based`, and `per_action` APIs are supported. Use
+`price_model="free"` for your first API. Move to subscription or operation-based
+pricing only after the first version is working and the API is useful enough for
+owners to pay. For JPY/JPYC operation billing, free operations are `0` and paid
+operations must be at least `15` minor units.
 
 ## How to publish your API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made `usage_based` and `per_action` live API Store / Game API Store pricing
+  models. These capabilities are free to invoke up front and charge only the
+  positive amount declared by the execution result.
+- Added buyer-facing `pricing_plan` support to Python/TypeScript SDK listing
+  records, manifest forwarding, OpenAPI, schema, diff detection, and docs.
+- Enforced a JPY/JPYC operation billing floor: free operations may use `0`, but
+  positive operation prices must be at least `15` minor units.
+
 ## [1.0.0] - 2026-06-03
 
 ### Breaking

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -222,7 +222,7 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `store_vertical` | **Required.** Explicit store surface. Use `"api"` for normal API Store listings and `"game"` for Game API Store listings. | `"api"`, `"game"` |
 | `permission_class` | Permission level ([see guide](#6-permission-classes-guide)) | `PermissionClass.READ_ONLY` |
 | `approval_mode` | How execution is approved | `ApprovalMode.AUTO` |
-| `price_model` | Billing model | `"free"`, `"subscription"` |
+| `price_model` | Billing model | `"free"`, `"subscription"`, `"usage_based"`, `"per_action"` |
 | `jurisdiction` | **Required.** ISO 3166-1 alpha-2 country code declaring the governing law of your API. [Details](docs/jurisdiction-and-compliance.md) | `"US"`, `"JP"`, `"US-CA"` |
 | `docs_url` | **Required for production registration.** Public usage guide for this API listing. Do not use your company homepage or the same URL as `source_url`. | `"https://docs.your-domain.com/weather-api"` |
 | `support_contact` | **Required for production registration.** Real support email address or public support URL. Placeholder domains are rejected. See [How buyer inquiries reach you](#how-buyer-inquiries-reach-you) below for the routing rules. | `"support@your-domain.com"` |
@@ -744,14 +744,39 @@ Declare the account type in `required_connected_accounts` with `managed_by: "api
 
 ### What's the difference between free and paid APIs?
 
-> Both free and subscription listings are supported. Use `price_model="free"` for free APIs or `price_model="subscription"` for paid APIs.
+> Free, subscription, `usage_based`, and `per_action` listings are supported.
 
-Use `price_model="free"` for free APIs. For subscription APIs, use `price_model="subscription"` with `price_value_minor` set to your monthly price in cents (e.g., 999 for $9.99/month). Minimum subscription price is $5.00/month (500 cents). The following pricing models are available:
+Use `price_model="free"` for free APIs. For subscription APIs, use
+`price_model="subscription"` with `price_value_minor` set to your monthly price
+in minor units. Minimum subscription price is $5.00/month (500 cents). The
+following pricing models are available:
 
-- **Free** (`price_model="free"`): Anyone can install. You can convert to subscription pricing at any time.
-- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon mainnet (chainId 137) via on-chain embedded-wallet auto-debit (see [PAYMENT_MIGRATION.md](PAYMENT_MIGRATION.md) for the deployed contract addresses). Revenue settles to your Siglume embedded wallet automatically; use `/owner/credits/payout` only if you want to change the payout token (USDC vs JPYC). Buyers purchase via on-chain Web3 mandate, and access grants are automatic.
+- **Free** (`price_model="free"`): Anyone can install. You can convert to paid pricing with a new material listing contract.
+- **Subscription** (`price_model="subscription"`): Monthly billing. Developer receives 93.4% each month. Settlement runs on Polygon mainnet (chainId 137) via on-chain embedded-wallet auto-debit. Revenue settles to your Siglume embedded wallet automatically; use `/owner/credits/payout` only if you want to change the payout token (USDC vs JPYC).
+- **Usage based / per action** (`price_model="usage_based"` or `"per_action"`): The capability can be invoked free up front. Your API executes, then reports the executed operation/request type in `ExecutionResult.receipt_summary`. The matching `pricing_plan` item sets the charge. The platform rejects a conflicting positive amount instead of charging arbitrary API-declared prices. Use this for APIs where connection checks, disconnects, dry-run previews, or other operations are free but successful side effects are paid.
 
-The SDK enum `PriceModel` also defines `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, and `PER_ACTION`. These are **reserved values for future phases** — they are not accepted by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
+For operation pricing, set `price_value_minor=0` when the amount varies by
+operation, and add a buyer-facing `pricing_plan`. `pricing_plan.items` is
+required for `usage_based` and `per_action` listings:
+
+```python
+pricing_plan={
+    "display_name": "Operation prices",
+    "currency": "JPY",
+    "free_upfront_invocation": True,
+    "items": [
+        {"key": "connection_check", "label": "Connection check", "price_minor": 0},
+        {"key": "dry_run", "label": "Dry-run preview", "price_minor": 0},
+        {"key": "text_post", "label": "Text post", "price_minor": 15},
+        {"key": "url_post", "label": "URL post", "price_minor": 20},
+        {"key": "reply", "label": "Reply", "price_minor": 30},
+    ],
+}
+```
+
+For JPY/JPYC listings, paid operations must be either `0` or at least `15`
+minor units. Positive amounts from `1` to `14` are rejected by the SDK and the
+platform because platform-sponsored gas can exceed the fee.
 
 Planned feature: your agent will be able to promote your API within Siglume, acting as your salesperson to other agents and their owners.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Node 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/)
 [![GitHub Discussions](https://img.shields.io/github/discussions/taihei-05/siglume-api-sdk)](https://github.com/taihei-05/siglume-api-sdk/discussions)
 
-**Build APIs that AI agents subscribe to. Earn 93.4% of subscription revenue.**
+**Build APIs that AI agents subscribe to. Earn 93.4% of paid API revenue.**
 
 ## Start here if you are new
 
@@ -332,19 +332,55 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 | | |
 |---|---|
-| **Developer share** | 93.4% of subscription revenue |
+| **Developer share** | 93.4% of paid API revenue |
 | **Platform fee** | 6.6% |
 | **Settlement** | On-chain on **Polygon mainnet** (chainId 137) via your non-custodial embedded smart wallet (see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md)) |
 | **Gas fees** | Covered by the platform — developers and buyers never touch POL/MATIC |
 | **Settlement tokens** | USDC and JPYC (ERC-20 on Polygon mainnet) |
 | **Minimum price** | USD 5.00/month or JPY equivalent for subscription APIs |
+| **Operation billing minimum** | JPY/JPYC paid operations must be `0` or at least `15` minor units |
 | **Free APIs** | Also supported — no wallet setup required for free listings |
 
-Both free and paid subscription APIs are live in production on Polygon mainnet (chainId 137). Free listings publish without a wallet; paid listings settle automatically to your non-custodial embedded smart wallet on each charge cycle. Publishers must explicitly set the listing currency in `AppManifest.currency`: `USD` prices settle in USDC, and `JPY` prices settle in JPYC. Publishers must also explicitly set `AppManifest.allow_free_trial` to decide whether Plus/Pro buyers can start a free trial for the listing.
+Free, subscription, `usage_based`, and `per_action` APIs are live in production
+on Polygon mainnet (chainId 137). Free listings publish without a wallet; paid
+listings settle automatically to your non-custodial embedded smart wallet.
+Publishers must explicitly set the listing currency in `AppManifest.currency`:
+`USD` prices settle in USDC, and `JPY` prices settle in JPYC. Publishers must
+also explicitly set `AppManifest.allow_free_trial` to decide whether Plus/Pro
+buyers can start a free trial for the listing.
 
-> **Note:** The SDK `PriceModel` enum includes `ONE_TIME`, `BUNDLE`, `USAGE_BASED`,
-> and `PER_ACTION`. These are **reserved for future phases** and are not accepted
-> by the platform today. Use only `FREE` or `SUBSCRIPTION` when registering.
+Use `PriceModel.USAGE_BASED` or `PriceModel.PER_ACTION` when the API must run
+before the final operation is known. The call is free up front; the API then
+returns the executed operation/request type in `ExecutionResult.receipt_summary`
+with `units_consumed`, `amount_minor`, and `currency` for receipt consistency.
+The `pricing_plan` item is authoritative for the charge. If the API returns a
+conflicting positive amount, the platform rejects the call instead of charging
+an arbitrary amount. Free operations such as connection checks, reconnect URLs,
+dry-run previews, or disconnect actions should have a `pricing_plan` price of
+`0`. For JPY/JPYC listings, paid operations must be at least `15`; values from
+`1` to `14` are rejected by the SDK and platform.
+`units_consumed` is kept for receipts and analytics; it does not multiply a
+request-type plan price.
+
+Use `pricing_plan` to show buyer-facing operation prices in API Store and Game
+API Store. `pricing_plan.items` is required for `usage_based` and `per_action`
+listings:
+
+```python
+pricing_plan={
+    "display_name": "Operation prices",
+    "currency": "JPY",
+    "free_upfront_invocation": True,
+    "items": [
+        {"key": "connection_check", "label": "Connection check", "price_minor": 0},
+        {"key": "text_post", "label": "Text post", "price_minor": 15},
+        {"key": "url_post", "label": "URL post", "price_minor": 20},
+        {"key": "reply", "label": "Reply", "price_minor": 30},
+    ],
+}
+```
+
+`ONE_TIME` and `BUNDLE` remain reserved values.
 
 ---
 
@@ -592,18 +628,22 @@ or a blank starter template.
 - Coverage inventory: [docs/sdk/v0.6-operation-inventory.md](./docs/sdk/v0.6-operation-inventory.md)
 - Generated review samples: [examples/generated](./examples/generated)
 
-## Experimental metering
+## Metering And Operation Billing
 
-Use `MeterClient` when you want to record usage events for analytics or future
-usage-based / per-action billing previews.
+Use `PriceModel.USAGE_BASED` or `PriceModel.PER_ACTION` for free-upfront
+capability calls that bill from the execution receipt. Use `MeterClient` only
+when you want to record separate usage events for analytics or deterministic
+invoice previews.
 
 - Python example: [examples/metering_record.py](./examples/metering_record.py)
 - TypeScript example: [examples-ts/metering_record.ts](./examples-ts/metering_record.ts)
 - API notes: [docs/metering.md](./docs/metering.md)
 
-The public platform still accepts only `free` and `subscription` listings at
-registration time. `usage_based` and `per_action` remain planned values, so the
-metering surface is marked experimental and confirms event receipt only.
+The runtime billing path is the capability `ExecutionResult`: return a
+machine-readable `receipt_summary.operation` / `request_type` that matches a
+`pricing_plan` item. The platform creates no payment for a `0`-priced item and
+creates a post-execution payment requirement only for a positive plan-priced
+operation.
 
 ## Web3 settlement helpers
 
@@ -629,7 +669,7 @@ your payment adapter without touching a live wallet.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows experimental usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 | Example | Permission | Runnable e2e | Description |
 |---|---|---|---|
@@ -641,7 +681,7 @@ your payment adapter without touching a live wallet.
 | [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
 | [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
 | [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
-| [metering_record.py](./examples/metering_record.py) | client | ✅ | Record experimental usage events and preview future invoice lines |
+| [metering_record.py](./examples/metering_record.py) | client | ✅ | Record usage events and preview invoice lines |
 | [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
 | [embedded_wallet_payment.ts](./examples-ts/embedded_wallet_payment.ts) | `PAYMENT` | ✅ | TypeScript mirror of the embedded-wallet settlement flow |
 | [visual_publisher.py](./examples/visual_publisher.py) | `ACTION` | starter | Generate images and publish social posts |
@@ -669,7 +709,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | [Buyer-side SDK](docs/buyer-sdk.md) | Discover and invoke Siglume capabilities from LangChain / Claude-style runtimes |
 | [Agent Behavior Operations](docs/agent-behavior.md) | Inspect owned agents and mirror charter / approval / budget operations, with the example adapter stopping at an approval proposal preview |
 | [Template Generator](docs/template-generator.md) | Generate `AppAdapter` wrappers directly from the owner-operation catalog |
-| [Metering](docs/metering.md) | Record usage events and preview future usage-based invoice lines |
+| [Metering](docs/metering.md) | Implement free-upfront usage/per-action billing and record usage-event analytics |
 | [Web3 Settlement Helpers](docs/web3-settlement.md) | Read Polygon mandate / receipt data and simulate local settlement flows |
 | [API Reference](openapi/developer-surface.yaml) | OpenAPI spec for the developer surface |
 | [Permission Scopes](docs/permission-scopes.md) | Choose the minimum safe scope set |

--- a/docs/metering.md
+++ b/docs/metering.md
@@ -1,10 +1,80 @@
-# Metering
+# Metering And Operation-Based Billing
 
-Siglume exposes experimental usage-event ingest so sellers can record
-analytics / future billing inputs without building a custom client. This is a
-pre-billing surface today: the public platform still accepts only `free` and
-`subscription` listings at registration time, so `usage_based` and
-`per_action` remain planned price models.
+Siglume now has two related but separate surfaces:
+
+- `usage_based` / `per_action` listing billing is live for API Store and Game
+  API Store capabilities. These listings are free to invoke up front. The
+  execution result identifies which operation ran, and the matching
+  `pricing_plan` item sets the charge.
+- `MeterClient` remains an analytics / external usage-event ingest helper. It
+  records usage rows and supports deterministic invoice previews, but it is not
+  the normal runtime charge path for a `cap_*` tool call.
+
+Use post-execution billing when one capability has free operations and paid
+operations, or when the amount depends on what the API actually did. Example:
+connection check = 0 JPY, dry-run preview = 0 JPY, text post = 15 JPY, URL post
+= 20 JPY, reply = 30 JPY.
+
+For JPY/JPYC listings, a paid operation must be either `0` or at least `15`
+minor units. `0` is valid for free operations. Positive amounts below `15` are
+rejected by the SDK and by the platform.
+
+## Runtime Billing Contract
+
+Declare the listing as `PriceModel.USAGE_BASED` or `PriceModel.PER_ACTION`.
+Set `price_value_minor=0` when prices vary per operation, then publish a
+buyer-facing `pricing_plan`. `pricing_plan.items` is required for
+`usage_based` and `per_action` listings:
+
+```python
+manifest = AppManifest(
+    # ...required fields...
+    price_model=PriceModel.PER_ACTION,
+    price_value_minor=0,
+    currency="JPY",
+    pricing_plan={
+        "display_name": "X post operation prices",
+        "currency": "JPY",
+        "free_upfront_invocation": True,
+        "items": [
+            {"key": "connection_check", "label": "Connection check", "price_minor": 0},
+            {"key": "dry_run", "label": "Dry-run preview", "price_minor": 0},
+            {"key": "text_post", "label": "Text post", "price_minor": 15},
+            {"key": "url_post", "label": "URL post", "price_minor": 20},
+            {"key": "reply", "label": "Reply", "price_minor": 30},
+        ],
+    },
+)
+```
+
+After execution, return the operation that actually ran in `ExecutionResult`.
+The platform uses that operation to select the matching `pricing_plan` item:
+
+```python
+return ExecutionResult(
+    success=True,
+    output={"posted": True, "post_url": "https://x.com/..."},
+    units_consumed=1,
+    amount_minor=20,
+    currency="JPY",
+    receipt_summary={
+        "operation": "url_post",
+        "amount_minor": 20,
+        "currency": "JPY",
+    },
+)
+```
+
+The `pricing_plan` is authoritative. If the receipt identifies `url_post`, the
+platform charges the `url_post` plan price. If the API returns a conflicting
+positive amount, the call is rejected instead of using the arbitrary amount.
+If the matched plan item is `0`, no on-chain payment is created. A positive
+receipt without a matching plan item is not billable.
+`units_consumed` is recorded for receipts/analytics and does not multiply a
+request-type price unless a future explicit metered-quantity plan is introduced.
+
+Use stable idempotency keys in your API and receipt metadata so repeated calls
+can be reconciled without double-charging.
 
 ## Python
 
@@ -56,14 +126,14 @@ await meter.record({
 ## Harness Preview
 
 Use `AppTestHarness.simulate_metering(...)` to preview how a usage record would
-map to a future invoice line without calling the API:
+map to an invoice line without calling the API:
 
 - `usage_based`: `subtotal_minor = units * price_value_minor`
 - `per_action`: one billable unit only when a non-dry-run execution succeeds
 - other price models: `invoice_line_preview` is `null`
 
 This is useful for example apps and tests where you want deterministic invoice
-line previews before the live metered billing path exists.
+line previews.
 
 ## API Surface
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -96,6 +96,7 @@ The following live-listing changes are material and are rejected with
 
 - `price_model`
 - `price_value_minor`
+- `pricing_plan`
 - `currency`
 - `price_value_minor_jpy`
 - `dual_currency`
@@ -213,6 +214,14 @@ preflight errors before calling `auto-register`.
   - `input_form_spec` can be seeded during `auto-register`
   - confirmation does not edit the submitted UI contract
 - For paid APIs: minimum price and an active embedded Polygon wallet before publish
+- For `usage_based` / `per_action` APIs:
+  - the capability is free to invoke up front and must declare the actual charge
+    in `ExecutionResult.units_consumed`, `amount_minor`, `currency`, and
+    `receipt_summary`
+  - use `pricing_plan` to expose buyer-facing operation prices in API Store and
+    Game API Store
+  - `0` is valid for free operations; positive JPY/JPYC operation prices must
+    be at least `15` minor units
 - For paid APIs, `AppManifest.allow_free_trial` must be explicitly set to
   `true` or `false`. When true, Plus/Pro buyers can start one lifetime trial
   per listing, subject to their monthly trial quota; `free_trial_duration_days`

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -47,6 +47,15 @@ one listing currency explicitly: `USD` listings settle in USDC, and `JPY`
 listings settle in JPYC. Current Polygon settlement and swap token support is
 limited to `USDC` and `JPYC`.
 
+For `usage_based` and `per_action` API Store / Game API Store listings, the
+capability invocation itself is free up front. The publisher API executes first
+and reports the executed operation/request type in its `ExecutionResult`. The
+matching `pricing_plan` item is authoritative for the charge. The platform then
+creates a post-execution payment requirement only when the matched plan price is
+positive; a `0`-priced operation produces no on-chain payment. JPY/JPYC paid
+operation amounts must be either `0` or at least `15` minor units. The SDK and
+platform reject positive JPY/JPYC operation prices below that floor.
+
 ## Client helpers
 
 ```python

--- a/examples-ts/metering_record.ts
+++ b/examples-ts/metering_record.ts
@@ -1,5 +1,5 @@
 /*
-API: record usage events for analytics and future usage-based billing previews.
+API: record usage events for analytics and usage-based billing previews.
 Intended user: sellers operating token/call-metered capabilities.
 Connected account: none.
 */
@@ -16,8 +16,8 @@ import {
   type UsageRecord,
 } from "../siglume-api-sdk-ts/src/index";
 
-const EXPERIMENTAL_NOTE =
-  "usage_based / per_action remain planned price models on the public platform. Metering currently confirms receipt of events for analytics and future billing previews.";
+const METERING_NOTE =
+  "usage_based / per_action are live price models. Runtime charges come from ExecutionResult; MeterClient records analytics usage events and previews invoice lines.";
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify({
@@ -46,6 +46,10 @@ export class TranslationHubMeteredApp extends AppAdapter {
     currency: "USD" as const,
     allow_free_trial: false,
       price_value_minor: 5,
+      pricing_plan: {
+        currency: "USD",
+        items: [{ key: "tokens_in", label: "Input tokens", price_minor: 5 }],
+      },
       jurisdiction: "US",
       short_description: "Translate text and preview token-based usage line items.",
       example_prompts: [
@@ -169,7 +173,7 @@ export async function runMeteringRecordExample(): Promise<string[]> {
   const dimensions = listed.items.map((item) => item.dimension ?? "").join(",");
 
   return [
-    `experimental_note: ${EXPERIMENTAL_NOTE}`,
+    `metering_note: ${METERING_NOTE}`,
     `record_status: accepted=${String(recorded.accepted)} replayed=${String(recorded.replayed)} external_id=${recorded.external_id}`,
     `batch_items: ${batched.length} last_period=${batched.at(-1)?.period_key ?? ""}`,
     `preview_subtotal_minor: ${preview.invoice_line_preview?.subtotal_minor ?? 0}`,

--- a/examples/metering_record.py
+++ b/examples/metering_record.py
@@ -1,4 +1,4 @@
-"""API: record usage events for analytics and future usage-based billing previews.
+"""API: record usage events for analytics and usage-based billing previews.
 Intended user: sellers operating token/call-metered capabilities.
 Connected account: none.
 """
@@ -27,9 +27,9 @@ from siglume_api_sdk import (  # noqa: E402
 from siglume_api_sdk.metering import MeterClient, UsageRecord  # noqa: E402
 
 
-EXPERIMENTAL_NOTE = (
-    "usage_based / per_action remain planned price models on the public platform. "
-    "Metering currently confirms receipt of events for analytics and future billing previews."
+METERING_NOTE = (
+    "usage_based / per_action are live price models. "
+    "Runtime charges come from ExecutionResult; MeterClient records analytics usage events and previews invoice lines."
 )
 
 
@@ -49,6 +49,10 @@ class TranslationHubMeteredApp(AppAdapter):
             currency="USD",
             allow_free_trial=False,
             price_value_minor=5,
+            pricing_plan={
+                "currency": "USD",
+                "items": [{"key": "tokens_in", "label": "Input tokens", "price_minor": 5}],
+            },
             jurisdiction="US",
             short_description="Translate text and preview token-based usage line items.",
             example_prompts=[
@@ -186,7 +190,7 @@ def run_metering_example() -> list[str]:
 
     dimensions = ",".join(item.dimension or "" for item in listed.items)
     return [
-        f"experimental_note: {EXPERIMENTAL_NOTE}",
+        f"metering_note: {METERING_NOTE}",
         f"record_status: accepted={recorded.accepted} replayed={recorded.replayed} external_id={recorded.external_id}",
         f"batch_items: {len(batched)} last_period={batched[-1].period_key}",
         f"preview_subtotal_minor: {preview['invoice_line_preview']['subtotal_minor']}",

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -277,11 +277,13 @@ paths:
                   description: Governing ISO 3166-1 alpha-2 country code for this API
                 price_model:
                   type: string
-                  enum: [free, subscription]
-                  description: Pricing model
+                  enum: [free, subscription, per_request, usage_based, per_action]
+                  description: Pricing model. `usage_based` and `per_action` are free to invoke up front and bill from the pricing_plan item selected by the execution receipt.
                 price_value_minor:
                   type: integer
-                  description: Price in cents (e.g., 999 for $9.99/month). Minimum 500 for subscriptions.
+                  description: Fixed price in minor currency units. Required for subscription/per_request; optional default hint for usage_based/per_action.
+                pricing_plan:
+                  $ref: '#/components/schemas/PricingPlan'
                 permission_class:
                   type: string
                   enum: [read-only, recommendation, action, payment]
@@ -554,6 +556,8 @@ paths:
                       type: string
                     price_value_minor:
                       type: integer
+                    pricing_plan:
+                      $ref: '#/components/schemas/PricingPlan'
                     dry_run_supported:
                       type: boolean
                     jurisdiction:
@@ -1263,9 +1267,9 @@ paths:
         immediately when the self-serve checks pass; it does not enqueue
         a separate manual review step.
 
-        Both free and subscription listings are supported.
-        Use `price_model=free` for free APIs, or `price_model=subscription`
-        for paid APIs with Polygon payout wallets (93.4% developer share).
+        Free, subscription, per_request, usage_based, and per_action listings are supported.
+        Use `price_model=usage_based` or `price_model=per_action` when the API must run
+        before the exact billable amount is known. Paid models require Polygon payout wallets.
       parameters:
         - name: listingId
           in: path
@@ -1422,7 +1426,7 @@ paths:
     post:
       operationId: recordUsageEvents
       summary: Record usage events
-      description: Experimental analytics / pre-billing ingest for future usage-based flows. The public platform still accepts only free and subscription price models for registration.
+      description: Usage analytics and metering ingest for usage_based and per_action flows.
       requestBody:
         required: true
         content:
@@ -1608,6 +1612,71 @@ paths:
 
 components:
   schemas:
+    PricingPlanItem:
+      type: object
+      additionalProperties: true
+      required: [key, price_minor]
+      properties:
+        key:
+          type: string
+          description: Stable operation key emitted in receipts, e.g. text_post or reply.
+        label:
+          type: string
+          description: Buyer-facing operation label.
+        price_minor:
+          type: integer
+          minimum: 0
+          description: Display price in minor currency units for this operation. JPY/JPYC paid operations must be 0 or at least 15.
+        amount_minor:
+          type: integer
+          minimum: 0
+          description: Alias for price_minor.
+        currency:
+          type: string
+          description: ISO currency or settlement token display code, e.g. JPY, USD, JPYC, USDC.
+        unit_label:
+          type: string
+        description:
+          type: string
+        receipt_code:
+          type: string
+          description: Optional receipt-side code that maps execution results to this row.
+
+    PricingPlan:
+      type: object
+      additionalProperties: true
+      description: |
+        Buyer-facing pricing plan. For usage_based/per_action listings, use
+        this to show operation-specific prices while keeping invocation free
+        up front. pricing_plan.items is required for usage_based/per_action.
+        Example items: connection check = 0 JPY, text post = 15 JPY, URL post = 20 JPY,
+        reply = 30 JPY. The execution receipt identifies the operation/request
+        type, but the matching pricing_plan item is authoritative for the
+        actual amount charged. For JPY/JPYC operation billing, 0 is allowed for
+        free operations and positive amounts must be at least 15 minor units.
+      properties:
+        billing_model:
+          type: string
+          enum: [free, subscription, per_request, usage_based, per_action]
+        display_name:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+        currency:
+          type: string
+        unit_label:
+          type: string
+        free_upfront_invocation:
+          type: boolean
+        fallback_note:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PricingPlanItem'
+
     EnvelopeMeta:
       type: object
       required: [request_id, trace_id]
@@ -1633,8 +1702,10 @@ components:
         Listing request for the developer surface.
 
         Listing request for the Siglume developer surface.
-        Both free and subscription models are live. Use `price_model=free`
-        for free APIs, or `price_model=subscription` for paid APIs with a Polygon payout wallet.
+        Free, subscription, usage_based, and per_action models are live.
+        Use `price_model=free` for free APIs, `subscription` for recurring paid APIs,
+        or `usage_based` / `per_action` for free upfront invocation with post-execution
+        billing declared by the API result. Paid models require a Polygon payout wallet.
       properties:
         capability_key: { type: string, minLength: 1, maxLength: 128 }
         name: { type: string, minLength: 1, maxLength: 255 }
@@ -1662,12 +1733,14 @@ components:
         permission_scopes: { type: array, items: { type: string } }
         price_model:
           type: string
-          enum: [free, subscription]
-          description: Pricing model. Only free and subscription are currently accepted by the public registration flow.
+          enum: [free, subscription, per_request, usage_based, per_action]
+          description: Pricing model. `usage_based` and `per_action` are free upfront and bill only when the execution receipt selects a positive pricing_plan item.
         price_value_minor:
           type: integer
           minimum: 0
-          description: Price in minor currency units. Use 0 for free listings.
+          description: Fixed price in minor currency units. Use 0 for free and for post-execution models where each execution declares its own amount.
+        pricing_plan:
+          $ref: '#/components/schemas/PricingPlan'
         currency: { type: string, default: USD }
         docs_url: { type: string, description: "Public API usage guide; not a generic seller homepage." }
         support_contact: { type: string, description: "Real support email address or public support URL." }
@@ -1825,6 +1898,8 @@ components:
         dry_run_supported: { type: boolean }
         price_model: { type: string }
         price_value_minor: { type: integer }
+        pricing_plan:
+          $ref: '#/components/schemas/PricingPlan'
         currency: { type: string }
         fulfillment_kind: { type: string }
         status: { type: string }

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -190,12 +190,39 @@
         "usage_based",
         "per_action"
       ],
-      "description": "Pricing model. Free and subscription are live. Other models (one_time, bundle, usage_based, per_action) are planned."
+      "description": "Pricing model. Free, subscription, usage_based, and per_action are live. one_time and bundle are reserved."
     },
     "price_value_minor": {
       "type": "integer",
       "minimum": 0,
       "default": 0
+    },
+    "pricing_plan": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Buyer-facing operation price table for usage_based/per_action listings. Use 0 for free operations; positive JPY/JPYC operation prices must be at least 15 minor units.",
+      "properties": {
+        "display_name": { "type": "string" },
+        "currency": { "type": "string" },
+        "free_upfront_invocation": { "type": "boolean" },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["key", "price_minor"],
+            "properties": {
+              "key": { "type": "string" },
+              "label": { "type": "string" },
+              "price_minor": { "type": "integer", "minimum": 0 },
+              "amount_minor": { "type": "integer", "minimum": 0 },
+              "currency": { "type": "string" },
+              "description": { "type": "string" },
+              "receipt_code": { "type": "string" }
+            }
+          }
+        }
+      }
     },
     "currency": {
       "type": "string",

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -83,6 +83,57 @@ includes runtime checks, contract checks, external OAuth declaration checks, pri
 rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.
 
+## Usage-Based And Per-Action Billing
+
+Use `price_model: PriceModel.USAGE_BASED` or `PriceModel.PER_ACTION` when the
+API must execute before the final operation is known. These listings are free to
+invoke up front. Your adapter returns the executed operation in
+`ExecutionResult.receipt_summary`; the matching `pricing_plan` item sets the
+charge:
+
+```ts
+return {
+  success: true,
+  output: { posted: true, post_url: "https://x.com/..." },
+  units_consumed: 1,
+  amount_minor: 20,
+  currency: "JPY",
+  receipt_summary: {
+    operation: "url_post",
+    amount_minor: 20,
+    currency: "JPY",
+  },
+};
+```
+
+Set `price_value_minor: 0` when prices vary by operation, and publish a
+buyer-facing `pricing_plan` so API Store and Game API Store can show the plan.
+`pricing_plan.items` is required for `usage_based` and `per_action` listings:
+
+```ts
+pricing_plan: {
+  display_name: "Operation prices",
+  currency: "JPY",
+  free_upfront_invocation: true,
+  items: [
+    { key: "connection_check", label: "Connection check", price_minor: 0 },
+    { key: "dry_run", label: "Dry-run preview", price_minor: 0 },
+    { key: "text_post", label: "Text post", price_minor: 15 },
+    { key: "url_post", label: "URL post", price_minor: 20 },
+    { key: "reply", label: "Reply", price_minor: 30 },
+  ],
+}
+```
+
+The `pricing_plan` is authoritative. If the adapter returns a conflicting
+positive amount, the platform rejects the call instead of charging an arbitrary
+API-declared amount. `0` is valid for free operations. For JPY/JPYC billing,
+positive operation prices must be at least `15` minor units; `1` through `14`
+are rejected by the SDK and platform because platform-sponsored gas can exceed
+the fee.
+`units_consumed` is kept for receipts and analytics; it does not multiply a
+request-type plan price.
+
 Company-name publishing is founder-only in the Phase 2 MVP. Use
 `publisher_type: "company"` with `company_id` in `app_manifest.yaml`, or pass
 `--company <company_id>` to the CLI. Paid company listings require the

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -77,6 +77,7 @@
   WorksPosterDashboardStats,
   WorksRegistrationRecord,
 } from "./types";
+import { MINIMUM_JPY_OPERATION_PRICE_MINOR } from "./types";
 import { SiglumeAPIError, SiglumeClientError, SiglumeNotFoundError } from "./errors";
 import {
   type QueuedWebhookEvent,
@@ -116,6 +117,7 @@ import {
 
 export const DEFAULT_SIGLUME_API_BASE = "https://siglume.com/v1";
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const MINIMUM_JPY_OPERATION_PRICE_CURRENCIES = new Set(["JPY", "JPYC"]);
 
 type FetchLike = typeof fetch;
 
@@ -186,6 +188,65 @@ function validateSaveDataSchema(schema: unknown, fieldName: string): void {
       throw new SiglumeClientError(`${fieldName}.required references undefined properties: ${missing.join(", ")}.`);
     }
   }
+}
+
+function validatePricingPlanFloor(plan: unknown, defaultCurrency: string): void {
+  if (plan === undefined || plan === null) {
+    return;
+  }
+  if (!isRecord(plan)) {
+    throw new SiglumeClientError("AppManifest.pricing_plan must be an object when provided.");
+  }
+  const items = plan.items;
+  if (items === undefined || items === null) {
+    return;
+  }
+  if (!Array.isArray(items)) {
+    throw new SiglumeClientError("AppManifest.pricing_plan.items must be an array when provided.");
+  }
+  const planCurrency = String(plan.currency ?? defaultCurrency ?? "").trim().toUpperCase();
+  const seenKeys = new Set<string>();
+  items.forEach((item, index) => {
+    if (!isRecord(item)) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}] must be an object.`);
+    }
+    const itemKey = String(
+      item.key ?? item.operation ?? item.operation_key ?? item.request_type ?? item.receipt_code ?? item.action ?? "",
+    ).trim();
+    if (!itemKey) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}].key is required.`);
+    }
+    if (seenKeys.has(itemKey)) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}].key duplicates ${itemKey}.`);
+    }
+    seenKeys.add(itemKey);
+    const amountRaw = item.price_minor ?? item.amount_minor ?? item.cost_minor ?? item.value_minor;
+    if (amountRaw === undefined || amountRaw === null) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}].price_minor is required.`);
+    }
+    const amountMinor =
+      typeof amountRaw === "number" ? amountRaw : typeof amountRaw === "string" && amountRaw.trim() ? Number(amountRaw) : NaN;
+    if (!Number.isInteger(amountMinor)) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}].price_minor must be an integer.`);
+    }
+    if (amountMinor < 0) {
+      throw new SiglumeClientError(`AppManifest.pricing_plan.items[${index}].price_minor must be zero or positive.`);
+    }
+    const currency = String(item.currency ?? planCurrency ?? defaultCurrency ?? "").trim().toUpperCase();
+    if (
+      MINIMUM_JPY_OPERATION_PRICE_CURRENCIES.has(currency) &&
+      amountMinor > 0 &&
+      amountMinor < MINIMUM_JPY_OPERATION_PRICE_MINOR
+    ) {
+      throw new SiglumeClientError(
+        `AppManifest.pricing_plan.items[${index}].price_minor must be 0 or at least ${MINIMUM_JPY_OPERATION_PRICE_MINOR} for JPY/JPYC operation billing.`,
+      );
+    }
+  });
+}
+
+function pricingPlanHasItems(plan: unknown): boolean {
+  return isRecord(plan) && Array.isArray(plan.items) && plan.items.length > 0;
 }
 
 type PendingConfirmation = {
@@ -820,6 +881,11 @@ function buildUrl(baseUrl: string, path: string, params?: RequestOptions["params
 
 function parseListing(data: Record<string, unknown>): AppListingRecord {
   const metadata = isRecord(data.metadata) ? data.metadata : {};
+  const pricing_plan = isRecord(data.pricing_plan)
+    ? data.pricing_plan
+    : isRecord(metadata.pricing_plan)
+      ? metadata.pricing_plan
+      : null;
   const persistence = isRecord(data.persistence)
     ? data.persistence
     : isRecord(metadata.persistence)
@@ -837,6 +903,7 @@ function parseListing(data: Record<string, unknown>): AppListingRecord {
     dry_run_supported: Boolean(data.dry_run_supported ?? false),
     price_model: stringOrNull(data.price_model),
     price_value_minor: Number(data.price_value_minor ?? 0),
+    pricing_plan: pricing_plan as AppListingRecord["pricing_plan"],
     currency: String(data.currency ?? "USD"),
     allow_free_trial: Boolean(data.allow_free_trial ?? false),
     free_trial_duration_days: Number(data.free_trial_duration_days ?? 30),
@@ -2199,6 +2266,7 @@ export class SiglumeClient implements SiglumeClientShape {
       "jurisdiction",
       "price_model",
       "price_value_minor",
+      "pricing_plan",
       "currency",
       "allow_free_trial",
       "free_trial_duration_days",
@@ -2215,6 +2283,12 @@ export class SiglumeClient implements SiglumeClientShape {
         payload[fieldName] = value;
       }
     }
+    if (
+      payload.pricing_plan !== undefined &&
+      (typeof payload.pricing_plan !== "object" || Array.isArray(payload.pricing_plan))
+    ) {
+      throw new SiglumeClientError("AppManifest.pricing_plan must be an object when provided.");
+    }
     if (payload.store_vertical === undefined || payload.store_vertical === null) {
       throw new SiglumeClientError(
         "AppManifest.store_vertical is required. Choose 'api' for normal API Store listings or 'game' for API games.",
@@ -2230,6 +2304,13 @@ export class SiglumeClient implements SiglumeClientShape {
       throw new SiglumeClientError(`AppManifest.currency must be 'USD' or 'JPY'. Got ${String(payload.currency)}.`);
     }
     payload.currency = currency;
+    if (payload.pricing_plan !== undefined) {
+      validatePricingPlanFloor(payload.pricing_plan, currency);
+    }
+    const priceModel = String(payload.price_model ?? "free").trim().toLowerCase();
+    if ((priceModel === "usage_based" || priceModel === "per_action") && !pricingPlanHasItems(payload.pricing_plan)) {
+      throw new SiglumeClientError("AppManifest.pricing_plan.items is required for usage_based/per_action pricing.");
+    }
     if (payload.allow_free_trial === undefined || payload.allow_free_trial === null) {
       throw new SiglumeClientError(
         "AppManifest.allow_free_trial is required. Pass true to offer a Plus/Pro buyer free trial or false to disable trials.",

--- a/siglume-api-sdk-ts/src/metering.ts
+++ b/siglume-api-sdk-ts/src/metering.ts
@@ -51,7 +51,7 @@ export interface MeteringSimulationResult {
 export type MeterClientOptions = SiglumeClientOptions;
 
 /**
- * Experimental analytics / pre-billing wrapper for usage-event ingest.
+ * Analytics wrapper for usage-event ingest and invoice previews.
  */
 export class MeterClient {
   readonly experimental = true;

--- a/siglume-api-sdk-ts/src/runtime.ts
+++ b/siglume-api-sdk-ts/src/runtime.ts
@@ -8,7 +8,7 @@ import type {
   ToolManual,
   ToolManualIssue,
 } from "./types";
-import { ApprovalMode, Environment, PermissionClass, PriceModel } from "./types";
+import { ApprovalMode, Environment, MINIMUM_JPY_OPERATION_PRICE_MINOR, PermissionClass, PriceModel } from "./types";
 import type { MeteringSimulationResult, UsageRecord } from "./metering";
 import { Recorder, RecordMode } from "./testing/recorder";
 import { validate_tool_manual } from "./tool-manual-validator";
@@ -16,6 +16,77 @@ import type { EmbeddedWalletCharge, PolygonMandate } from "./web3";
 import { simulate_embedded_wallet_charge, simulate_polygon_mandate } from "./web3";
 
 const CAPABILITY_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+const MINIMUM_JPY_OPERATION_PRICE_CURRENCIES = new Set(["JPY", "JPYC"]);
+
+function pricingPlanFloorIssues(plan: unknown, defaultCurrency: string): string[] {
+  const issues: string[] = [];
+  if (plan === undefined || plan === null) {
+    return issues;
+  }
+  if (typeof plan !== "object" || Array.isArray(plan)) {
+    return ["pricing_plan must be an object when provided"];
+  }
+  const record = plan as Record<string, unknown>;
+  const items = record.items;
+  if (items === undefined || items === null) {
+    return issues;
+  }
+  if (!Array.isArray(items)) {
+    return ["pricing_plan.items must be an array when provided"];
+  }
+  const planCurrency = String(record.currency ?? defaultCurrency ?? "").trim().toUpperCase();
+  const seenKeys = new Set<string>();
+  items.forEach((item, index) => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      issues.push(`pricing_plan.items[${index}] must be an object`);
+      return;
+    }
+    const itemRecord = item as Record<string, unknown>;
+    const itemKey = String(
+      itemRecord.key ??
+        itemRecord.operation ??
+        itemRecord.operation_key ??
+        itemRecord.request_type ??
+        itemRecord.receipt_code ??
+        itemRecord.action ??
+        "",
+    ).trim();
+    if (!itemKey) {
+      issues.push(`pricing_plan.items[${index}].key is required`);
+    } else if (seenKeys.has(itemKey)) {
+      issues.push(`pricing_plan.items[${index}].key duplicates ${itemKey}`);
+    } else {
+      seenKeys.add(itemKey);
+    }
+    const amountRaw =
+      itemRecord.price_minor ?? itemRecord.amount_minor ?? itemRecord.cost_minor ?? itemRecord.value_minor;
+    if (amountRaw === undefined || amountRaw === null) {
+      issues.push(`pricing_plan.items[${index}].price_minor is required`);
+      return;
+    }
+    const amountMinor =
+      typeof amountRaw === "number" ? amountRaw : typeof amountRaw === "string" && amountRaw.trim() ? Number(amountRaw) : NaN;
+    if (!Number.isInteger(amountMinor)) {
+      issues.push(`pricing_plan.items[${index}].price_minor must be an integer`);
+      return;
+    }
+    if (amountMinor < 0) {
+      issues.push(`pricing_plan.items[${index}].price_minor must be zero or positive`);
+      return;
+    }
+    const currency = String(itemRecord.currency ?? planCurrency ?? defaultCurrency ?? "").trim().toUpperCase();
+    if (
+      MINIMUM_JPY_OPERATION_PRICE_CURRENCIES.has(currency) &&
+      amountMinor > 0 &&
+      amountMinor < MINIMUM_JPY_OPERATION_PRICE_MINOR
+    ) {
+      issues.push(
+        `pricing_plan.items[${index}].price_minor must be 0 or at least ${MINIMUM_JPY_OPERATION_PRICE_MINOR} for JPY/JPYC operation billing`,
+      );
+    }
+  });
+  return issues;
+}
 
 function normalizeExecutionResult(result: ExecutionResult, executionKind: ExecutionKind): ExecutionResult {
   return {
@@ -146,6 +217,13 @@ export class AppTestHarness {
     if (!manifest.example_prompts || manifest.example_prompts.length === 0) {
       issues.push("at least one example_prompt is recommended");
     }
+    issues.push(...pricingPlanFloorIssues(manifest.pricing_plan, String(manifest.currency ?? "USD")));
+    if (
+      (manifest.price_model === PriceModel.USAGE_BASED || manifest.price_model === PriceModel.PER_ACTION) &&
+      (!manifest.pricing_plan || !Array.isArray(manifest.pricing_plan.items) || manifest.pricing_plan.items.length === 0)
+    ) {
+      issues.push("pricing_plan.items is required for usage_based/per_action pricing");
+    }
     if (manifest.permission_class === PermissionClass.ACTION || manifest.permission_class === PermissionClass.PAYMENT) {
       if (!manifest.dry_run_supported) {
         issues.push("action/payment apps should support dry_run");
@@ -234,7 +312,7 @@ export class AppTestHarness {
     }
 
     return {
-      experimental: manifest.price_model === PriceModel.USAGE_BASED || manifest.price_model === PriceModel.PER_ACTION,
+      experimental: false,
       usage_record,
       invoice_line_preview,
     };

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -83,6 +83,8 @@ export const ListingCurrency = {
 } as const;
 export type ListingCurrency = (typeof ListingCurrency)[keyof typeof ListingCurrency];
 
+export const MINIMUM_JPY_OPERATION_PRICE_MINOR = 15;
+
 export const PersistenceMode = {
   NONE: "none",
   LOCAL: "local",
@@ -119,6 +121,7 @@ export interface AppManifest {
   permission_scopes?: string[];
   price_model?: PriceModel;
   price_value_minor?: number;
+  pricing_plan?: PricingPlan;
   currency: ListingCurrency;
   allow_free_trial: boolean;
   free_trial_duration_days?: number;
@@ -286,6 +289,30 @@ export interface EnvelopeMeta {
   trace_id?: string | null;
 }
 
+export interface PricingPlanItem {
+  key?: string | null;
+  label?: string | null;
+  price_minor?: number | null;
+  amount_minor?: number | null;
+  currency?: string | null;
+  unit_label?: string | null;
+  description?: string | null;
+  conditions?: unknown;
+  receipt_code?: string | null;
+}
+
+export interface PricingPlan {
+  billing_model?: string | null;
+  display_name?: string | null;
+  summary?: string | null;
+  description?: string | null;
+  currency?: string | null;
+  unit_label?: string | null;
+  free_upfront_invocation?: boolean | null;
+  fallback_note?: string | null;
+  items?: PricingPlanItem[];
+}
+
 export interface CursorPage<T> {
   items: T[];
   next_cursor?: string | null;
@@ -308,6 +335,7 @@ export interface AppListingRecord {
   dry_run_supported: boolean;
   price_model?: string | null;
   price_value_minor: number;
+  pricing_plan?: PricingPlan | null;
   currency: string;
   allow_free_trial: boolean;
   free_trial_duration_days: number;

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -136,6 +136,40 @@ function buildRuntimeValidation() {
 }
 
 describe("SiglumeClient", () => {
+  it("rejects JPY operation prices below the platform minimum before transport", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input) => {
+        throw new Error(`Validation should fail before transport: ${requestUrl(input).pathname}`);
+      },
+    });
+
+    await expect(
+      client.auto_register(
+        {
+          ...buildManifest(),
+          capability_key: "x-poster",
+          name: "X Poster",
+          job_to_be_done: "Post approved social updates.",
+          category: AppCategory.COMMUNICATION,
+          permission_class: PermissionClass.ACTION,
+          approval_mode: ApprovalMode.ALWAYS_ASK,
+          dry_run_supported: true,
+          price_model: PriceModel.PER_ACTION,
+          price_value_minor: 0,
+          pricing_plan: {
+            currency: "JPY",
+            items: [{ key: "text_post", label: "Text post", price_minor: 5 }],
+          },
+          currency: "JPY",
+          jurisdiction: "JP",
+        },
+        buildToolManual(),
+      ),
+    ).rejects.toThrow("at least 15");
+  });
+
   it("returns typed objects for auto-register and confirm-registration", async () => {
     const requests: Array<{ method: string; path: string; body: Record<string, unknown> }> = [];
     const manifest = buildManifest();

--- a/siglume-api-sdk-ts/test/examples.test.ts
+++ b/siglume-api-sdk-ts/test/examples.test.ts
@@ -331,7 +331,7 @@ describe("TypeScript example suite", () => {
   it("returns stable summary lines for metering_record", async () => {
     const lines = await runMeteringRecordExample();
 
-    expect(lines[0]).toContain("experimental_note: usage_based / per_action remain planned");
+    expect(lines[0]).toContain("metering_note: usage_based / per_action are live price models");
     expect(lines[1]).toBe("record_status: accepted=true replayed=false external_id=evt_usage_001");
     expect(lines[2]).toBe("batch_items: 2 last_period=202604");
     expect(lines[3]).toBe("preview_subtotal_minor: 7615");

--- a/siglume-api-sdk-ts/test/metering.test.ts
+++ b/siglume-api-sdk-ts/test/metering.test.ts
@@ -48,6 +48,13 @@ class MeteredApp extends AppAdapter {
       required_connected_accounts: [],
       price_model: this.priceModel as typeof PriceModel[keyof typeof PriceModel],
       price_value_minor: 5,
+      pricing_plan:
+        this.priceModel === PriceModel.USAGE_BASED || this.priceModel === PriceModel.PER_ACTION
+          ? {
+              currency: "USD",
+              items: [{ key: "tokens_in", label: "Input tokens", price_minor: 5 }],
+            }
+          : undefined,
       currency: "USD" as const,
       allow_free_trial: false,
       jurisdiction: "US",
@@ -541,7 +548,7 @@ describe("metering", () => {
       occurred_at_iso: "2026-04-19T10:00:00Z",
     });
 
-    expect(preview.experimental).toBe(true);
+    expect(preview.experimental).toBe(false);
     expect(preview.invoice_line_preview?.subtotal_minor).toBe(7615);
     expect(preview.invoice_line_preview?.billable_units).toBe(1523);
   });

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -100,6 +100,30 @@ export interface ExecutionResult {
   approval_hint?: ApprovalRequestHint;
 }
 
+export interface PricingPlanItem {
+  key?: string;
+  label?: string;
+  price_minor?: number;
+  amount_minor?: number;
+  currency?: string;
+  unit_label?: string;
+  description?: string;
+  conditions?: unknown;
+  receipt_code?: string;
+}
+
+export interface PricingPlan {
+  billing_model?: string;
+  display_name?: string;
+  summary?: string;
+  description?: string;
+  currency?: string;
+  unit_label?: string;
+  free_upfront_invocation?: boolean;
+  fallback_note?: string;
+  items?: PricingPlanItem[];
+}
+
 export interface CapabilityListing {
   id: string;
   capability_key: string;
@@ -111,6 +135,7 @@ export interface CapabilityListing {
   dry_run_supported: boolean;
   price_model: PriceModel;
   price_value_minor: number;
+  pricing_plan?: PricingPlan;
   currency: string;
   status: string;
   short_description?: string;

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -22,6 +22,8 @@ from typing import Any, Mapping
 # ISO 3166-1 alpha-2 country code, optionally with a sub-region suffix.
 # Examples: "US", "US-CA", "JP", "GB", "DE", "SG".
 _JURISDICTION_PATTERN = re.compile(r"^[A-Z]{2}(-[A-Z0-9]{1,3})?$")
+MINIMUM_JPY_OPERATION_PRICE_MINOR = 15
+_MINIMUM_JPY_OPERATION_PRICE_CURRENCIES = {"JPY", "JPYC"}
 _MAX_SAVE_DATA_SCHEMA_BYTES = 8192
 
 
@@ -65,16 +67,16 @@ class Environment(str, Enum):
 class PriceModel(str, Enum):
     """Pricing models for agent APIs.
 
-    Live: free, subscription (USD).
-    Planned: one_time, bundle, usage_based, per_action.
+    Live: free, subscription, usage_based, per_action.
+    Planned: one_time, bundle.
     Platform fee: 6.6%. Developer keeps 93.4%.
     """
     FREE = "free"                    # No charge.
     SUBSCRIPTION = "subscription"    # Monthly recurring (USD).
     ONE_TIME = "one_time"            # Planned: single purchase.
     BUNDLE = "bundle"                # Planned: bundled package.
-    USAGE_BASED = "usage_based"      # Planned: per-use metering.
-    PER_ACTION = "per_action"        # Planned: per-successful-action.
+    USAGE_BASED = "usage_based"      # Free upfront; execution declares billable usage.
+    PER_ACTION = "per_action"        # Free upfront; successful actions declare charges.
 
 
 class AppCategory(str, Enum):
@@ -175,6 +177,68 @@ def _validate_save_data_schema(schema: Any, *, field_name: str) -> None:
             )
 
 
+def _validate_pricing_plan_floor(plan: Any, *, default_currency: str) -> None:
+    """Validate operation-level prices before the platform rejects the manifest."""
+    if plan is None:
+        return
+    if not isinstance(plan, Mapping):
+        raise ValueError("AppManifest.pricing_plan must be a dict/object when provided.")
+    raw_items = plan.get("items")
+    if raw_items is None:
+        return
+    if not isinstance(raw_items, list):
+        raise ValueError("AppManifest.pricing_plan.items must be a list when provided.")
+    plan_currency = str(plan.get("currency") or default_currency or "").strip().upper()
+    seen_keys: set[str] = set()
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"AppManifest.pricing_plan.items[{index}] must be a dict/object.")
+        item_key = str(
+            item.get("key")
+            or item.get("operation")
+            or item.get("operation_key")
+            or item.get("request_type")
+            or item.get("receipt_code")
+            or item.get("action")
+            or ""
+        ).strip()
+        if not item_key:
+            raise ValueError(f"AppManifest.pricing_plan.items[{index}].key is required.")
+        if item_key in seen_keys:
+            raise ValueError(f"AppManifest.pricing_plan.items[{index}].key duplicates {item_key!r}.")
+        seen_keys.add(item_key)
+        amount_raw = None
+        for key in ("price_minor", "amount_minor", "cost_minor", "value_minor"):
+            if key in item and item.get(key) is not None:
+                amount_raw = item.get(key)
+                break
+        if amount_raw is None:
+            raise ValueError(f"AppManifest.pricing_plan.items[{index}].price_minor is required.")
+        try:
+            amount_minor = int(amount_raw)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be an integer."
+            ) from None
+        if amount_minor < 0:
+            raise ValueError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be zero or positive."
+            )
+        currency = str(item.get("currency") or plan_currency or default_currency or "").strip().upper()
+        if (
+            currency in _MINIMUM_JPY_OPERATION_PRICE_CURRENCIES
+            and 0 < amount_minor < MINIMUM_JPY_OPERATION_PRICE_MINOR
+        ):
+            raise ValueError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be 0 or at least "
+                f"{MINIMUM_JPY_OPERATION_PRICE_MINOR} for JPY/JPYC operation billing."
+            )
+
+
+def _pricing_plan_has_items(plan: Any) -> bool:
+    return isinstance(plan, Mapping) and isinstance(plan.get("items"), list) and bool(plan.get("items"))
+
+
 @dataclass
 class AppManifest:
     """Declares what the app does and what it needs.
@@ -199,6 +263,7 @@ class AppManifest:
     permission_scopes: list[str] = field(default_factory=list)
     price_model: PriceModel = PriceModel.FREE
     price_value_minor: int = 0             # minor units for `currency` (USD cents, JPY yen)
+    pricing_plan: dict[str, Any] | None = None  # optional buyer-facing operation price table
     currency: ListingCurrency | str | None = None  # REQUIRED: "USD" -> USDC, "JPY" -> JPYC
     allow_free_trial: bool | None = None   # REQUIRED: True/False must be an explicit publisher choice
     free_trial_duration_days: int = 30     # 1-90 when allow_free_trial=True
@@ -241,6 +306,12 @@ class AppManifest:
                 f"Got: {self.currency!r}"
             )
         self.currency = ListingCurrency(currency)
+        _validate_pricing_plan_floor(self.pricing_plan, default_currency=currency)
+        price_model_value = self.price_model.value if isinstance(self.price_model, PriceModel) else str(self.price_model or "")
+        if price_model_value in {PriceModel.USAGE_BASED.value, PriceModel.PER_ACTION.value} and not _pricing_plan_has_items(
+            self.pricing_plan
+        ):
+            raise ValueError("AppManifest.pricing_plan.items is required for usage_based/per_action pricing.")
 
         if self.allow_free_trial is None:
             raise ValueError(
@@ -1169,6 +1240,15 @@ class AppTestHarness:
             issues.append(
                 "example_prompts must include at least 2 distinct non-empty sample prompts"
             )
+        try:
+            _validate_pricing_plan_floor(m.pricing_plan, default_currency=str(m.currency.value if isinstance(m.currency, ListingCurrency) else m.currency))
+        except ValueError as exc:
+            issues.append(str(exc))
+        price_model_value = m.price_model.value if isinstance(m.price_model, PriceModel) else str(m.price_model or "")
+        if price_model_value in {PriceModel.USAGE_BASED.value, PriceModel.PER_ACTION.value} and not _pricing_plan_has_items(
+            m.pricing_plan
+        ):
+            issues.append("pricing_plan.items is required for usage_based/per_action pricing")
         if m.permission_class in (PermissionClass.ACTION, PermissionClass.PAYMENT):
             if not m.dry_run_supported:
                 issues.append("action/payment apps should support dry_run")
@@ -1239,11 +1319,10 @@ class AppTestHarness:
         *,
         execution_result: ExecutionResult | None = None,
     ) -> dict[str, Any]:
-        """Preview how a usage record would map to a future invoice line.
+        """Preview how a usage record would map to an invoice line.
 
-        This is an experimental analytics / pre-billing helper. It validates the
-        usage payload shape locally and returns a deterministic preview. It does
-        not create a charge.
+        This helper validates the usage payload shape locally and returns a
+        deterministic preview. It does not create a charge.
         """
         try:
             from siglume_api_sdk.metering import _normalize_usage_record as _normalize
@@ -1287,7 +1366,7 @@ class AppTestHarness:
             }
 
         return {
-            "experimental": usage_based_matches or per_action_matches,
+            "experimental": False,
             "usage_record": usage_record,
             "invoice_line_preview": invoice_line_preview,
         }

--- a/siglume_api_sdk/buyer.py
+++ b/siglume_api_sdk/buyer.py
@@ -58,6 +58,7 @@ class CapabilityListing:
     dry_run_supported: bool = False
     price_model: str | None = None
     price_value_minor: int = 0
+    pricing_plan: dict[str, Any] | None = None
     currency: str = "USD"
     allow_free_trial: bool = False
     free_trial_duration_days: int = 30
@@ -103,6 +104,7 @@ class CapabilityListing:
             dry_run_supported=listing.dry_run_supported,
             price_model=listing.price_model,
             price_value_minor=listing.price_value_minor,
+            pricing_plan=dict(listing.pricing_plan) if isinstance(listing.pricing_plan, dict) else None,
             currency=listing.currency,
             allow_free_trial=listing.allow_free_trial,
             free_trial_duration_days=listing.free_trial_duration_days,

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -1004,6 +1004,17 @@ def _api_usage_docs_template(manifest: AppManifest) -> str:
         - Price model: `{price_model}`
         - Required connected accounts: `{required_accounts}`
 
+        ## Pricing And Billing
+
+        If this API uses `usage_based` or `per_action` pricing, explain each
+        operation in `pricing_plan` and return the executed operation/request
+        type after execution in `ExecutionResult.receipt_summary`. The
+        capability call is free up front; Siglume creates a payment only when
+        the matched `pricing_plan` item has a positive amount. Use `0` for free
+        operations such as connection checks, disconnects, and dry-run previews.
+        For JPY/JPYC operation billing, positive operation prices must be at
+        least `15` minor units.
+
         ## Inputs
 
         Describe the request fields your API accepts. Keep this aligned with

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 DEFAULT_SIGLUME_API_BASE = "https://siglume.com/v1"
 RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+MINIMUM_JPY_OPERATION_PRICE_MINOR = 15
+_MINIMUM_JPY_OPERATION_PRICE_CURRENCIES = {"JPY", "JPYC"}
 T = TypeVar("T")
 
 
@@ -117,6 +119,7 @@ class AppListingRecord:
     dry_run_supported: bool = False
     price_model: str | None = None
     price_value_minor: int = 0
+    pricing_plan: dict[str, Any] | None = None
     currency: str = "USD"
     allow_free_trial: bool = False
     free_trial_duration_days: int = 30
@@ -1398,6 +1401,7 @@ def _build_auto_register_request(
         "jurisdiction",
         "price_model",
         "price_value_minor",
+        "pricing_plan",
         "currency",
         "allow_free_trial",
         "free_trial_duration_days",
@@ -1412,6 +1416,8 @@ def _build_auto_register_request(
         value = manifest_payload.get(field_name)
         if value is not None:
             payload[field_name] = _enum_value(value)
+    if "pricing_plan" in payload and not isinstance(payload["pricing_plan"], Mapping):
+        raise SiglumeClientError("AppManifest.pricing_plan must be an object when provided.")
     if "store_vertical" not in payload:
         raise SiglumeClientError(
             "AppManifest.store_vertical is required. Choose 'api' for normal "
@@ -1428,6 +1434,11 @@ def _build_auto_register_request(
             f"AppManifest.currency must be 'USD' or 'JPY'. Got {payload.get('currency')!r}."
         )
     payload["currency"] = currency
+    if "pricing_plan" in payload:
+        _validate_pricing_plan_floor(payload.get("pricing_plan"), default_currency=currency)
+    price_model = str(payload.get("price_model") or "free").strip().lower()
+    if price_model in {"usage_based", "per_action"} and not _pricing_plan_has_items(payload.get("pricing_plan")):
+        raise SiglumeClientError("AppManifest.pricing_plan.items is required for usage_based/per_action pricing.")
     if "allow_free_trial" not in payload:
         raise SiglumeClientError(
             "AppManifest.allow_free_trial is required. Pass True to offer a Plus/Pro "
@@ -1481,6 +1492,67 @@ def _build_auto_register_request(
         payload["publisher_identity"] = publisher_identity
         payload["legal"] = {"publisher_identity": publisher_identity}
     return payload
+
+
+def _validate_pricing_plan_floor(plan: Any, *, default_currency: str) -> None:
+    if plan is None:
+        return
+    if not isinstance(plan, Mapping):
+        raise SiglumeClientError("AppManifest.pricing_plan must be an object when provided.")
+    raw_items = plan.get("items")
+    if raw_items is None:
+        return
+    if not isinstance(raw_items, list):
+        raise SiglumeClientError("AppManifest.pricing_plan.items must be an array when provided.")
+    plan_currency = str(plan.get("currency") or default_currency or "").strip().upper()
+    seen_keys: set[str] = set()
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, Mapping):
+            raise SiglumeClientError(f"AppManifest.pricing_plan.items[{index}] must be an object.")
+        item_key = str(
+            item.get("key")
+            or item.get("operation")
+            or item.get("operation_key")
+            or item.get("request_type")
+            or item.get("receipt_code")
+            or item.get("action")
+            or ""
+        ).strip()
+        if not item_key:
+            raise SiglumeClientError(f"AppManifest.pricing_plan.items[{index}].key is required.")
+        if item_key in seen_keys:
+            raise SiglumeClientError(f"AppManifest.pricing_plan.items[{index}].key duplicates {item_key!r}.")
+        seen_keys.add(item_key)
+        amount_raw = None
+        for key in ("price_minor", "amount_minor", "cost_minor", "value_minor"):
+            if key in item and item.get(key) is not None:
+                amount_raw = item.get(key)
+                break
+        if amount_raw is None:
+            raise SiglumeClientError(f"AppManifest.pricing_plan.items[{index}].price_minor is required.")
+        try:
+            amount_minor = int(amount_raw)
+        except (TypeError, ValueError):
+            raise SiglumeClientError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be an integer."
+            ) from None
+        if amount_minor < 0:
+            raise SiglumeClientError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be zero or positive."
+            )
+        currency = str(item.get("currency") or plan_currency or default_currency or "").strip().upper()
+        if (
+            currency in _MINIMUM_JPY_OPERATION_PRICE_CURRENCIES
+            and 0 < amount_minor < MINIMUM_JPY_OPERATION_PRICE_MINOR
+        ):
+            raise SiglumeClientError(
+                f"AppManifest.pricing_plan.items[{index}].price_minor must be 0 or at least "
+                f"{MINIMUM_JPY_OPERATION_PRICE_MINOR} for JPY/JPYC operation billing."
+            )
+
+
+def _pricing_plan_has_items(plan: Any) -> bool:
+    return isinstance(plan, Mapping) and isinstance(plan.get("items"), list) and bool(plan.get("items"))
 
 
 def _validate_manifest_persistence_contract(payload: Mapping[str, Any]) -> None:
@@ -1547,6 +1619,9 @@ def _parse_listing(data: Mapping[str, Any]) -> AppListingRecord:
     persistence = data.get("persistence")
     if not isinstance(persistence, Mapping):
         persistence = metadata.get("persistence") if isinstance(metadata, Mapping) else {}
+    pricing_plan = data.get("pricing_plan")
+    if not isinstance(pricing_plan, Mapping) and isinstance(metadata, Mapping):
+        pricing_plan = metadata.get("pricing_plan")
     return AppListingRecord(
         listing_id=listing_id,
         capability_key=str(data.get("capability_key") or ""),
@@ -1559,6 +1634,7 @@ def _parse_listing(data: Mapping[str, Any]) -> AppListingRecord:
         dry_run_supported=bool(data.get("dry_run_supported") or False),
         price_model=_string_or_none(data.get("price_model")),
         price_value_minor=int(data.get("price_value_minor") or 0),
+        pricing_plan=dict(pricing_plan) if isinstance(pricing_plan, Mapping) else None,
         currency=str(data.get("currency") or "USD"),
         allow_free_trial=bool(data.get("allow_free_trial") or False),
         free_trial_duration_days=int(data.get("free_trial_duration_days") or 30),

--- a/siglume_api_sdk/diff.py
+++ b/siglume_api_sdk/diff.py
@@ -54,6 +54,7 @@ _SPECIAL_MANIFEST_KEYS = {
     "short_description",
     "permission_class",
     "price_model",
+    "pricing_plan",
     "currency",
     "jurisdiction",
 }
@@ -95,6 +96,15 @@ def diff_manifest(*, old: Any, new: Any) -> list[Change]:
         old_value=old_payload.get("price_model"),
         new_value=new_payload.get("price_model"),
         message="Manifest price_model changed; billing compatibility may break existing installs.",
+    )
+    _append_value_change(
+        changes,
+        emitted_keys,
+        level=ChangeLevel.BREAKING,
+        key="pricing_plan",
+        old_value=old_payload.get("pricing_plan"),
+        new_value=new_payload.get("pricing_plan"),
+        message="Manifest pricing_plan changed; operation-level billing display changed.",
     )
     _append_value_change(
         changes,

--- a/siglume_api_sdk/metering.py
+++ b/siglume_api_sdk/metering.py
@@ -1,4 +1,4 @@
-"""Experimental seller-side usage metering helpers for the Siglume API."""
+"""Seller-side usage metering helpers for analytics and invoice previews."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -46,7 +46,7 @@ class MeterRecordResult:
 
 
 class MeterClient:
-    """Experimental analytics / pre-billing wrapper for usage-event ingest."""
+    """Analytics wrapper for usage-event ingest and invoice previews."""
 
     experimental = True
 
@@ -79,7 +79,7 @@ class MeterClient:
     def record(self, record: UsageRecord | Mapping[str, Any]) -> MeterRecordResult:
         """Record a single usage event.
 
-        This confirms receipt of usage data for analytics / future billing.
+        This confirms receipt of usage data for analytics and reconciliation.
         It does not mean that a charge was created immediately.
         """
         results = self.record_batch([record])

--- a/siglume_api_sdk_client.ts
+++ b/siglume_api_sdk_client.ts
@@ -1,4 +1,4 @@
-import type { ToolManual, ToolManualQualityReport } from "./siglume-api-types";
+import type { PricingPlan, ToolManual, ToolManualQualityReport } from "./siglume-api-types";
 
 export interface EnvelopeMeta {
   request_id?: string | null;
@@ -25,6 +25,7 @@ export interface AppListingRecord {
   dry_run_supported: boolean;
   price_model?: string | null;
   price_value_minor: number;
+  pricing_plan?: PricingPlan | null;
   currency: string;
   short_description?: string | null;
   description?: string | null;

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -335,6 +335,58 @@ def test_app_manifest_normalizes_jpy_listing_currency() -> None:
     assert manifest.currency == ListingCurrency.JPY
 
 
+def test_app_manifest_rejects_jpy_operation_price_below_minimum() -> None:
+    with pytest.raises(ValueError, match="at least 15"):
+        AppManifest(
+            capability_key="x-poster",
+            name="X Poster",
+            job_to_be_done="Post approved social updates.",
+            category=AppCategory.COMMUNICATION,
+            store_vertical=StoreVertical.API,
+            permission_class=PermissionClass.ACTION,
+            approval_mode=ApprovalMode.ALWAYS_ASK,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.PER_ACTION,
+            price_value_minor=0,
+            pricing_plan={
+                "currency": "JPY",
+                "items": [{"key": "text_post", "label": "Text post", "price_minor": 5}],
+            },
+            currency="JPY",
+            allow_free_trial=False,
+            jurisdiction="JP",
+        )
+
+
+def test_app_manifest_accepts_free_and_minimum_jpy_operation_prices() -> None:
+    manifest = AppManifest(
+        capability_key="x-poster",
+        name="X Poster",
+        job_to_be_done="Post approved social updates.",
+        category=AppCategory.COMMUNICATION,
+        store_vertical=StoreVertical.API,
+        permission_class=PermissionClass.ACTION,
+        approval_mode=ApprovalMode.ALWAYS_ASK,
+        dry_run_supported=True,
+        required_connected_accounts=[],
+        price_model=PriceModel.PER_ACTION,
+        price_value_minor=0,
+        pricing_plan={
+            "currency": "JPY",
+            "items": [
+                {"key": "dry_run", "label": "Dry run", "price_minor": 0},
+                {"key": "text_post", "label": "Text post", "price_minor": 15},
+            ],
+        },
+        currency="JPY",
+        allow_free_trial=False,
+        jurisdiction="JP",
+    )
+
+    assert manifest.pricing_plan["items"][1]["price_minor"] == 15
+
+
 def test_game_manifest_with_save_persistence_requires_save_data_schema() -> None:
     with pytest.raises(ValueError, match="persistence.save_data_schema is REQUIRED"):
         AppManifest(
@@ -504,6 +556,37 @@ def test_auto_register_dict_manifest_rejects_oversized_save_data_schema() -> Non
 
     with build_client(handler) as client:
         with pytest.raises(SiglumeClientError, match="save_data_schema must be at most 8192 bytes"):
+            client.auto_register(manifest, build_tool_manual())
+
+
+def test_auto_register_dict_manifest_rejects_jpy_operation_price_below_minimum() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Validation should fail before transport: {request.method} {request.url}")
+
+    manifest = {
+        "capability_key": "x-poster",
+        "name": "X Poster",
+        "job_to_be_done": "Post approved social updates.",
+        "category": "communication",
+        "store_vertical": "api",
+        "permission_class": "action",
+        "approval_mode": "always-ask",
+        "dry_run_supported": True,
+        "required_connected_accounts": [],
+        "price_model": "per_action",
+        "price_value_minor": 0,
+        "pricing_plan": {
+            "currency": "JPY",
+            "items": [{"key": "text_post", "label": "Text post", "price_minor": 5}],
+        },
+        "currency": "JPY",
+        "allow_free_trial": False,
+        "jurisdiction": "JP",
+        "example_prompts": ["Post this approved draft.", "Create a dry-run preview."],
+    }
+
+    with build_client(handler) as client:
+        with pytest.raises(SiglumeClientError, match="at least 15"):
             client.auto_register(manifest, build_tool_manual())
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -142,7 +142,7 @@ def test_metering_record_example_runs_with_mock_client() -> None:
 
     output = module.run_metering_example()
 
-    assert output[0].startswith("experimental_note: usage_based / per_action remain planned")
+    assert output[0].startswith("metering_note: usage_based / per_action are live price models")
     assert output[1] == "record_status: accepted=True replayed=False external_id=evt_usage_001"
     assert output[2] == "batch_items: 2 last_period=202604"
     assert output[3] == "preview_subtotal_minor: 7615"

--- a/tests/test_metering.py
+++ b/tests/test_metering.py
@@ -54,6 +54,12 @@ class MeteredApp(AppAdapter):
             required_connected_accounts=[],
             price_model=self._price_model,
             price_value_minor=5,
+            pricing_plan={
+                "currency": "USD",
+                "items": [{"key": "tokens_in", "label": "Input tokens", "price_minor": 5}],
+            }
+            if self._price_model in {PriceModel.USAGE_BASED, PriceModel.PER_ACTION}
+            else None,
             currency="USD",
             allow_free_trial=False,
             jurisdiction="US",
@@ -330,7 +336,7 @@ def test_app_test_harness_simulates_usage_based_metering() -> None:
         )
     )
 
-    assert preview["experimental"] is True
+    assert preview["experimental"] is False
     assert preview["invoice_line_preview"]["subtotal_minor"] == 7615
     assert preview["invoice_line_preview"]["billable_units"] == 1523
 
@@ -371,7 +377,7 @@ def test_app_test_harness_simulate_metering_handles_str_price_model() -> None:
             occurred_at_iso="2026-04-19T10:00:00Z",
         )
     )
-    assert preview["experimental"] is True
+    assert preview["experimental"] is False
     assert preview["invoice_line_preview"] is not None
     assert preview["invoice_line_preview"]["price_model"] == "usage_based"
 


### PR DESCRIPTION
## Summary
- expose usage_based/per_action pricing plans in the public SDK contract
- document free, subscription, and usage-based pricing plan semantics
- enforce JPY/JPYC operation prices as 0 or at least 15 minor units

## Verification
- py -3 -m pytest tests\\test_client.py tests\\test_metering.py tests\\test_examples.py
- npm run typecheck (siglume-api-sdk-ts)
- npx vitest run test/client.test.ts test/metering.test.ts test/examples.test.ts