### PR TITLE
Release SDK v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-04
+
 ### Changed
 
 - Made `usage_based` and `per_action` live API Store / Game API Store pricing

--- a/README.md
+++ b/README.md
@@ -58,15 +58,17 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.0.0.** Python and TypeScript are version-aligned and
+> **Current release: v1.1.0.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
-> long-form buyer-facing `description`, and platform-controlled release semver
-> via `version_bump`. v1.0.0 removes platform OAuth broker APIs from the SDK:
+> operation pricing plans, long-form buyer-facing `description`, and
+> platform-controlled release semver via `version_bump`. v1.0.0 removes
+> platform OAuth broker APIs from the SDK:
 > publisher APIs now own external OAuth, token storage, refresh, revocation,
 > and user-to-token mapping behind their own `connect_url`.
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
 > [RELEASE_NOTES_v1.0.0.md](./RELEASE_NOTES_v1.0.0.md), and
 > [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md) for the current
 > release line.
@@ -773,7 +775,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.0.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v1.1.0 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v1.1.0.md
+++ b/RELEASE_NOTES_v1.1.0.md
@@ -1,0 +1,18 @@
+# Release notes v1.1.0
+
+Operation pricing plans are now live in the public SDK.
+
+## Highlights
+
+- `pricing_plan` is available on Python and TypeScript `AppManifest` records.
+- `usage_based` and `per_action` price models are live for API Store / Game API Store listings.
+- Capabilities can be free to invoke up front, then charge according to the matched pricing-plan operation after execution.
+- JPY/JPYC operation prices must be either `0` or at least `15` minor units.
+
+## Publisher impact
+
+Use `pricing_plan.items` to define request or operation types such as `text_only`, `text_with_url`, or `dry_run`, each with its own price. The platform treats the pricing plan as authoritative for billing; execution receipts identify which operation ran.
+
+## Compatibility
+
+This release is additive on top of v1.0.0. Platform-managed connected-account OAuth remains removed: publisher APIs continue to own OAuth, token storage, refresh, revocation, and user-to-token mapping behind their own `connect_url`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "1.0.0"
+version = "1.1.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "1.0.0";
+export const SDK_VERSION = "1.1.0";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "1.0.0"
+SDK_VERSION = "1.1.0"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -100,7 +100,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "1.0.0"
+    assert python_version == "1.1.0"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -115,7 +115,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.0.0 (beta)**" in readme
+    assert "This is **v1.1.0 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary
- bump Python and TypeScript SDK versions to 1.1.0
- move pricing_plan / usage_based / per_action changes from Unreleased to v1.1.0
- add v1.1.0 release notes for operation pricing plans

## Verification
- py -3 -m pytest
- npm run typecheck
- npm run test -- --coverage.enabled=false
- py -3.11 -m build
- py -3.11 -m twine check dist\\*
- npm run build
- npm run pack:check