### PR TITLE
Release SDK v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-04
+
+### Added
+
+- Added `AppManifest.billing_timing` (`"post"` or `"prepay"`) to support
+  quote-first direct payment for irreversible per-action APIs.
+
 ## [1.1.0] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -364,6 +364,15 @@ dry-run previews, or disconnect actions should have a `pricing_plan` price of
 `units_consumed` is kept for receipts and analytics; it does not multiply a
 request-type plan price.
 
+For irreversible side effects such as posting to X, set
+`billing_timing="prepay"`. In that mode the platform first calls your API with
+`execution_kind="quote"` / `dry_run=True`; your API must return
+`billingPreview.operation` and a `draftToken`. The platform prices that
+operation from `pricing_plan`, collects the direct payment, then calls the
+ACTION endpoint with the same token as `commit_token`. If payment fails, the
+ACTION call is never made. Keep the default `billing_timing="post"` only for
+read-only or reversible usage where execute-then-settle is acceptable.
+
 Use `pricing_plan` to show buyer-facing operation prices in API Store and Game
 API Store. `pricing_plan.items` is required for `usage_based` and `per_action`
 listings:
@@ -380,6 +389,30 @@ pricing_plan={
         {"key": "reply", "label": "Reply", "price_minor": 30},
     ],
 }
+```
+
+```python
+manifest = AppManifest(
+    capability_key="x-poster",
+    name="X Poster",
+    permission_class=PermissionClass.ACTION,
+    approval_mode=ApprovalMode.ALWAYS_ASK,
+    dry_run_supported=True,
+    price_model=PriceModel.PER_ACTION,
+    price_value_minor=0,
+    billing_timing="prepay",
+    currency="JPY",
+    allow_free_trial=False,
+    jurisdiction="JP",
+    store_vertical="api",
+    pricing_plan={
+        "currency": "JPY",
+        "items": [
+            {"key": "text_only", "label": "Text only", "price_minor": 15},
+            {"key": "text_with_url", "label": "Text with URL", "price_minor": 28},
+        ],
+    },
+)
 ```
 
 `ONE_TIME` and `BUNDLE` remain reserved values.

--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.1.0.** Python and TypeScript are version-aligned and
+> **Current release: v1.2.0.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
-> operation pricing plans, long-form buyer-facing `description`, and
+> operation pricing plans, prepay quote billing, long-form buyer-facing `description`, and
 > platform-controlled release semver via `version_bump`. v1.0.0 removes
 > platform OAuth broker APIs from the SDK:
 > publisher APIs now own external OAuth, token storage, refresh, revocation,
 > and user-to-token mapping behind their own `connect_url`.
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v1.2.0.md](./RELEASE_NOTES_v1.2.0.md),
 > [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
 > [RELEASE_NOTES_v1.0.0.md](./RELEASE_NOTES_v1.0.0.md), and
 > [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md) for the current
@@ -808,7 +809,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.1.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v1.2.0 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v1.2.0.md
+++ b/RELEASE_NOTES_v1.2.0.md
@@ -1,0 +1,18 @@
+# Siglume API SDK v1.2.0
+
+v1.2.0 adds `billing_timing` support for per-action APIs that must collect
+payment before an irreversible side effect.
+
+## Highlights
+
+- Python and TypeScript `AppManifest` now accept `billing_timing: "post" |
+  "prepay"` with `"post"` as the default.
+- `billing_timing="prepay"` lets a per-action API run a free quote/dry-run,
+  return a draft token and operation price, and require payment before the
+  final action call.
+- Listing records now expose `billing_timing` so buyers and tools can explain
+  whether per-action settlement is post-execution or quote-first prepay.
+
+Use `billing_timing="prepay"` for irreversible paid actions such as publishing,
+posting, sending, booking, or other operations where "executed but unpaid" must
+not be possible.

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -278,12 +278,17 @@ paths:
                 price_model:
                   type: string
                   enum: [free, subscription, per_request, usage_based, per_action]
-                  description: Pricing model. `usage_based` and `per_action` are free to invoke up front and bill from the pricing_plan item selected by the execution receipt.
+                  description: Pricing model. `usage_based` and `per_action` price operations from pricing_plan. With billing_timing=post they settle after the execution receipt; with billing_timing=prepay they require a quote and direct payment before ACTION execution.
                 price_value_minor:
                   type: integer
                   description: Fixed price in minor currency units. Required for subscription/per_request; optional default hint for usage_based/per_action.
                 pricing_plan:
                   $ref: '#/components/schemas/PricingPlan'
+                billing_timing:
+                  type: string
+                  enum: [post, prepay]
+                  default: post
+                  description: Billing timing for usage_based/per_action. `post` settles from the execution receipt after the API runs. `prepay` requires a quote/draftToken and confirmed payment before ACTION execution.
                 permission_class:
                   type: string
                   enum: [read-only, recommendation, action, payment]
@@ -558,6 +563,9 @@ paths:
                       type: integer
                     pricing_plan:
                       $ref: '#/components/schemas/PricingPlan'
+                    billing_timing:
+                      type: string
+                      enum: [post, prepay]
                     dry_run_supported:
                       type: boolean
                     jurisdiction:
@@ -1734,13 +1742,18 @@ components:
         price_model:
           type: string
           enum: [free, subscription, per_request, usage_based, per_action]
-          description: Pricing model. `usage_based` and `per_action` are free upfront and bill only when the execution receipt selects a positive pricing_plan item.
+          description: Pricing model. `usage_based` and `per_action` price operations from pricing_plan. With billing_timing=post they settle after the execution receipt; with billing_timing=prepay they require a quote and direct payment before ACTION execution.
         price_value_minor:
           type: integer
           minimum: 0
           description: Fixed price in minor currency units. Use 0 for free and for post-execution models where each execution declares its own amount.
         pricing_plan:
           $ref: '#/components/schemas/PricingPlan'
+        billing_timing:
+          type: string
+          enum: [post, prepay]
+          default: post
+          description: Billing timing for usage_based/per_action. Use prepay for irreversible side effects.
         currency: { type: string, default: USD }
         docs_url: { type: string, description: "Public API usage guide; not a generic seller homepage." }
         support_contact: { type: string, description: "Real support email address or public support URL." }
@@ -1900,6 +1913,7 @@ components:
         price_value_minor: { type: integer }
         pricing_plan:
           $ref: '#/components/schemas/PricingPlan'
+        billing_timing: { type: string, enum: [post, prepay] }
         currency: { type: string }
         fulfillment_kind: { type: string }
         status: { type: string }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "1.1.0"
+version = "1.2.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -134,6 +134,14 @@ the fee.
 `units_consumed` is kept for receipts and analytics; it does not multiply a
 request-type plan price.
 
+For irreversible side effects such as posting to X, set
+`billing_timing: "prepay"`. The platform first calls your API as a quote
+(`execution_kind="quote"` / `dry_run=true`), reads `billingPreview.operation`
+and `draftToken`, collects the direct payment for that pricing-plan operation,
+then calls the ACTION endpoint with the same token as `commit_token`. If payment
+fails, the ACTION call is never made. Use the default `"post"` timing only for
+read-only or reversible usage.
+
 Company-name publishing is founder-only in the Phase 2 MVP. Use
 `publisher_type: "company"` with `company_id` in `app_manifest.yaml`, or pass
 `--company <company_id>` to the CLI. Paid company listings require the

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -904,6 +904,7 @@ function parseListing(data: Record<string, unknown>): AppListingRecord {
     price_model: stringOrNull(data.price_model),
     price_value_minor: Number(data.price_value_minor ?? 0),
     pricing_plan: pricing_plan as AppListingRecord["pricing_plan"],
+    billing_timing: String(data.billing_timing ?? metadata.billing_timing ?? "post"),
     currency: String(data.currency ?? "USD"),
     allow_free_trial: Boolean(data.allow_free_trial ?? false),
     free_trial_duration_days: Number(data.free_trial_duration_days ?? 30),
@@ -2267,6 +2268,7 @@ export class SiglumeClient implements SiglumeClientShape {
       "price_model",
       "price_value_minor",
       "pricing_plan",
+      "billing_timing",
       "currency",
       "allow_free_trial",
       "free_trial_duration_days",
@@ -2288,6 +2290,13 @@ export class SiglumeClient implements SiglumeClientShape {
       (typeof payload.pricing_plan !== "object" || Array.isArray(payload.pricing_plan))
     ) {
       throw new SiglumeClientError("AppManifest.pricing_plan must be an object when provided.");
+    }
+    if (payload.billing_timing !== undefined && payload.billing_timing !== null) {
+      const billingTiming = String(payload.billing_timing || "post").trim().toLowerCase();
+      if (billingTiming !== "post" && billingTiming !== "prepay") {
+        throw new SiglumeClientError("AppManifest.billing_timing must be 'post' or 'prepay'.");
+      }
+      payload.billing_timing = billingTiming;
     }
     if (payload.store_vertical === undefined || payload.store_vertical === null) {
       throw new SiglumeClientError(

--- a/siglume-api-sdk-ts/src/runtime.ts
+++ b/siglume-api-sdk-ts/src/runtime.ts
@@ -219,6 +219,13 @@ export class AppTestHarness {
     }
     issues.push(...pricingPlanFloorIssues(manifest.pricing_plan, String(manifest.currency ?? "USD")));
     if (
+      manifest.billing_timing !== undefined &&
+      manifest.billing_timing !== "post" &&
+      manifest.billing_timing !== "prepay"
+    ) {
+      issues.push("billing_timing must be 'post' or 'prepay'");
+    }
+    if (
       (manifest.price_model === PriceModel.USAGE_BASED || manifest.price_model === PriceModel.PER_ACTION) &&
       (!manifest.pricing_plan || !Array.isArray(manifest.pricing_plan.items) || manifest.pricing_plan.items.length === 0)
     ) {

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -58,6 +58,7 @@ export const PriceModel = {
   PER_ACTION: "per_action",
 } as const;
 export type PriceModel = (typeof PriceModel)[keyof typeof PriceModel];
+export type BillingTiming = "post" | "prepay";
 
 export const AppCategory = {
   COMMERCE: "commerce",
@@ -122,6 +123,7 @@ export interface AppManifest {
   price_model?: PriceModel;
   price_value_minor?: number;
   pricing_plan?: PricingPlan;
+  billing_timing?: BillingTiming;
   currency: ListingCurrency;
   allow_free_trial: boolean;
   free_trial_duration_days?: number;
@@ -336,6 +338,7 @@ export interface AppListingRecord {
   price_model?: string | null;
   price_value_minor: number;
   pricing_plan?: PricingPlan | null;
+  billing_timing?: BillingTiming | string | null;
   currency: string;
   allow_free_trial: boolean;
   free_trial_duration_days: number;

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "1.1.0";
+export const SDK_VERSION = "1.2.0";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -264,6 +264,7 @@ class AppManifest:
     price_model: PriceModel = PriceModel.FREE
     price_value_minor: int = 0             # minor units for `currency` (USD cents, JPY yen)
     pricing_plan: dict[str, Any] | None = None  # optional buyer-facing operation price table
+    billing_timing: str = "post"           # "post" (execute then settle) or "prepay" (quote then pay before action)
     currency: ListingCurrency | str | None = None  # REQUIRED: "USD" -> USDC, "JPY" -> JPYC
     allow_free_trial: bool | None = None   # REQUIRED: True/False must be an explicit publisher choice
     free_trial_duration_days: int = 30     # 1-90 when allow_free_trial=True
@@ -307,6 +308,10 @@ class AppManifest:
             )
         self.currency = ListingCurrency(currency)
         _validate_pricing_plan_floor(self.pricing_plan, default_currency=currency)
+        billing_timing = str(self.billing_timing or "post").strip().lower()
+        if billing_timing not in {"post", "prepay"}:
+            raise ValueError("AppManifest.billing_timing must be 'post' or 'prepay'.")
+        self.billing_timing = billing_timing
         price_model_value = self.price_model.value if isinstance(self.price_model, PriceModel) else str(self.price_model or "")
         if price_model_value in {PriceModel.USAGE_BASED.value, PriceModel.PER_ACTION.value} and not _pricing_plan_has_items(
             self.pricing_plan
@@ -1244,6 +1249,9 @@ class AppTestHarness:
             _validate_pricing_plan_floor(m.pricing_plan, default_currency=str(m.currency.value if isinstance(m.currency, ListingCurrency) else m.currency))
         except ValueError as exc:
             issues.append(str(exc))
+        billing_timing = str(getattr(m, "billing_timing", "post") or "post").strip().lower()
+        if billing_timing not in {"post", "prepay"}:
+            issues.append("billing_timing must be 'post' or 'prepay'")
         price_model_value = m.price_model.value if isinstance(m.price_model, PriceModel) else str(m.price_model or "")
         if price_model_value in {PriceModel.USAGE_BASED.value, PriceModel.PER_ACTION.value} and not _pricing_plan_has_items(
             m.pricing_plan

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "1.1.0"
+SDK_VERSION = "1.2.0"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -120,6 +120,7 @@ class AppListingRecord:
     price_model: str | None = None
     price_value_minor: int = 0
     pricing_plan: dict[str, Any] | None = None
+    billing_timing: str = "post"
     currency: str = "USD"
     allow_free_trial: bool = False
     free_trial_duration_days: int = 30
@@ -1402,6 +1403,7 @@ def _build_auto_register_request(
         "price_model",
         "price_value_minor",
         "pricing_plan",
+        "billing_timing",
         "currency",
         "allow_free_trial",
         "free_trial_duration_days",
@@ -1418,6 +1420,11 @@ def _build_auto_register_request(
             payload[field_name] = _enum_value(value)
     if "pricing_plan" in payload and not isinstance(payload["pricing_plan"], Mapping):
         raise SiglumeClientError("AppManifest.pricing_plan must be an object when provided.")
+    if "billing_timing" in payload:
+        billing_timing = str(payload.get("billing_timing") or "post").strip().lower()
+        if billing_timing not in {"post", "prepay"}:
+            raise SiglumeClientError("AppManifest.billing_timing must be 'post' or 'prepay'.")
+        payload["billing_timing"] = billing_timing
     if "store_vertical" not in payload:
         raise SiglumeClientError(
             "AppManifest.store_vertical is required. Choose 'api' for normal "
@@ -1635,6 +1642,7 @@ def _parse_listing(data: Mapping[str, Any]) -> AppListingRecord:
         price_model=_string_or_none(data.get("price_model")),
         price_value_minor=int(data.get("price_value_minor") or 0),
         pricing_plan=dict(pricing_plan) if isinstance(pricing_plan, Mapping) else None,
+        billing_timing=str(data.get("billing_timing") or metadata.get("billing_timing") or "post"),
         currency=str(data.get("currency") or "USD"),
         allow_free_trial=bool(data.get("allow_free_trial") or False),
         free_trial_duration_days=int(data.get("free_trial_duration_days") or 30),

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -100,7 +100,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "1.1.0"
+    assert python_version == "1.2.0"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -115,7 +115,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.1.0 (beta)**" in readme
+    assert "This is **v1.2.0 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
Release v1.2.0 with billing_timing support for per-action prepay quote billing.\n\nValidation run locally:\n- py -3 -m pytest tests/test_client.py tests/test_cli.py -q\n- npm run typecheck\n- npm test -- --coverage.enabled=false\n- py -3 -m build\n- npm run pack:check