### PR TITLE
Release SDK v1.2.1 pricing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-04
+
+### Fixed
+
+- Added the canonical [Pricing And Billing](docs/pricing-and-billing.md)
+  developer guide covering free APIs, subscriptions, operation-based
+  `usage_based` / `per_action` plans, JPY/JPYC minimum operation pricing, and
+  `billing_timing="prepay"`.
+- Updated SDK docs that still described `usage_based` / `per_action` as future
+  values, and added a regression test so docs stay aligned with the live
+  operation billing contract.
+- Added `billing_timing` to `schemas/app-manifest.schema.json` so schema-driven
+  editors and validation tools see the same manifest field as Python and
+  TypeScript SDKs.
+
 ## [1.2.0] - 2026-06-04
 
 ### Added

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -223,6 +223,8 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `permission_class` | Permission level ([see guide](#6-permission-classes-guide)) | `PermissionClass.READ_ONLY` |
 | `approval_mode` | How execution is approved | `ApprovalMode.AUTO` |
 | `price_model` | Billing model | `"free"`, `"subscription"`, `"usage_based"`, `"per_action"` |
+| `pricing_plan` | Required operation price table for `usage_based` / `per_action` | `{"items": [{"key": "text_post", "price_minor": 15}]}` |
+| `billing_timing` | Operation billing timing. Use `"prepay"` for irreversible actions. | `"post"`, `"prepay"` |
 | `jurisdiction` | **Required.** ISO 3166-1 alpha-2 country code declaring the governing law of your API. [Details](docs/jurisdiction-and-compliance.md) | `"US"`, `"JP"`, `"US-CA"` |
 | `docs_url` | **Required for production registration.** Public usage guide for this API listing. Do not use your company homepage or the same URL as `source_url`. | `"https://docs.your-domain.com/weather-api"` |
 | `support_contact` | **Required for production registration.** Real support email address or public support URL. Placeholder domains are rejected. See [How buyer inquiries reach you](#how-buyer-inquiries-reach-you) below for the routing rules. | `"support@your-domain.com"` |
@@ -745,6 +747,7 @@ Declare the account type in `required_connected_accounts` with `managed_by: "api
 ### What's the difference between free and paid APIs?
 
 > Free, subscription, `usage_based`, and `per_action` listings are supported.
+> For the full contract, see [Pricing And Billing](docs/pricing-and-billing.md).
 
 Use `price_model="free"` for free APIs. For subscription APIs, use
 `price_model="subscription"` with `price_value_minor` set to your monthly price
@@ -777,6 +780,12 @@ pricing_plan={
 For JPY/JPYC listings, paid operations must be either `0` or at least `15`
 minor units. Positive amounts from `1` to `14` are rejected by the SDK and the
 platform because platform-sponsored gas can exceed the fee.
+
+For irreversible side effects such as posting to X, set
+`billing_timing="prepay"`. The platform quotes the operation with a dry-run,
+collects the matching direct payment from `pricing_plan`, and only then calls
+the live action with the quoted commit token. Use the default
+`billing_timing="post"` only when execute-then-settle is acceptable.
 
 Planned feature: your agent will be able to promote your API within Siglume, acting as your salesperson to other agents and their owners.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first idea.
 
 > ✅ **Payment stack is on-chain and live.** Siglume settles 100% on **Polygon mainnet** (chainId 137) — non-custodial embedded smart wallets, platform-sponsored gas, auto-debit subscription mandates. Stripe Connect was retired in v0.2.0; the migration is complete across all five settlement surfaces (Plan / Partner / API Store paid / AIWorks Escrow / Ads). See [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md) for the migration history and on-chain contract addresses.
 
-Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs and agents subscribe to them) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store — you publish an API once; any Siglume agent whose owner opts in can subscribe and call it, and you get paid per subscription. The customers are **autonomous AI agents**, not humans.
+Siglume runs two distinct surfaces: the **Agent API Store** (where developers publish APIs for agents to install and call) and **AIWorks** (where agents fulfil jobs). This SDK targets the Agent API Store: you publish an API once, any Siglume agent whose owner opts in can use it, and billing follows the listing's price model: free, subscription, or operation-based usage billing. The customers are **autonomous AI agents**, not humans.
 
 **Who this is for:** developers shipping API products who want a new distribution channel where the *customer is the AI agent itself*.
 
@@ -58,7 +58,7 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.2.0.** Python and TypeScript are version-aligned and
+> **Current release: v1.2.1.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
@@ -68,6 +68,7 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 > publisher APIs now own external OAuth, token storage, refresh, revocation,
 > and user-to-token mapping behind their own `connect_url`.
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v1.2.1.md](./RELEASE_NOTES_v1.2.1.md),
 > [RELEASE_NOTES_v1.2.0.md](./RELEASE_NOTES_v1.2.0.md),
 > [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
 > [RELEASE_NOTES_v1.0.0.md](./RELEASE_NOTES_v1.0.0.md), and
@@ -78,6 +79,8 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 > For the current browser-vs-CLI entry points into the same `auto-register`
 > flow, see
 > [docs/publish-flow.md](./docs/publish-flow.md).
+> For the canonical pricing model reference, see
+> [docs/pricing-and-billing.md](./docs/pricing-and-billing.md).
 
 ### 3-minute first success
 
@@ -346,7 +349,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 Free, subscription, `usage_based`, and `per_action` APIs are live in production
 on Polygon mainnet (chainId 137). Free listings publish without a wallet; paid
-listings settle automatically to your non-custodial embedded smart wallet.
+listings settle automatically to your non-custodial embedded smart wallet. See
+[docs/pricing-and-billing.md](./docs/pricing-and-billing.md) for the full
+developer contract and examples.
 Publishers must explicitly set the listing currency in `AppManifest.currency`:
 `USD` prices settle in USDC, and `JPY` prices settle in JPYC. Publishers must
 also explicitly set `AppManifest.allow_free_trial` to decide whether Plus/Pro
@@ -809,7 +814,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.2.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v1.2.1 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v1.2.1.md
+++ b/RELEASE_NOTES_v1.2.1.md
@@ -1,0 +1,40 @@
+# Siglume API SDK v1.2.1
+
+v1.2.1 is a documentation and schema patch for operation-based billing.
+
+## Why this release exists
+
+v1.2.0 shipped `billing_timing` support, but the SDK documentation was not yet
+consistent enough for a new API developer to rely on it as the primary
+development reference. Some pages still described `usage_based` and
+`per_action` as future values, and the manifest JSON schema did not expose
+`billing_timing`.
+
+## What's fixed
+
+- Added [docs/pricing-and-billing.md](docs/pricing-and-billing.md), the
+  canonical guide for:
+  - free API calls
+  - subscription APIs
+  - operation-based `usage_based` / `per_action` pricing plans
+  - JPY/JPYC minimum operation price of `0` or at least `15`
+  - `billing_timing="post"` vs `billing_timing="prepay"`
+  - prepay quote fields such as `billingPreview.operation` and `draftToken`
+- Updated README, Getting Started, TypeScript README, metering, receipts,
+  dry-run/approval, Web3 settlement, publish flow, and core concepts docs so the
+  same pricing model language is used everywhere.
+- Added `billing_timing` to `schemas/app-manifest.schema.json`.
+- Added docs-contract regression coverage so public docs cannot drift back to
+  describing `usage_based` / `per_action` as unsupported future values.
+
+## Developer takeaway
+
+Use this mental model:
+
+- free: `price_model="free"`
+- subscription: `price_model="subscription"`
+- operation-priced usage: `price_model="usage_based"` or `"per_action"` with
+  `pricing_plan.items`
+
+Use `billing_timing="prepay"` for irreversible paid actions such as posting or
+sending, where the action must not run before the quoted payment succeeds.

--- a/docs/coding-agent-guide.md
+++ b/docs/coding-agent-guide.md
@@ -21,6 +21,19 @@ Good first API constraints:
 Avoid `ACTION`, `PAYMENT`, OAuth, and subscription pricing until the first API
 passes the local loop and the human understands the publish flow.
 
+If the human explicitly asks for paid pricing, read
+`docs/pricing-and-billing.md` first. Treat the live choices as:
+
+- free call: `price_model="free"`
+- subscription: `price_model="subscription"`
+- operation-based usage billing: `price_model="usage_based"` or
+  `"per_action"` plus `pricing_plan.items`
+
+For operation-based JPY/JPYC billing, free operations use `0` and paid
+operations must be at least `15` minor units. Use `billing_timing="prepay"` for
+irreversible side effects such as posting, sending, or other actions that must
+not run before payment succeeds.
+
 ## Files to create or update
 
 Create or update these files in the generated project:

--- a/docs/dry-run-and-approval.md
+++ b/docs/dry-run-and-approval.md
@@ -45,9 +45,24 @@ Examples:
 - `action` and `payment` APIs should generally use `always-ask` or `budget-bounded`
 - approval prompts should be short, specific, and human-readable
 
-## Beta Rule
+## Billing timing
 
-Both free and subscription APIs are supported. Action and payment APIs can be published with appropriate permission classes.
+Free, subscription, `usage_based`, and `per_action` listings are live. Billing
+model and permission class are separate choices: a paid API can still be
+`READ_ONLY`, and a free API can still be `ACTION` if it changes external state.
+
+For operation-based billing, choose the timing explicitly:
+
+- `billing_timing="post"`: execute first, then the platform settles the matching
+  positive `pricing_plan` item from the execution receipt. This is the default.
+- `billing_timing="prepay"`: quote first, collect payment for the quoted
+  operation, then call the live action. Use this for irreversible side effects
+  such as posting to X.
+
+For `prepay`, the quote/dry-run response must include a stable `draftToken` and
+`billingPreview.operation` matching a `pricing_plan.items[].key`. The action
+handler must accept the same token as the configured commit token and must not
+recompute a different operation after payment.
 
 ## Example
 
@@ -57,7 +72,11 @@ if ctx.execution_kind == ExecutionKind.DRY_RUN:
         success=True,
         execution_kind=ExecutionKind.DRY_RUN,
         output={"preview": "Will post 1 tweet"},
+        receipt_summary={"operation": "dry_run", "amount_minor": 0, "currency": "JPY"},
         needs_approval=True,
         approval_prompt="Post this summary to X?",
     )
 ```
+
+See [Pricing And Billing](./pricing-and-billing.md) for a complete prepay quote
+example.

--- a/docs/execution-receipts.md
+++ b/docs/execution-receipts.md
@@ -148,3 +148,31 @@ result = ExecutionResult(
 - When the API is in `dry_run`, return a preview receipt instead of a fake live one
 - Use `SideEffectRecord.reversible` honestly — it affects rollback review
 - Always include `external_id` when the provider returns one
+
+## Operation billing receipts
+
+For `price_model="usage_based"` or `price_model="per_action"`, the receipt is
+also the billing selector. Return the operation/request type that actually ran:
+
+```python
+return ExecutionResult(
+    success=True,
+    output={"posted": True},
+    units_consumed=1,
+    amount_minor=15,
+    currency="JPY",
+    receipt_summary={
+        "operation": "text_only",
+        "amount_minor": 15,
+        "currency": "JPY",
+    },
+)
+```
+
+The operation must match a `pricing_plan.items[].key`. The plan item is
+authoritative for the charge. If the receipt reports a conflicting positive
+amount, the platform rejects the call instead of charging the arbitrary amount.
+For free/no-op operations, return `amount_minor=0`; the platform creates no
+payment for a `0`-priced plan item.
+
+See [Pricing And Billing](./pricing-and-billing.md) for the full contract.

--- a/docs/metering.md
+++ b/docs/metering.md
@@ -15,6 +15,10 @@ operations, or when the amount depends on what the API actually did. Example:
 connection check = 0 JPY, dry-run preview = 0 JPY, text post = 15 JPY, URL post
 = 20 JPY, reply = 30 JPY.
 
+For irreversible side effects, use `billing_timing="prepay"` so the platform
+quotes the operation, collects payment, and only then calls the live action. See
+[Pricing And Billing](./pricing-and-billing.md) for the end-to-end contract.
+
 For JPY/JPYC listings, a paid operation must be either `0` or at least `15`
 minor units. `0` is valid for free operations. Positive amounts below `15` are
 rejected by the SDK and by the platform.

--- a/docs/pricing-and-billing.md
+++ b/docs/pricing-and-billing.md
@@ -1,0 +1,223 @@
+# Pricing And Billing Guide
+
+This is the canonical pricing guide for new Siglume API Store and Game API
+Store developers.
+
+Siglume supports three live commercial shapes:
+
+| Shape | Manifest fields | When to use it | Buyer-facing wording |
+|---|---|---|---|
+| Free call | `price_model="free"`, `price_value_minor=0` | Read-only APIs, free utilities, or early launches | Free |
+| Subscription | `price_model="subscription"`, monthly `price_value_minor` | Buyers pay for ongoing access to the API | Monthly subscription |
+| Operation-based usage billing | `price_model="usage_based"` or `"per_action"`, `price_value_minor=0`, `pricing_plan.items` | One API package has multiple request types with different prices, including free operations | From N JPY/call, operation-based billing |
+
+`one_time` and `bundle` are reserved values. Do not use them in new manifests.
+
+## Free APIs
+
+Use free pricing when the API call itself should never create a Siglume payment:
+
+```python
+manifest = AppManifest(
+    # required identity, permission, docs, support, jurisdiction fields...
+    price_model=PriceModel.FREE,
+    price_value_minor=0,
+    currency="JPY",
+    allow_free_trial=False,
+)
+```
+
+Free does not mean the outside world is free. A shopping finder API can be free
+while the product price, shipping, tax, and merchant checkout remain outside
+Siglume.
+
+## Subscription APIs
+
+Use subscription pricing when buyers pay for ongoing access, independent of the
+exact operation executed:
+
+```python
+manifest = AppManifest(
+    # required identity, permission, docs, support, jurisdiction fields...
+    price_model=PriceModel.SUBSCRIPTION,
+    price_value_minor=500,
+    currency="USD",
+    allow_free_trial=False,
+)
+```
+
+Subscription prices are monthly minor units: USD cents for `USD`, JPY yen for
+`JPY`. Paid subscription listings require payout readiness before production
+publish. Revenue settles to the seller's Siglume embedded wallet.
+
+Do not use `permission_class="payment"` just because the listing is paid.
+`permission_class` describes what the API does during execution. A paid API that
+posts to X is still `ACTION`; a paid API that only reads data can still be
+`READ_ONLY`.
+
+## Operation-Based Billing
+
+Use `usage_based` or `per_action` when one API package contains request types
+with different prices.
+
+Examples:
+
+- connection check: 0 JPY
+- dry-run preview: 0 JPY
+- text-only X post: 15 JPY
+- X post with URL: 28 JPY
+- X post with image: 35 JPY
+- X reply: 30 JPY
+
+The listing call can start without a flat upfront charge. The operation price is
+selected from `pricing_plan.items`.
+
+```python
+manifest = AppManifest(
+    # required identity, permission, docs, support, jurisdiction fields...
+    permission_class=PermissionClass.ACTION,
+    approval_mode=ApprovalMode.ALWAYS_ASK,
+    dry_run_supported=True,
+    price_model=PriceModel.PER_ACTION,
+    price_value_minor=0,
+    currency="JPY",
+    allow_free_trial=False,
+    pricing_plan={
+        "display_name": "X post operation prices",
+        "currency": "JPY",
+        "free_upfront_invocation": True,
+        "items": [
+            {"key": "connection_check", "label": "Connection check", "price_minor": 0},
+            {"key": "dry_run", "label": "Dry-run preview", "price_minor": 0},
+            {"key": "text_only", "label": "Text only post", "price_minor": 15},
+            {"key": "text_with_url", "label": "Text post with URL", "price_minor": 28},
+            {"key": "reply", "label": "Reply", "price_minor": 30},
+        ],
+    },
+)
+```
+
+Rules:
+
+- `pricing_plan.items` is required for `usage_based` and `per_action`.
+- Each item needs a stable key. The runtime receipt must return the same key.
+- `price_value_minor=0` is the normal setting when the amount varies by
+  operation.
+- A `0`-priced operation is free and creates no on-chain payment.
+- For JPY/JPYC operation billing, paid operations must be `0` or at least `15`
+  minor units. Amounts from `1` to `14` are rejected by the SDK and platform.
+- The `pricing_plan` is authoritative. The platform will not charge an arbitrary
+  positive amount just because the API returned it.
+
+The runtime result identifies the operation that actually ran:
+
+```python
+return ExecutionResult(
+    success=True,
+    output={"posted": True, "post_url": "https://x.com/..."},
+    units_consumed=1,
+    amount_minor=28,
+    currency="JPY",
+    receipt_summary={
+        "operation": "text_with_url",
+        "amount_minor": 28,
+        "currency": "JPY",
+    },
+)
+```
+
+Accepted operation-key fields are `operation`, `operation_key`, `request_type`,
+`pricing_key`, `price_key`, `receipt_code`, and `action`. Prefer
+`receipt_summary["operation"]` for new APIs.
+
+`units_consumed` is recorded for receipts and analytics. In the current
+request-type pricing plan, it does not multiply the item price.
+
+## Billing Timing: post vs prepay
+
+`billing_timing` controls whether payment happens after execution or before an
+irreversible live action.
+
+| Timing | Manifest value | Flow | Use for |
+|---|---|---|---|
+| Post execution | omit or `billing_timing="post"` | API executes, returns a receipt, then the platform settles the matching positive plan item | Read-only, reversible, or low-risk operations |
+| Prepay on quote | `billing_timing="prepay"` | Platform requests a quote/dry-run, prices the quoted operation, collects payment, then calls the live action with the quoted token | Irreversible side effects such as posting to X |
+
+For `prepay`, your API must support a quote/dry-run path that returns enough
+data for the platform to bind the later action to the paid quote:
+
+```python
+if ctx.execution_kind in {ExecutionKind.DRY_RUN, ExecutionKind.QUOTE}:
+    return ExecutionResult(
+        success=True,
+        execution_kind=ctx.execution_kind,
+        output={
+            "status": "ready",
+            "draftToken": draft_token,
+            "billingPreview": {
+                "operation": "text_with_url",
+                "priceMinorIfActionSucceeds": 28,
+                "currency": "JPY",
+            },
+        },
+        units_consumed=0,
+        amount_minor=0,
+        currency="JPY",
+        receipt_summary={
+            "operation": "dry_run",
+            "amount_minor": 0,
+            "currency": "JPY",
+        },
+    )
+```
+
+When payment is confirmed, the platform calls the live action and injects the
+same token as `commit_token` using the runtime validation token mapping. If
+payment fails, the live ACTION call is not made.
+
+Important boundary: prepay prevents "action executed before payment". It does
+not automatically refund a confirmed payment if the seller API or external
+provider fails after the paid live action starts. Your API should make the
+quote/dry-run validate connection, policy, idempotency, and provider readiness,
+and should return a failed or zero-priced receipt for known no-op outcomes.
+
+## Choosing Between usage_based And per_action
+
+Use `per_action` when the price is tied to a named operation/request type:
+`text_only`, `text_with_url`, `reply`, `image_generation`, and similar.
+
+Use `usage_based` when the operation still maps to a plan item but the product
+is conceptually metered usage. The current live plan still charges the matched
+plan item. Do not rely on `units_consumed * price_value_minor` for API Store
+runtime billing unless a future explicit metered-quantity plan is introduced.
+
+## Store Display
+
+API Store and Game API Store use `pricing_plan` for buyer-facing display.
+
+Examples:
+
+- all free operations: `FREE`
+- subscription: monthly price
+- operation-based paid plan: `from 15 JPY/call` plus an operation-based billing
+  badge
+- prepay operation billing: "free before payment" or equivalent copy, with the
+  plan table showing operation prices
+
+Do not describe a `usage_based` or `per_action` listing as free just because
+`price_value_minor=0`. The free value only means there is no flat per-request
+price; the operation plan may still contain paid items.
+
+## Checklist
+
+Before publishing operation-based billing:
+
+- [ ] `price_model` is `usage_based` or `per_action`.
+- [ ] `price_value_minor=0` when operation prices vary.
+- [ ] `pricing_plan.items` includes every billable and free operation key.
+- [ ] Positive JPY/JPYC operation prices are at least `15`.
+- [ ] Runtime receipts return the executed operation key.
+- [ ] Free/no-op operations return `amount_minor=0`.
+- [ ] Irreversible side effects use `billing_timing="prepay"`.
+- [ ] The quote/dry-run path returns `billingPreview.operation` and `draftToken`.
+- [ ] The action path is idempotent and verifies the quoted token before acting.

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -77,7 +77,8 @@ There is no normal human review step in the self-serve publish flow anymore.
 6. Sends a functional test request using your dedicated review/test key.
 7. Verifies the runtime sample request / response against the declared
    `input_schema` and `output_schema`.
-8. Checks connected-account requirements and paid pricing rules.
+ 8. Checks connected-account requirements, paid pricing rules, operation
+    pricing plans, and billing timing.
 9. Persists a private draft only if those checks pass. The CLI then confirms it
    by default unless `--draft-only` was requested.
 10. On confirmation, reruns the LLM legal review against the immutable stored
@@ -110,6 +111,11 @@ The following live-listing changes are material and are rejected with
 When a material term changes, create a new API listing with a new
 `capability_key`. Siglume does not silently migrate existing buyers or grants to
 new commercial or authorization terms.
+
+One exception is allowed: an existing operation-priced listing may move from
+the default `billing_timing="post"` to `billing_timing="prepay"` in place. That
+change makes irreversible actions safer because payment is confirmed before the
+live side effect. Other billing timing changes may still be treated as material.
 
 ## The mandatory LLM legal review
 
@@ -222,6 +228,8 @@ preflight errors before calling `auto-register`.
     Game API Store
   - `0` is valid for free operations; positive JPY/JPYC operation prices must
     be at least `15` minor units
+  - use `billing_timing="prepay"` for irreversible actions that must not run
+    before payment succeeds
 - For paid APIs, `AppManifest.allow_free_trial` must be explicitly set to
   `true` or `false`. When true, Plus/Pro buyers can start one lifetime trial
   per listing, subject to their monthly trial quota; `free_trial_duration_days`

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -1,20 +1,20 @@
 # SDK Core Concepts
 
-Quick reference of the types and helpers you touch most often when
-building an API for the Siglume API Store. Runnable examples live in
+Quick reference of the types and helpers you touch most often when building an
+API for the Siglume API Store or Game API Store. Runnable examples live in
 [`examples/`](../examples); this page is the type-level map.
 
 ## Core runtime types
 
 | Component | What it does |
 |---|---|
-| `AppAdapter` | Base class. Implement `manifest()` and `execute()` (required); `supported_task_types()` is optional. |
-| `AppManifest` | Metadata, permissions, pricing. Produced by `AppAdapter.manifest()`. |
-| `ExecutionContext` | Task details passed to `execute()`. |
-| `ExecutionResult` | Output and usage data returned from `execute()`. |
+| `AppAdapter` | Base class. Implement `manifest()` and `execute()`; `supported_task_types()` is optional. |
+| `AppManifest` | Metadata, permissions, pricing, billing timing, and store placement. Produced by `AppAdapter.manifest()`. |
+| `ExecutionContext` | Task details passed to `execute()`, including `execution_kind` such as `dry_run`, `quote`, or `action`. |
+| `ExecutionResult` | Output, usage data, amount fields, and receipt data returned from `execute()`. |
 | `ExecutionArtifact` | Describes a discrete output produced by execution. |
 | `SideEffectRecord` | Describes an external side effect for audit and rollback review. |
-| `ReceiptRef` | Opaque reference to a receipt (set by runtime). |
+| `ReceiptRef` | Opaque reference to a receipt, set by the runtime. |
 | `ApprovalRequestHint` | Structured context the owner sees in the approval dialog. |
 
 ## Enums
@@ -23,53 +23,73 @@ building an API for the Siglume API Store. Runnable examples live in
 
 Supported tiers for live listings:
 
-- `READ_ONLY` — search, retrieve, review, suggest
-- `ACTION` — cart, reserve, draft, publish
-- `PAYMENT` — pay, purchase, settle
+- `READ_ONLY` - search, retrieve, review, suggest
+- `ACTION` - cart, reserve, draft, publish
+- `PAYMENT` - pay, purchase, settle
 
 > **Legacy:** `RECOMMENDATION` is a deprecated alias of `READ_ONLY`
-> retained for backward compatibility with v0.2-era manifests. It is
-> treated as `READ_ONLY` at runtime and will be removed in a future
-> major release. **Do not use it in new manifests.** The parallel
-> `ToolManualPermissionClass` enum has never accepted
-> `RECOMMENDATION`.
+> retained for backward compatibility with v0.2-era manifests. It is treated as
+> `READ_ONLY` at runtime and will be removed in a future major release. Do not
+> use it in new manifests.
 
 ### `ApprovalMode`
 
-- `AUTO` — auto-execute without asking the owner (allowed for `READ_ONLY`)
-- `ALWAYS_ASK` — always require an explicit owner approval
-- `BUDGET_BOUNDED` — auto-execute while inside the delegated budget; escalate otherwise
+- `AUTO` - auto-execute without asking the owner; normally for `READ_ONLY`
+- `ALWAYS_ASK` - always require explicit owner approval
+- `BUDGET_BOUNDED` - auto-execute inside the delegated budget; escalate otherwise
 
 ### `PriceModel`
 
-Live today: `FREE`, `SUBSCRIPTION`.
+Live today:
 
-Reserved for future phases (not accepted by the platform at registration
-time): `ONE_TIME`, `BUNDLE`, `USAGE_BASED`, `PER_ACTION`.
+- `FREE` - no Siglume payment for API calls.
+- `SUBSCRIPTION` - monthly access price in `price_value_minor`.
+- `USAGE_BASED` - operation-based billing with required `pricing_plan.items`.
+- `PER_ACTION` - action/request-type billing with required `pricing_plan.items`.
+
+Reserved values: `ONE_TIME`, `BUNDLE`.
+
+For `USAGE_BASED` and `PER_ACTION`, keep `price_value_minor=0` when prices vary
+by operation, publish `pricing_plan.items`, and return the executed operation in
+`ExecutionResult.receipt_summary`. Positive JPY/JPYC operation prices must be at
+least `15` minor units. Use `AppManifest.billing_timing="prepay"` for
+irreversible side effects and the default `"post"` for execute-then-settle
+flows. See [Pricing And Billing](./pricing-and-billing.md).
+
+## Manifest pricing fields
+
+| Field | Purpose |
+|---|---|
+| `price_model` | Selects free, subscription, or operation-based billing. |
+| `price_value_minor` | Monthly subscription amount, or `0` when operation prices vary by plan item. |
+| `currency` | Required listing currency. `USD` settles in USDC; `JPY` settles in JPYC. |
+| `allow_free_trial` | Required explicit publisher choice for paid subscription trial availability. |
+| `pricing_plan` | Buyer-facing operation price table for `usage_based` / `per_action`. |
+| `billing_timing` | `"post"` by default; use `"prepay"` to quote and collect payment before irreversible actions. |
 
 ## Tool manual
 
 | Component | What it does |
 |---|---|
 | `ToolManual` | Machine-readable contract that agents read to decide whether to call your API. |
-| `ToolManualIssue` | Single validation or quality issue (raised by the grader). |
-| `ToolManualQualityReport` | Aggregated quality score (0–100 / grade A–F). Grade B is the minimum to publish. The same scorer is also published as the open-source [`siglume-agent-core.tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01) — install it locally to predict your grade before submission. |
+| `ToolManualIssue` | Single validation or quality issue raised by the grader. |
+| `ToolManualQualityReport` | Aggregated quality score. Grade B is the minimum to publish. |
 | `validate_tool_manual()` | Client-side validation that mirrors the server rules. |
-| `draft_tool_manual()` | Generate a ToolManual skeleton from a job description using an LLM provider. |
-| `fill_tool_manual_gaps()` | Repair / fill missing fields on an existing ToolManual. |
+| `draft_tool_manual()` | Generate a Tool Manual skeleton from a job description using an LLM provider. |
+| `fill_tool_manual_gaps()` | Repair or fill missing fields on an existing Tool Manual. |
 
 ## Testing helpers
 
 | Component | What it does |
 |---|---|
-| `AppTestHarness` | Local sandbox test runner. Validates the manifest, runs dry-runs, exercises quote / payment / receipt paths for `ACTION` and `PAYMENT` tiers. |
+| `AppTestHarness` | Local sandbox test runner. Validates the manifest, runs dry-runs, and exercises quote, payment, and receipt paths for `ACTION` and `PAYMENT` tiers. |
 | `StubProvider` | Mock external APIs for testing without hitting live services. |
 
 ## AIWorks extension (`siglume_api_sdk_aiworks`)
 
 Separate module for capabilities that may be invoked inside AIWorks job
-fulfillment. Import it when the platform passes a `JobExecutionContext`
-into your `execute()`; skip it otherwise.
+fulfillment. Import it when the platform passes a `JobExecutionContext` into
+your `execute()`; skip it otherwise.
 
 | Component | What it does |
 |---|---|
@@ -80,8 +100,9 @@ into your `execute()`; skip it otherwise.
 
 ## Related
 
-- [Getting Started](../GETTING_STARTED.md) — end-to-end build / validate / register flow
-- [Permission Scopes](./permission-scopes.md) — how to choose the minimum safe tier
-- [Dry Run and Approval](./dry-run-and-approval.md) — safe execution for `ACTION` / `PAYMENT` tiers
-- [Execution Receipts](./execution-receipts.md) — what to return after execution
-- **[`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core)** — the open-source decision logic that runs *after* you publish: the same Tool Manual scorer, the API Store tool-selection function (`tool_selector`), the LLM tool-use orchestrate loop, the per-tool failure-learning rules, the publisher dev simulator (`dev_simulator`) for pre-publish dry runs, and the AI Works route/candidate-selection helpers (`job_feasibility`, `works_candidate_selector`). AGPL-3.0; same code path as production.
+- [Getting Started](../GETTING_STARTED.md) - end-to-end build, validate, and register flow
+- [Pricing And Billing](./pricing-and-billing.md) - free, subscription, operation plans, and prepay billing
+- [Permission Scopes](./permission-scopes.md) - how to choose the minimum safe tier
+- [Dry Run and Approval](./dry-run-and-approval.md) - safe execution for `ACTION` / `PAYMENT` tiers
+- [Execution Receipts](./execution-receipts.md) - what to return after execution
+- [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) - open-source decision logic used after you publish

--- a/docs/web3-settlement.md
+++ b/docs/web3-settlement.md
@@ -48,13 +48,15 @@ listings settle in JPYC. Current Polygon settlement and swap token support is
 limited to `USDC` and `JPYC`.
 
 For `usage_based` and `per_action` API Store / Game API Store listings, the
-capability invocation itself is free up front. The publisher API executes first
-and reports the executed operation/request type in its `ExecutionResult`. The
-matching `pricing_plan` item is authoritative for the charge. The platform then
-creates a post-execution payment requirement only when the matched plan price is
-positive; a `0`-priced operation produces no on-chain payment. JPY/JPYC paid
-operation amounts must be either `0` or at least `15` minor units. The SDK and
-platform reject positive JPY/JPYC operation prices below that floor.
+publisher declares a buyer-facing `pricing_plan`. With the default
+`billing_timing="post"`, the publisher API executes first and reports the
+executed operation/request type in its `ExecutionResult`; the matching
+`pricing_plan` item is authoritative for the charge. With
+`billing_timing="prepay"`, the platform first collects payment for a quoted
+operation and only then calls the live action. A `0`-priced operation produces
+no on-chain payment. JPY/JPYC paid operation amounts must be either `0` or at
+least `15` minor units. The SDK and platform reject positive JPY/JPYC operation
+prices below that floor.
 
 ## Client helpers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "1.2.0"
+version = "1.2.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/schemas/app-manifest.schema.json
+++ b/schemas/app-manifest.schema.json
@@ -224,6 +224,12 @@
         }
       }
     },
+    "billing_timing": {
+      "type": "string",
+      "enum": ["post", "prepay"],
+      "default": "post",
+      "description": "Operation billing timing for usage_based/per_action listings. Use 'post' to execute then settle; use 'prepay' to quote and collect payment before irreversible live actions."
+    },
     "currency": {
       "type": "string",
       "enum": ["USD", "JPY"],

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -2,7 +2,7 @@
 
 TypeScript runtime for building, testing, and registering Siglume developer apps.
 
-This package is prepared in the public SDK repo and ships with the current v0.10.x release line.
+This package is prepared in the public SDK repo and ships with the current v1.2.x release line.
 
 It also includes `draft_tool_manual()` and `fill_tool_manual_gaps()` with
 bundled `AnthropicProvider` and `OpenAIProvider` classes. Provide
@@ -84,6 +84,9 @@ rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.
 
 ## Usage-Based And Per-Action Billing
+
+For the canonical pricing reference, see
+[`../docs/pricing-and-billing.md`](../docs/pricing-and-billing.md).
 
 Use `price_model: PriceModel.USAGE_BASED` or `PriceModel.PER_ACTION` when the
 API must execute before the final operation is known. These listings are free to

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "1.2.0";
+export const SDK_VERSION = "1.2.1";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "1.2.0"
+SDK_VERSION = "1.2.1"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -100,7 +100,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "1.2.0"
+    assert python_version == "1.2.1"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -115,7 +115,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.2.0 (beta)**" in readme
+    assert "This is **v1.2.1 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security
@@ -236,3 +236,37 @@ def test_payment_docs_match_current_polygon_settlement_language() -> None:
     assert "bank account or wallet address" not in docs
     assert "Wallet at `/owner/credits/payout`" in docs
     assert "external payout wallets are not supported" in docs
+
+
+def test_pricing_docs_match_live_operation_billing_contract() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("docs/pricing-and-billing.md"),
+            _read("docs/sdk-core-concepts.md"),
+            _read("docs/dry-run-and-approval.md"),
+            _read("docs/execution-receipts.md"),
+            _read("docs/metering.md"),
+            _read("docs/publish-flow.md"),
+            _read("siglume-api-sdk-ts/README.md"),
+        ]
+    )
+    normalized_docs = " ".join(docs.split())
+    schema = json.loads(_read("schemas/app-manifest.schema.json"))
+
+    assert "Reserved for future phases (not accepted by the platform" not in docs
+    assert "`USAGE_BASED` - operation-based billing" in docs
+    assert "`PER_ACTION` - action/request-type billing" in docs
+    assert "price_model=\"free\"" in docs
+    assert "price_model=\"subscription\"" in docs
+    assert "price_model=\"usage_based\"" in docs
+    assert "price_model=\"per_action\"" in docs
+    assert "pricing_plan.items" in docs
+    assert "billing_timing=\"prepay\"" in docs
+    assert "priceMinorIfActionSucceeds" in docs
+    assert "draftToken" in docs
+    assert "at least `15`" in docs
+    assert "does not automatically refund a confirmed payment" in normalized_docs
+    assert "Do not describe a `usage_based` or `per_action` listing as free just because" in docs
+    assert schema["properties"]["billing_timing"]["enum"] == ["post", "prepay"]


### PR DESCRIPTION
## Summary
- add canonical pricing and billing guide for free, subscription, usage_based/per_action, pricing_plan, and prepay quote billing
- add billing_timing to app manifest schema and align Python/TS package versions to 1.2.1
- update docs contract tests so operation billing docs cannot drift back to stale future wording

## Verification
- py -3 -m pytest tests/test_docs_contract.py tests/test_client.py tests/test_cli.py -q
- npm run typecheck
- py -3 -m build