### PR TITLE
Release SDK v1.2.2 observability docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-06-04
+
+### Fixed
+
+- Added [Developer Observability](docs/developer-observability.md) so new
+  developers can find `siglume dev tail`, seller listing receipts, owner
+  installed-tool receipts, support identifiers, and the privacy boundary.
+- Cross-linked receipt/log inspection from pricing, metering, publish, Getting
+  Started, execution receipt, TypeScript, and installed-tool docs.
+- Removed stale jurisdiction guidance that still described the payment stack as
+  migrating and incorrectly said Japan-based listings could not price in JPY.
+
 ## [1.2.1] - 2026-06-04
 
 ### Fixed

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -844,6 +844,18 @@ Capture the `listing_id`, `capability_key`, `review_url`, `trace_id`, and
 CLI/API key for `auto-register`, but it must send the full registration
 contract: `manifest`, `tool_manual`, and `runtime_validation`.
 
+After a sandbox or live run, use the developer observability commands to see
+what happened:
+
+```bash
+siglume dev tail
+siglume dev tail --listing-id LISTING_ID
+```
+
+The listing-scoped view is privacy-redacted for publishers. It shows execution
+evidence and support identifiers without exposing buyer prompts, owner ids, or
+private agent details. See [Developer Observability](docs/developer-observability.md).
+
 ### Step 2: Inspect the result in the owner console
 
 Open the `review_url` returned by the CLI, or go to
@@ -883,6 +895,10 @@ Then verify the sandbox run through usage data:
 curl "https://siglume.com/v1/market/usage?environment=sandbox&capability_key=my-api" \
   -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN"
 ```
+
+For normal developer diagnostics, prefer `siglume dev tail` or
+`siglume dev tail --listing-id LISTING_ID`; those commands expose recent
+execution receipts without relying on browser-session sandbox endpoints.
 
 Sandbox mode is isolated from live data. No real payments or side effects occur.
 When you are ready to go live, publish through `siglume register .` and the
@@ -1485,12 +1501,13 @@ other language before the draft can be confirmed.
 
 ## 12. Pricing and Payouts
 
-### Two pricing options
+### Three pricing options
 
 | Model | Description | Minimum |
 |---|---|---|
 | **Free** | No charge. Anyone can install. | - |
 | **Subscription** | Monthly recurring charge (USD). | $5.00/month |
+| **Operation-based billing** | Free upfront call, then a `pricing_plan` item charges only the operation that actually ran. | JPY/JPYC paid operations: 15 yen minimum |
 
 Set this in the `manifest` object inside your full `auto-register` payload. The
 full payload still needs the production registration contract: `manifest`,
@@ -1511,6 +1528,13 @@ payload["manifest"]["price_value_minor"] = 999
 
 `price_value_minor` uses the selected listing currency's minor unit: cents for
 USD (`$5.00 = 500`) and yen for JPY (`JPY 500 = 500`).
+
+For operation-priced APIs, use `price_model="usage_based"` or
+`price_model="per_action"`, set `price_value_minor=0`, define
+`pricing_plan.items`, and return the executed operation in
+`ExecutionResult.receipt_summary`. Use `billing_timing="prepay"` when a paid
+irreversible action must not run before payment succeeds. See
+[Pricing And Billing](docs/pricing-and-billing.md).
 
 ### Platform fee
 
@@ -1875,6 +1899,10 @@ Then verify the sandbox run through usage data:
 curl "https://siglume.com/v1/market/usage?environment=sandbox&capability_key=price-compare-helper" \
   -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN"
 ```
+
+For published listings, use `siglume dev tail --listing-id LISTING_ID` to view
+recent privacy-redacted execution receipts as a publisher. Use
+`siglume dev tail` without `--listing-id` for owner-scoped receipts.
 
 This is the currently exposed manual fallback for end-to-end validation. The
 older release-level `sandbox-test` and release-publish endpoints are not part of

--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.2.1.** Python and TypeScript are version-aligned and
+> **Current release: v1.2.2.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
-> operation pricing plans, prepay quote billing, long-form buyer-facing `description`, and
+> operation pricing plans, prepay quote billing, developer receipt/log
+> observability, long-form buyer-facing `description`, and
 > platform-controlled release semver via `version_bump`. v1.0.0 removes
 > platform OAuth broker APIs from the SDK:
 > publisher APIs now own external OAuth, token storage, refresh, revocation,
 > and user-to-token mapping behind their own `connect_url`.
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v1.2.2.md](./RELEASE_NOTES_v1.2.2.md),
 > [RELEASE_NOTES_v1.2.1.md](./RELEASE_NOTES_v1.2.1.md),
 > [RELEASE_NOTES_v1.2.0.md](./RELEASE_NOTES_v1.2.0.md),
 > [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
@@ -81,6 +83,8 @@ Siglume runs two distinct surfaces: the **Agent API Store** (where developers pu
 > [docs/publish-flow.md](./docs/publish-flow.md).
 > For the canonical pricing model reference, see
 > [docs/pricing-and-billing.md](./docs/pricing-and-billing.md).
+> To inspect runtime logs, receipts, and seller-side listing evidence, see
+> [docs/developer-observability.md](./docs/developer-observability.md).
 
 ### 3-minute first success
 
@@ -686,6 +690,12 @@ machine-readable `receipt_summary.operation` / `request_type` that matches a
 creates a post-execution payment requirement only for a positive plan-priced
 operation.
 
+After a run, inspect execution evidence with `siglume dev tail`,
+`siglume dev tail --listing-id <listing_id>`, or the Python helpers
+`list_execution_receipts()` and `list_listing_recent_receipts()`. See
+[Developer Observability](./docs/developer-observability.md) for the CLI,
+SDK, privacy boundary, and support checklist.
+
 ## Web3 settlement helpers
 
 Siglume subscription payments settle on Polygon via **non-custodial
@@ -751,6 +761,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | [Agent Behavior Operations](docs/agent-behavior.md) | Inspect owned agents and mirror charter / approval / budget operations, with the example adapter stopping at an approval proposal preview |
 | [Template Generator](docs/template-generator.md) | Generate `AppAdapter` wrappers directly from the owner-operation catalog |
 | [Metering](docs/metering.md) | Implement free-upfront usage/per-action billing and record usage-event analytics |
+| [Developer Observability](docs/developer-observability.md) | Inspect runtime logs, receipts, listing activity, and support identifiers |
 | [Web3 Settlement Helpers](docs/web3-settlement.md) | Read Polygon mandate / receipt data and simulate local settlement flows |
 | [API Reference](openapi/developer-surface.yaml) | OpenAPI spec for the developer surface |
 | [Permission Scopes](docs/permission-scopes.md) | Choose the minimum safe scope set |
@@ -814,7 +825,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.2.1 (beta)** — the platform is launched on Polygon mainnet
+This is **v1.2.2 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with all five settlement surfaces (Plan / Partner / API
 Store paid / AIWorks Escrow / Ads) live on-chain, and the SDK has
 reached parity with the production registration and operation surface.

--- a/RELEASE_NOTES_v1.2.2.md
+++ b/RELEASE_NOTES_v1.2.2.md
@@ -1,0 +1,19 @@
+# Siglume API SDK v1.2.2
+
+This patch release tightens developer documentation for the current production
+pricing and observability surface.
+
+## What changed
+
+- Added `docs/developer-observability.md`, the canonical guide for viewing
+  execution logs, receipts, listing activity, support identifiers, and analytics.
+- Documented `siglume dev tail`, `siglume dev tail --listing-id`, seller
+  receipt helpers, owner installed-tool receipt helpers, and privacy-redacted
+  publisher views.
+- Cross-linked observability from Pricing and Billing, Metering, Publish Flow,
+  Getting Started, Execution Receipts, Installed Tools, README, and the
+  TypeScript README.
+- Updated jurisdiction docs to reflect the live Polygon settlement stack and
+  current `currency="JPY"` / JPYC support.
+
+No runtime API contract changed from v1.2.1.

--- a/docs/developer-observability.md
+++ b/docs/developer-observability.md
@@ -1,0 +1,124 @@
+# Developer Observability: Logs, Receipts, And Analytics
+
+If you cannot see what happened after your API runs, the feature is effectively
+undocumented. Use this page to inspect execution receipts, seller-side listing
+activity, and buyer/owner installed-tool evidence.
+
+## What You Can See
+
+Siglume keeps two privacy boundaries:
+
+| View | Who uses it | What it is for | Privacy boundary |
+|---|---|---|---|
+| Owner execution receipts | The agent owner or the same account that ran the tool | Debug your own agent runs and inspect step evidence | Scoped to your owner account |
+| Seller listing receipts | The API publisher | Confirm that your listing was invoked, failed, or produced billable evidence | Privacy-redacted; buyer prompts, owner ids, agent ids, summaries, and sensitive failure details are not exposed |
+| Installed-tool receipts | The owner of installed capabilities | Inspect installed capability executions and step receipts | Scoped to the owner-operation route |
+
+Receipts are evidence, not a second pricing system. For `usage_based` and
+`per_action` APIs, the charge is selected from `pricing_plan.items` using the
+operation key in `ExecutionResult.receipt_summary`. Do not invent a price in
+support replies unless the receipt and listing plan agree.
+
+## CLI Quick Start
+
+After you register or publish an API, capture the `listing_id`, `trace_id`, and
+`request_id` from `siglume register . --json`. They are the fastest support
+handles when registration or runtime behavior needs investigation.
+
+```bash
+# Recent receipts in your owner account
+siglume dev tail
+
+# Watch new owner-scoped receipts as they arrive
+siglume dev tail --follow
+
+# Publisher view: recent privacy-redacted receipts for one listing
+siglume dev tail --listing-id listing_123
+
+# Seller analytics for one listing
+siglume dev stats listing_123
+siglume dev miss-analysis listing_123
+siglume dev keywords listing_123
+
+# Market-level context for API demand
+siglume dev market-vitals
+siglume dev gap-report
+```
+
+Use `--json` when a support script or CI job needs machine-readable output:
+
+```bash
+siglume dev tail --listing-id listing_123 --limit 20 --json
+```
+
+## Python SDK
+
+```python
+import os
+
+from siglume_api_sdk import SiglumeClient
+
+with SiglumeClient(api_key=os.environ["SIGLUME_API_KEY"]) as client:
+    # Owner-scoped execution receipts for your own account.
+    failures = client.list_execution_receipts(status="failed", limit=20)
+
+    # Seller-scoped, privacy-redacted receipts for a listing you publish.
+    listing_receipts = client.list_listing_recent_receipts("listing_123", limit=20)
+
+    stats = client.get_seller_listing_stats("listing_123")
+    vitals = client.get_market_vitals()
+```
+
+`list_listing_recent_receipts()` is intentionally redacted. It is enough to see
+that your listing ran, its status, timing, step counts, and support identifiers,
+but it must not expose the buyer's private prompt or account details.
+
+## Installed Tool Evidence
+
+If you are building owner tooling around installed capabilities, use the
+installed-tool wrappers:
+
+```python
+from siglume_api_sdk import SiglumeClient
+
+client = SiglumeClient(api_key="sig_live_...")
+
+receipts = client.list_installed_tool_receipts(status="completed", limit=10)
+receipt = client.get_installed_tool_receipt(receipts[0].receipt_id)
+steps = client.get_installed_tool_receipt_steps(receipts[0].receipt_id)
+```
+
+See [Installed Tools Operations](./installed-tools-operations.md) for the full
+wrapper list and parameter reference.
+
+## Billing Checks
+
+For operation-priced APIs:
+
+1. Confirm the listing has `price_model="usage_based"` or
+   `price_model="per_action"`.
+2. Confirm `pricing_plan.items` contains the operation key.
+3. Confirm the runtime returned that key in
+   `ExecutionResult.receipt_summary["operation"]`.
+4. Confirm free operations returned `amount_minor=0`.
+5. For `billing_timing="prepay"`, confirm the quote/dry-run returned
+   `billingPreview.operation` and `draftToken` before payment.
+
+The platform charges from the plan item, not from arbitrary prose in the output.
+If the receipt amount conflicts with the plan, the call is rejected instead of
+charging an unplanned amount.
+
+## Support Checklist
+
+When debugging a buyer report, ask for or collect:
+
+- `listing_id`
+- `capability_key`
+- `trace_id`
+- `request_id`
+- receipt id, if available
+- operation key from `receipt_summary`
+- whether the run was `dry_run`, `quote`, or live `action`
+
+Do not ask buyers for OAuth tokens, browser cookies, private prompts, card
+details, or wallet keys.

--- a/docs/execution-receipts.md
+++ b/docs/execution-receipts.md
@@ -11,6 +11,11 @@ Receipts help owners and operators answer:
 - what external action was taken
 - how to debug failures
 
+To view receipts after a run, use `siglume dev tail`, `siglume dev tail
+--listing-id <listing_id>`, or the SDK helpers `list_execution_receipts()` and
+`list_listing_recent_receipts()`. Publisher listing receipts are
+privacy-redacted. See [Developer Observability](./developer-observability.md).
+
 ## Two approaches: legacy and structured
 
 ### Legacy: `receipt_summary` (free-form dict)
@@ -146,7 +151,7 @@ result = ExecutionResult(
 - Do not include secrets or raw tokens
 - Include identifiers that help support investigate problems
 - When the API is in `dry_run`, return a preview receipt instead of a fake live one
-- Use `SideEffectRecord.reversible` honestly — it affects rollback review
+- Use `SideEffectRecord.reversible` honestly; it affects rollback review
 - Always include `external_id` when the provider returns one
 
 ## Operation billing receipts

--- a/docs/installed-tools-operations.md
+++ b/docs/installed-tools-operations.md
@@ -4,6 +4,12 @@
 owner-operation family that currently rides on the public owner-operation
 execute route.
 
+These wrappers are the owner-side evidence path for installed capabilities. If
+you are a publisher trying to inspect your own listing activity, use
+`siglume dev tail --listing-id <listing_id>` or
+`list_listing_recent_receipts()` instead. See
+[Developer Observability](./developer-observability.md).
+
 Covered today:
 
 - `installed_tools.list`

--- a/docs/jurisdiction-and-compliance.md
+++ b/docs/jurisdiction-and-compliance.md
@@ -10,14 +10,12 @@ The `jurisdiction` field is also the basis for the country-flag icon the
 API Store renders next to each listing — an instant visual cue of
 where the API is "from".
 
-> 🔄 **Payment-stack migration notice.** This document still references
-> Stripe Connect in several places. The platform is transitioning to
-> on-chain embedded-wallet settlement; the compliance surface there
-> differs (e.g. country-scoped payout rails are replaced by wallet-based
-> settlement). See [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for
-> the current cutover state. The **jurisdiction declaration requirement
-> itself is unchanged** — consumer-protection, tax, and data-residency
-> obligations continue to apply regardless of the settlement mechanism.
+> **Payment stack status.** On-chain embedded-wallet settlement is live on
+> Polygon mainnet, and Stripe Connect is retired. See
+> [PAYMENT_MIGRATION.md](../PAYMENT_MIGRATION.md) for the migration history.
+> The **jurisdiction declaration requirement itself is unchanged**:
+> consumer-protection, tax, and data-residency obligations continue to apply
+> regardless of the settlement mechanism.
 
 ## Why this is required
 
@@ -192,9 +190,10 @@ Consumer-protection laws of the end-user's country may still apply, but
 your contract is under US law.
 
 **Q: We're based in Japan and sell mostly to JP customers. Can we price in JPY?**
-A: No. `jurisdiction = "JP"` is fine — that's your governing law — but
-pricing is USD. Convert at your current FX and set a round USD number
-(e.g. ¥2,980/mo → $19.99/mo).
+A: Yes. Set `jurisdiction = "JP"` for the governing law and choose
+`currency="JPY"` when the Store price should be in yen and settle in JPYC.
+You may also choose `currency="USD"` for a USDC-priced offer. In both cases,
+`price_value_minor` follows the selected currency: yen for JPY, cents for USD.
 
 **Q: We operate in multiple countries with separate legal entities.**
 A: Register separate APIs per entity, each with its own `capability_key`

--- a/docs/metering.md
+++ b/docs/metering.md
@@ -80,6 +80,13 @@ request-type price unless a future explicit metered-quantity plan is introduced.
 Use stable idempotency keys in your API and receipt metadata so repeated calls
 can be reconciled without double-charging.
 
+To inspect runtime receipts after a live run, use `siglume dev tail`,
+`siglume dev tail --listing-id <listing_id>`,
+`SiglumeClient.list_execution_receipts()`, or
+`SiglumeClient.list_listing_recent_receipts()`. See
+[Developer Observability](./developer-observability.md) for the privacy
+boundary and support checklist.
+
 ## Python
 
 ```python

--- a/docs/pricing-and-billing.md
+++ b/docs/pricing-and-billing.md
@@ -208,6 +208,30 @@ Do not describe a `usage_based` or `per_action` listing as free just because
 `price_value_minor=0`. The free value only means there is no flat per-request
 price; the operation plan may still contain paid items.
 
+## Inspecting Logs And Billing Evidence
+
+After registration or a live run, use the developer observability surface:
+
+```bash
+siglume dev tail
+siglume dev tail --listing-id listing_123
+```
+
+The owner-scoped command shows receipts for your own account. The listing-scoped
+command is for publishers and is privacy-redacted: it confirms status, timing,
+step counts, operation evidence, and support identifiers without exposing buyer
+prompts or private agent details.
+
+Python SDK equivalents:
+
+```python
+client.list_execution_receipts(status="failed", limit=20)
+client.list_listing_recent_receipts("listing_123", limit=20)
+```
+
+See [Developer Observability](./developer-observability.md) for the full CLI,
+SDK, installed-tool receipt, and support checklist.
+
 ## Checklist
 
 Before publishing operation-based billing:
@@ -221,3 +245,4 @@ Before publishing operation-based billing:
 - [ ] Irreversible side effects use `billing_timing="prepay"`.
 - [ ] The quote/dry-run path returns `billingPreview.operation` and `draftToken`.
 - [ ] The action path is idempotent and verifies the quoted token before acting.
+- [ ] You know how to inspect receipts with `siglume dev tail --listing-id`.

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -57,6 +57,9 @@ There is no normal human review step in the self-serve publish flow anymore.
     intentionally needs an immutable draft for explicit human review.
 11. The draft can then be published by rerunning plain `siglume register .` or
     calling `confirm-auto-register`.
+12. After live or sandbox execution, use `siglume dev tail` or
+    `siglume dev tail --listing-id <listing_id>` to inspect execution receipts
+    and support identifiers. See [Developer Observability](developer-observability.md).
 
 ## What auto-register does
 

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -102,6 +102,7 @@ your `execute()`; skip it otherwise.
 
 - [Getting Started](../GETTING_STARTED.md) - end-to-end build, validate, and register flow
 - [Pricing And Billing](./pricing-and-billing.md) - free, subscription, operation plans, and prepay billing
+- [Developer Observability](./developer-observability.md) - logs, receipts, listing activity, and support identifiers
 - [Permission Scopes](./permission-scopes.md) - how to choose the minimum safe tier
 - [Dry Run and Approval](./dry-run-and-approval.md) - safe execution for `ACTION` / `PAYMENT` tiers
 - [Execution Receipts](./execution-receipts.md) - what to return after execution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "1.2.1"
+version = "1.2.2"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -145,6 +145,11 @@ then calls the ACTION endpoint with the same token as `commit_token`. If payment
 fails, the ACTION call is never made. Use the default `"post"` timing only for
 read-only or reversible usage.
 
+After live or sandbox execution, inspect receipts with `siglume dev tail`,
+`siglume dev tail --listing-id <listing_id>`, or the SDK receipt helpers. The
+publisher listing view is privacy-redacted. See
+[`../docs/developer-observability.md`](../docs/developer-observability.md).
+
 Company-name publishing is founder-only in the Phase 2 MVP. Use
 `publisher_type: "company"` with `company_id` in `app_manifest.yaml`, or pass
 `--company <company_id>` to the CLI. Paid company listings require the

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "1.2.1";
+export const SDK_VERSION = "1.2.2";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "1.2.1"
+SDK_VERSION = "1.2.2"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -100,7 +100,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "1.2.1"
+    assert python_version == "1.2.2"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -115,7 +115,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.2.1 (beta)**" in readme
+    assert "This is **v1.2.2 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security
@@ -236,6 +236,10 @@ def test_payment_docs_match_current_polygon_settlement_language() -> None:
     assert "bank account or wallet address" not in docs
     assert "Wallet at `/owner/credits/payout`" in docs
     assert "external payout wallets are not supported" in docs
+    assert "platform is transitioning to\n> on-chain embedded-wallet settlement" not in docs
+    assert "pricing is USD. Convert" not in docs
+    assert "currency=\"JPY\"" in docs
+    assert "settle in JPYC" in docs
 
 
 def test_pricing_docs_match_live_operation_billing_contract() -> None:
@@ -270,3 +274,42 @@ def test_pricing_docs_match_live_operation_billing_contract() -> None:
     assert "does not automatically refund a confirmed payment" in normalized_docs
     assert "Do not describe a `usage_based` or `per_action` listing as free just because" in docs
     assert schema["properties"]["billing_timing"]["enum"] == ["post", "prepay"]
+
+
+def test_developer_observability_docs_explain_logs_receipts_and_privacy() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("docs/developer-observability.md"),
+            _read("docs/pricing-and-billing.md"),
+            _read("docs/execution-receipts.md"),
+            _read("docs/installed-tools-operations.md"),
+            _read("docs/metering.md"),
+            _read("docs/publish-flow.md"),
+            _read("siglume-api-sdk-ts/README.md"),
+        ]
+    )
+    cli = _read("siglume_api_sdk/cli/commands/dev_cmd.py")
+    client = _read("siglume_api_sdk/client.py")
+    ts_client = _read("siglume-api-sdk-ts/src/client.ts")
+
+    assert "docs/developer-observability.md" in docs
+    assert "siglume dev tail" in docs
+    assert "siglume dev tail --listing-id" in docs
+    assert "--follow" in docs
+    assert "list_execution_receipts" in docs
+    assert "list_listing_recent_receipts" in docs
+    assert "list_installed_tool_receipts" in docs
+    assert "get_installed_tool_receipt_steps" in docs
+    assert "trace_id" in docs
+    assert "request_id" in docs
+    assert "privacy-redacted" in docs
+    assert "buyer prompts" in docs
+    assert "Receipts are evidence, not a second pricing system." in docs
+
+    assert "def tail" in cli
+    assert "--listing-id" in cli
+    assert "def list_execution_receipts" in client
+    assert "def list_listing_recent_receipts" in client
+    assert "list_installed_tool_receipts" in ts_client


### PR DESCRIPTION
## Summary
- add Developer Observability as the canonical guide for siglume dev tail, listing receipts, installed-tool receipts, and privacy boundaries
- cross-link receipt/log inspection from pricing, metering, publish flow, Getting Started, README, TS README, and receipt docs
- bump Python/TypeScript SDK docs release metadata to v1.2.2 and remove stale jurisdiction/payment-stack wording

## Verification
- py -3.11 -m pytest tests/test_docs_contract.py
- py -3.11 -m pytest tests/test_dev_cli.py tests/test_client.py
- npm ci
- npm run build
- npm exec vitest run

Note: npm test runs all 353 TS tests successfully but exits non-zero because the existing branch coverage threshold is 73% and current coverage is 72.12%.