### PR TITLE
[codex] docs: add existing product diagnosis prompt

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -62,6 +62,11 @@ Give Codex, Claude Code, or another coding agent this repo, your API idea, and
 [docs/coding-agent-guide.md](docs/coding-agent-guide.md). Ask it to start with a
 free, read-only API and to make the local loop pass before using any API keys.
 
+If you already have a product, open that product repository in the coding agent
+and ask it to diagnose publishability using
+[the existing product diagnosis prompt](docs/coding-agent-guide.md#existing-product-diagnosis-prompt).
+The agent needs both this SDK and your product source.
+
 ```text
 Build a Siglume API Store project from my idea.
 Start as FREE and READ_ONLY.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ You do not need to design the whole API by yourself. The recommended beginner
 path is to use Codex, Claude Code, or another coding agent to turn a plain
 language idea into a Siglume API project.
 
+Already have a product? Open that product repository in your coding agent, give
+it this SDK URL, and ask whether the product can become a Siglume Agent API. The
+agent needs both this SDK and your product source; the SDK URL alone is not
+enough. Use the [existing product diagnosis prompt](#existing-product-diagnosis-prompt)
+below.
+
 Start with a **free, read-only API**. Avoid OAuth, posting, wallet actions,
 payments, and other side effects until your first API is published.
 
@@ -166,6 +172,44 @@ TypeScript variant: ask the coding agent to create `adapter.ts`,
 `tool_manual.json`, package scripts, and local tests using `@siglume/api-sdk`,
 while keeping the same FREE, READ_ONLY, no-OAuth, no-payment first-version
 constraints.
+
+### Existing product diagnosis prompt
+
+Open your existing product repository in Codex, Claude Code, Cursor, or another
+coding agent, then paste this prompt:
+
+```text
+Diagnose whether the currently open product can be published as a Siglume Agent
+API Store listing.
+
+Siglume SDK:
+https://github.com/taihei-05/siglume-api-sdk
+
+Read the SDK README.md, GETTING_STARTED.md, docs/coding-agent-guide.md,
+docs/platform-api-boundary.md, and docs/publish-flow.md.
+
+Inspect this product's features, inputs, outputs, external dependencies,
+authentication, side effects, and resale or terms-of-service risks.
+
+Classify the product as one of:
+- publishable as-is
+- publishable with small changes
+- needs major changes
+- not a good fit
+
+If it is a fit, design the smallest Siglume version. Start as FREE, READ_ONLY,
+no OAuth, no payment, and no external side effects unless I explicitly approve
+otherwise. Create or propose adapter.py or adapter.ts, tool_manual.json, a local
+README, and useful local tests.
+
+Aim to make this pass before asking for API keys or production credentials:
+siglume test .
+siglume score . --offline
+
+Do not run plain siglume register ., change production systems, issue API keys,
+set pricing, or publish anything unless I explicitly approve. End with the
+human decisions still needed.
+```
 
 ---
 

--- a/docs/coding-agent-guide.md
+++ b/docs/coding-agent-guide.md
@@ -21,6 +21,43 @@ Good first API constraints:
 Avoid `ACTION`, `PAYMENT`, OAuth, and subscription pricing until the first API
 passes the local loop and the human understands the publish flow.
 
+## Existing product diagnosis mode
+
+Use this mode when the human has an existing product repository and asks whether
+it can be published as a Siglume Agent API Store listing.
+
+The coding agent must read both:
+
+- this SDK repository
+- the existing product repository currently open in the workspace
+
+The SDK repository alone is not enough to judge publishability.
+
+First inspect the product:
+
+- core features and the smallest useful API surface
+- inputs, outputs, and error cases
+- external services, quotas, and terms-of-service or resale constraints
+- authentication and secret handling
+- side effects such as posting, sending, deleting, purchasing, or changing data
+- whether a first version can be free, read-only, and no-OAuth
+
+Classify the result as exactly one of:
+
+- publishable as-is
+- publishable with small changes
+- needs major changes
+- not a good fit
+
+Then explain the reason in plain language. If the product is a fit, design the
+smallest Siglume version before implementing anything complex. Prefer a
+read-only query, analysis, conversion, summary, lookup, validation, or preview
+operation over write actions.
+
+Do not run plain `siglume register .`, create production credentials, change
+pricing, modify external production systems, or publish the listing unless the
+human explicitly approves.
+
 If the human explicitly asks for paid pricing, read
 `docs/pricing-and-billing.md` and `docs/platform-api-boundary.md` first. Treat
 the live choices as:
@@ -179,4 +216,41 @@ siglume register . --draft-only
 
 Do not run plain siglume register . unless I explicitly approve immediate
 publish.
+```
+
+## Existing product diagnosis prompt
+
+The human can paste this into a coding agent with their product repository open:
+
+```text
+Diagnose whether the currently open product can be published as a Siglume Agent
+API Store listing.
+
+Siglume SDK:
+https://github.com/taihei-05/siglume-api-sdk
+
+Read the SDK README.md, GETTING_STARTED.md, docs/coding-agent-guide.md,
+docs/platform-api-boundary.md, and docs/publish-flow.md.
+
+Inspect this product's features, inputs, outputs, external dependencies,
+authentication, side effects, and resale or terms-of-service risks.
+
+Classify the product as one of:
+- publishable as-is
+- publishable with small changes
+- needs major changes
+- not a good fit
+
+If it is a fit, design the smallest Siglume version. Start as FREE, READ_ONLY,
+no OAuth, no payment, and no external side effects unless I explicitly approve
+otherwise. Create or propose adapter.py or adapter.ts, tool_manual.json, a local
+README, and useful local tests.
+
+Aim to make this pass before asking for API keys or production credentials:
+siglume test .
+siglume score . --offline
+
+Do not run plain siglume register ., change production systems, issue API keys,
+set pricing, or publish anything unless I explicitly approve. End with the
+human decisions still needed.
 ```


### PR DESCRIPTION
## What changed

- Added an existing-product diagnosis path to the README.
- Added a copy-paste diagnosis prompt for coding agents.
- Documented the diagnosis mode and safety boundaries in `docs/coding-agent-guide.md`.
- Linked the prompt from `GETTING_STARTED.md`.

## Why

The SDK already supports an agent-first build flow, but the public docs were framed around starting from a new API idea. This adds a clearer path for developers who already have a product and want a coding agent to judge whether it can become a Siglume Agent API Store listing.

## Validation

- `git diff --check -- README.md GETTING_STARTED.md docs/coding-agent-guide.md`
- `pytest tests/test_docs_contract.py`