### PR TITLE
Release API SDK 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-06-23
+
+### Removed
+
+- Removed the retired job-fulfillment extension from the public Python and
+  TypeScript SDK packages, including dedicated helper modules, examples, docs,
+  generated types, and wrapper tests.
+
+### Changed
+
+- Updated public settlement and input-form documentation so the SDK package
+  describes only the currently supported API Store, MCP Router, metering,
+  webhook, and Direct Request Payment surfaces.
+
 ## [2.0.0] - 2026-06-10
 
 ### Removed

--- a/RELEASE_NOTES_v2.0.1.md
+++ b/RELEASE_NOTES_v2.0.1.md
@@ -1,0 +1,18 @@
+# v2.0.1 — retired surface cleanup
+
+This patch release removes the retired job-fulfillment extension from the
+public SDK distribution.
+
+## Highlights
+
+- Removed the dedicated Python helper module and TypeScript generated type file
+  for the retired extension.
+- Removed obsolete examples, docs, and wrapper tests for that retired surface.
+- Kept the supported API Store, MCP Router, metering, webhook, and Direct
+  Request Payment SDK surfaces unchanged.
+
+## Upgrade Notes
+
+Applications that use the current API Store or MCP Router SDK paths do not need
+code changes. If a project still imports the retired extension module, delete
+that integration before upgrading.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "2.0.0"
+version = "2.0.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "2.0.0";
+export const SDK_VERSION = "2.0.1";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "2.0.0"
+SDK_VERSION = "2.0.1"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -102,7 +102,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "2.0.0"
+    assert python_version == "2.0.1"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
Prepares the 2.0.1 patch release so npm/PyPI packages pick up the retired surface cleanup already merged to main.\n\nLocal verification:\n- py -3 -m pytest tests -q\n- npm run typecheck (siglume-api-sdk-ts)\n- npm test (siglume-api-sdk-ts)\n- residual retired-surface grep: no matches