### PR TITLE
docs: correct "how your API gets selected" to match the live execution model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"How your API actually gets selected" now matches the live execution model.**
+  The section previously stated that whenever a buyer's agent receives a request,
+  the platform decides whether to call your API by running a server-side
+  `installed_tool_prefilter → tool_selector → orchestrate → provider_adapters →
+  capability_failure_learning` pipeline. That describes Siglume's own tool-use
+  runtime, **not** the primary MCP connector path: when a buyer connects their own
+  AI over MCP, that AI selects the tool from your Tool Manual and Siglume only
+  resolves + dispatches it — the keyword selector and orchestration loop do not
+  run. The README now splits **Path 1 (MCP — the buyer's AI selects)** from
+  **Path 2 (Siglume's own runtime / `siglume dev simulate`, where the open-core
+  pipeline runs)**, clarifies that `installed_tool_prefilter` is a prompt-budget
+  helper rather than an always-on runtime gate, and reframes the reading list and
+  the "improve these fields" guidance accordingly. `GETTING_STARTED.md` gains the
+  same Path 1 / Path 2 caveat on the `dev_simulator` callout. The open-core
+  provenance, the publish-gate scorer, and the dry-run simulator's mechanics are
+  unchanged — those were and remain accurate. No SDK behaviour change.
+
 ## [2.0.1] - 2026-06-23
 
 ### Removed

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1861,7 +1861,9 @@ Your tool manual is automatically scored 0-100 with a letter grade:
 
 > **Score locally before you submit.** The same A–F scorer is published as open source: [`siglume-agent-core.tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01). Install with `pip install siglume-agent-core` and call `score_manual_quality(my_manual)` to get the same grade you'll see at registration time, without burning a CLI/API key or hitting the platform.
 
-> **Want to know whether the planner would even pick your API once published?** [`siglume-agent-core.dev_simulator`](https://github.com/taihei-05/siglume-agent-core#7-dev_simulator-v07) runs the same selection pipeline (top-N catalog → keyword pre-filter → single `tool_choice="auto"` turn) against the live catalog and returns the predicted tool chain — without executing any of it. Pair it with `score_manual_quality` to validate **both** "will I pass the publish gate?" and "will I get picked once published?" before submission.
+> **Want to know whether the planner would even pick your API once published?** [`siglume-agent-core.dev_simulator`](https://github.com/taihei-05/siglume-agent-core#7-dev_simulator-v07) runs the `tool_selector` selection pipeline (top-N catalog → keyword pre-filter → single `tool_choice="auto"` turn) against the live catalog and returns the predicted tool chain — without executing any of it. Pair it with `score_manual_quality` to validate **both** "will I pass the publish gate?" and "will I get picked once published?" before submission.
+>
+> This models **Siglume's own server-side runtime (Path 2)**. When a buyer connects their AI over MCP — the primary path today — *their* AI selects the tool from your Tool Manual and Siglume only resolves + dispatches it, so the keyword pipeline never runs. The simulator is still a good proxy for "is my Tool Manual concrete enough to be chosen," but treat it as guidance, not a guarantee. See [How your API actually gets selected](README.md#how-your-api-actually-gets-selected--and-whats-open-source) for the two-path breakdown.
 
 ### What gets penalized
 

--- a/README.md
+++ b/README.md
@@ -472,9 +472,13 @@ required fields, scoring rules, and examples.
 
 ---
 
-## How your API actually gets selected — the algorithm is public
+## How your API actually gets selected — and what's open source
 
-When a buyer's agent receives a request, the platform decides whether to call your API by running the API Store tool-selection pipeline below. Every stage is open source — same code that runs on `siglume.com`, byte-for-byte, available as the AGPL-licensed [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) PyPI package. (This SDK itself is MIT-licensed; the OSS claim is about agent-core, not about the SDK code in *this* repo.) Throughout the section below, "the planner" is the same thing the SDK's CLI output calls "the orchestrator" — different words, same component.
+Once your API is published, **the decision to call it is made by the buyer's agent, not by Siglume.** *How* that decision is reached depends on how the buyer's agent is connected to the store — and there are two paths today that select tools differently:
+
+**Path 1 — MCP connectors (Claude and other MCP clients), the primary path today.** The buyer points their own AI at Siglume over MCP. Siglume lists your tool to that AI whenever it is installed for the agent, the publisher OAuth is healthy (`account_readiness = ready`), and it is not a `payment`-class or high-risk (`double_confirm`) capability. From there, **the buyer's own AI reads your Tool Manual and decides which tool to call.** Siglume resolves the named tool and dispatches it to your `invoke_url` — it does **not** re-rank your tool with its own keyword selector, and it does **not** run an LLM tool-use loop on your behalf. On this path the keyword pipeline below does not run; your only lever is the Tool Manual.
+
+**Path 2 — Siglume's own server-side tool-use runtime.** The pipeline in the box below is the open-core logic Siglume's first-party runtime imports, and it is exactly what the `siglume dev simulate` dry run executes against the live catalog. Every decision stage is open source — the same code the platform imports from the AGPL-licensed [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) PyPI package. (This SDK itself is MIT-licensed; the OSS claim is about agent-core, not about the SDK code in *this* repo.) Throughout this section, "the planner" / "the orchestrator" refer to this server-side runtime.
 
 ```
    You publish via siglume-api-sdk  ──►  Buyer agent installs your API
@@ -489,7 +493,7 @@ When a buyer's agent receives a request, the platform decides whether to call yo
                                                     │
                                                     ▼
    ┌──────────────────────────────────────────────────────────┐
-   │ Runtime (a buyer's agent receives a request)             │
+   │ Path 2 only - Siglume's own runtime selects              │
    │  1. installed_tool_prefilter — TF-IDF top-N from the     │  agent-core v0.2
    │     agent's installed pool                               │
    │  2. tool_selector            — keyword score + permission│  agent-core v0.3
@@ -503,12 +507,16 @@ When a buyer's agent receives a request, the platform decides whether to call yo
    └──────────────────────────────────────────────────────────┘
 ```
 
+> **Which path is your buyer on?** If they connect through an MCP client — the common case for Claude users today — it is **Path 1**: their own AI reads your Tool Manual and decides, and Siglume only lists the tool and dispatches the call. The keyword pipeline in the box above runs only on **Path 2** (Siglume's own runtime and the `siglume dev simulate` dry run). `installed_tool_prefilter` in particular is a prompt-budget helper for that path's prompt build, not a gate that runs on every request. Net: the dry run is a good proxy for "is my Tool Manual concrete enough to be chosen," but a live MCP buyer's AI may weigh it differently — treat the simulator as guidance, not a guarantee.
+
 ### Reading list by question
+
+These modules govern **Path 2** (Siglume's own runtime) and the pre-publish tools. On **Path 1** (MCP) there is no Siglume-side selection function to read — the buyer's AI picks from your Tool Manual, so manual quality is the lever, not a platform scorer.
 
 | If you want to know… | Read this in agent-core |
 |---|---|
 | Why my Tool Manual was graded A / B / C / D / F | [`tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01) |
-| Why my published API was / wasn't picked for a request | [`tool_selector`](https://github.com/taihei-05/siglume-agent-core#4-tool_selector-v03) — `select_tools()` is THE selection function |
+| Why my published API was / wasn't picked **when Siglume's own runtime ran the loop (Path 2)** | [`tool_selector`](https://github.com/taihei-05/siglume-agent-core#4-tool_selector-v03) — `select_tools()` is THE selection function on that path |
 | What happens when an agent has too many installed tools to fit in the prompt | [`installed_tool_prefilter`](https://github.com/taihei-05/siglume-agent-core#3-installed_tool_prefilter-v02) |
 | What rules govern "tool got blocked after a recent failure" | [`capability_failure_learning`](https://github.com/taihei-05/siglume-agent-core#5-capability_failure_learning-v04) |
 | How the LLM tool-use loop runs end-to-end | [`orchestrate`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) |
@@ -581,10 +589,10 @@ for call in result.predicted_chain:
 
 If the planner picks your API for the offers your target buyers would write, you're publish-ready. If not, improve the Tool Manual fields the selection pipeline actually reads:
 
-- `tool_selector` runs a keyword-based hard filter (stage 2 in the diagram above) over your `capability_key`, `display_name`, `description`, and `usage_hints`. If none of those overlap the buyer's request, the LLM never even sees your API as a candidate. Make these four fields concrete and request-shaped.
+- `tool_selector` runs a keyword-based hard filter (the `tool_selector` step above, Path 2) over your `capability_key`, `display_name`, `description`, and `usage_hints`. If none of those overlap the buyer's request, the LLM never even sees your API as a candidate. Make these four fields concrete and request-shaped.
 - Once your API *is* in the candidate set, the LLM reads a short tool-description string while picking between candidates. That string is sourced from your manual via the fallback chain `tool_prompt_compact` → `compact_prompt` → `description` → `summary_for_model` → listing description / title / `capability_key`. In practice the LLM almost always sees `tool_prompt_compact` (or `compact_prompt`), so polish that field first; `summary_for_model` and the others are only fallbacks if the earlier sources are empty. `trigger_conditions` is captured in the schema for the publish gate's quality check but is not threaded into the LLM-visible tool description today — keep it accurate, but don't expect it to move the planner directly.
 
-This pipeline is the substrate behind both the [Acceptance bar](#acceptance-bar) (the scorer at stage "pre-publish") and the [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed) reality (stages 1–5 at runtime). The acceptance bar tells you whether you can list; the runtime pipeline decides whether you actually get *picked* once listed.
+These same Tool Manual fields feed both gates that matter to you: the [Acceptance bar](#acceptance-bar) (the pre-publish scorer that decides whether you can *list*) and the selection step that decides whether you actually get *picked* once listed — your buyer's own AI on Path 1, or `tool_selector` on Path 2. Polishing them is the one lever that helps on every path, so do it before you worry about anything else. (See also [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed).)
 
 ---
 


### PR DESCRIPTION
## Problem

The README section **"How your API actually gets selected — the algorithm is public"** told publishers that, whenever a buyer's agent receives a request, *the platform* runs a 5-stage server-side pipeline (`installed_tool_prefilter → tool_selector → orchestrate → provider_adapters → capability_failure_learning`) to decide whether to call your API.

That describes Siglume's **internal** tool-use runtime — not the primary way buyers reach an API today (MCP). On the MCP path the buyer's own AI selects the tool from your Tool Manual and the platform only resolves + dispatches it; the keyword selector and the orchestration loop do not run.

## Change (docs only)

- Rewrite the section as **two paths**: Path 1 (MCP — the buyer's AI selects, primary today) vs Path 2 (Siglume's own runtime / `siglume dev simulate` — the open-core pipeline runs).
- Relabel the diagram's second box "Path 2 only".
- Demote `installed_tool_prefilter` to a prompt-budget helper; scope the reading list + dev-simulator guidance to Path 2.
- Add the same Path 1/Path 2 caveat to `GETTING_STARTED.md`'s `dev_simulator` callout.
- `CHANGELOG.md` `[Unreleased]` entry.

The open-core provenance, the publish-gate scorer, and the simulator's mechanics are unchanged — those were and remain accurate. **No SDK behaviour change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)