### PR TITLE
release 2.0.2 — ToolManual.supports + discovery exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-06-25
+
+### Added
+
+- **`ToolManual.supports`** — an optional structured capability-flags dict
+  (e.g. `{"reply_thread": false, "scheduled_one_time": true, "images_max": 4}`).
+  It is serialized into the published tool manual and surfaced verbatim on the
+  Siglume API Store discovery responses (`market_get_capability`), so a calling
+  agent can judge what a capability can and cannot do **before** binding it,
+  instead of inferring from human-facing marketing copy. Read forward-compatibly
+  (defaults to `{}`); existing manuals are unaffected.
+
 ### Fixed
 
 - **"How your API actually gets selected" now matches the live execution model.**

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -2915,6 +2915,8 @@ components:
         error_hints: { type: array, items: { type: string } }
         supports:
           type: object
+          additionalProperties:
+            type: [boolean, number, string]
           description: >-
             Optional structured capability flags (flat boolean/number/string
             values, e.g. { reply_thread: false, scheduled_one_time: true,

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -2913,6 +2913,14 @@ components:
         usage_hints: { type: array, items: { type: string } }
         result_hints: { type: array, items: { type: string } }
         error_hints: { type: array, items: { type: string } }
+        supports:
+          type: object
+          description: >-
+            Optional structured capability flags (flat boolean/number/string
+            values, e.g. { reply_thread: false, scheduled_one_time: true,
+            images_max: 4 }) surfaced verbatim on the API Store discovery
+            responses so an agent can judge what a capability can/can't do
+            before binding it.
         # Conditional: required for action / payment
         approval_summary_template: { type: string, minLength: 1 }
         preview_schema: { type: object }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "2.0.1"
+version = "2.0.2"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/schemas/tool-manual.schema.json
+++ b/schemas/tool-manual.schema.json
@@ -123,6 +123,10 @@
       "items": { "type": "string" },
       "description": "Guidance for the LLM on handling errors."
     },
+    "supports": {
+      "type": "object",
+      "description": "Optional structured capability flags (flat bool/int/string values, e.g. {\"reply_thread\": false, \"scheduled_one_time\": true, \"images_max\": 4}) surfaced verbatim on the discovery surface (market_get_capability) so an agent can judge fit before binding."
+    },
     "approval_summary_template": {
       "type": "string",
       "minLength": 1,

--- a/schemas/tool-manual.schema.json
+++ b/schemas/tool-manual.schema.json
@@ -125,6 +125,7 @@
     },
     "supports": {
       "type": "object",
+      "additionalProperties": { "type": ["boolean", "number", "string"] },
       "description": "Optional structured capability flags (flat bool/int/string values, e.g. {\"reply_thread\": false, \"scheduled_one_time\": true, \"images_max\": 4}) surfaced verbatim on the discovery surface (market_get_capability) so an agent can judge fit before binding."
     },
     "approval_summary_template": {

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/tool-manual-assist.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-assist.ts
@@ -28,6 +28,7 @@ const ALL_TOOL_MANUAL_FIELDS = [
   "refund_or_cancellation_note",
   "jurisdiction",
   "legal_notes",
+  "supports",
 ] as const;
 const BASE_REQUIRED_FIELDS = [
   "tool_name",
@@ -700,6 +701,7 @@ function buildToolManualSchema(
     refund_or_cancellation_note: { type: "string" },
     jurisdiction: { type: "string" },
     legal_notes: { type: "string" },
+    supports: { type: "object" },
   };
   const selectedFields = [...new Set(fields)];
   let required = [...selectedFields];

--- a/siglume-api-sdk-ts/src/tool-manual-assist.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-assist.ts
@@ -701,7 +701,7 @@ function buildToolManualSchema(
     refund_or_cancellation_note: { type: "string" },
     jurisdiction: { type: "string" },
     legal_notes: { type: "string" },
-    supports: { type: "object" },
+    supports: { type: "object", additionalProperties: { type: ["boolean", "number", "string"] } },
   };
   const selectedFields = [...new Set(fields)];
   let required = [...selectedFields];

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -248,6 +248,13 @@ export interface ToolManual {
   usage_hints: string[];
   result_hints: string[];
   error_hints: string[];
+  /**
+   * Optional structured capability flags (flat boolean/number/string values,
+   * e.g. `{ reply_thread: false, scheduled_one_time: true, images_max: 4 }`)
+   * surfaced verbatim on the API Store discovery responses so an agent can
+   * judge what a capability can/can't do before binding it.
+   */
+  supports?: Record<string, boolean | number | string>;
   approval_summary_template?: string;
   preview_schema?: Record<string, unknown>;
   idempotency_support?: boolean;

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "2.0.1";
+export const SDK_VERSION = "2.0.2";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume-api-sdk-ts/test/recorder.test.ts
+++ b/siglume-api-sdk-ts/test/recorder.test.ts
@@ -91,6 +91,7 @@ function buildToolManual() {
     usage_hints: ["Use this tool after the owner has named a product and wants evidence-backed price comparison."],
     result_hints: ["Lead with the best offer and then summarize notable trade-offs."],
     error_hints: ["If no offers are found, ask for a clearer product name or model number."],
+    supports: {},
   };
 }
 

--- a/siglume-api-types.ts
+++ b/siglume-api-types.ts
@@ -192,6 +192,11 @@ export interface ToolManual {
   usage_hints: string[];
   result_hints: string[];
   error_hints: string[];
+  // Optional structured capability flags (flat boolean/number/string values,
+  // e.g. { reply_thread: false, scheduled_one_time: true, images_max: 4 })
+  // surfaced verbatim on the API Store discovery responses so an agent can judge
+  // what a capability can/can't do before binding it.
+  supports?: Record<string, boolean | number | string>;
 
   // Required for action / payment
   approval_summary_template?: string;

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -647,6 +647,13 @@ class ToolManual:
     usage_hints: list[str] = field(default_factory=list)
     result_hints: list[str] = field(default_factory=list)
     error_hints: list[str] = field(default_factory=list)
+    # Optional structured capability flags an agent can read to judge fit BEFORE
+    # binding, e.g. {"reply_thread": False, "scheduled_one_time": True,
+    # "unattended_autopay": True, "images_max": 4}. Surfaced verbatim on the
+    # discovery surface (market_get_capability) so agents stop mis-judging what a
+    # capability can/can't do. Keep values flat (bool/int/str); express anything
+    # richer in usage_hints / do_not_use_when prose.
+    supports: dict[str, Any] = field(default_factory=dict)
 
     # ── Required for action / payment ──
     approval_summary_template: str | None = None
@@ -682,6 +689,7 @@ class ToolManual:
             "usage_hints": self.usage_hints,
             "result_hints": self.result_hints,
             "error_hints": self.error_hints,
+            "supports": self.supports,
         }
         if self.permission_class in (
             ToolManualPermissionClass.ACTION,

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -647,13 +647,6 @@ class ToolManual:
     usage_hints: list[str] = field(default_factory=list)
     result_hints: list[str] = field(default_factory=list)
     error_hints: list[str] = field(default_factory=list)
-    # Optional structured capability flags an agent can read to judge fit BEFORE
-    # binding, e.g. {"reply_thread": False, "scheduled_one_time": True,
-    # "unattended_autopay": True, "images_max": 4}. Surfaced verbatim on the
-    # discovery surface (market_get_capability) so agents stop mis-judging what a
-    # capability can/can't do. Keep values flat (bool/int/str); express anything
-    # richer in usage_hints / do_not_use_when prose.
-    supports: dict[str, Any] = field(default_factory=dict)
 
     # ── Required for action / payment ──
     approval_summary_template: str | None = None
@@ -672,6 +665,17 @@ class ToolManual:
     # AppManifest.jurisdiction. ISO 3166-1 alpha-2 (optionally -subregion).
     jurisdiction: str | None = None
     legal_notes: str | None = None                       # optional, surfaced on approval prompt
+
+    # Declared LAST so the dataclass __init__ positional order of every
+    # pre-existing field is preserved — a patch release must not shift positional
+    # args (an action/payment caller passing approval_summary_template
+    # positionally must not land in `supports`). Optional structured capability
+    # flags an agent reads to judge fit BEFORE binding, e.g.
+    # {"reply_thread": False, "scheduled_one_time": True, "images_max": 4}.
+    # Surfaced verbatim on the discovery surface (market_get_capability). Keep
+    # values flat (bool/int/str); express anything richer in usage_hints /
+    # do_not_use_when prose.
+    supports: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the dict format expected by the platform API."""

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "2.0.1"
+SDK_VERSION = "2.0.2"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/siglume_api_sdk/tool_manual_assist.py
+++ b/siglume_api_sdk/tool_manual_assist.py
@@ -41,6 +41,7 @@ _ALL_TOOL_MANUAL_FIELDS = (
     "refund_or_cancellation_note",
     "jurisdiction",
     "legal_notes",
+    "supports",
 )
 _BASE_REQUIRED_FIELDS = (
     "tool_name",
@@ -694,6 +695,7 @@ def _build_tool_manual_schema(*, permission_class: str | None, fields: Sequence[
         "refund_or_cancellation_note": {"type": "string"},
         "jurisdiction": {"type": "string"},
         "legal_notes": {"type": "string"},
+        "supports": {"type": "object"},
     }
     selected_fields = list(dict.fromkeys(field for field in fields if field in properties))
     required = list(selected_fields)

--- a/siglume_api_sdk/tool_manual_assist.py
+++ b/siglume_api_sdk/tool_manual_assist.py
@@ -695,7 +695,7 @@ def _build_tool_manual_schema(*, permission_class: str | None, fields: Sequence[
         "refund_or_cancellation_note": {"type": "string"},
         "jurisdiction": {"type": "string"},
         "legal_notes": {"type": "string"},
-        "supports": {"type": "object"},
+        "supports": {"type": "object", "additionalProperties": {"type": ["boolean", "number", "string"]}},
     }
     selected_fields = list(dict.fromkeys(field for field in fields if field in properties))
     required = list(selected_fields)

--- a/tests/cassettes/auto_register_flow.json
+++ b/tests/cassettes/auto_register_flow.json
@@ -110,6 +110,7 @@
               "Lead with the best offer and then summarize notable trade-offs."
             ],
             "summary_for_model": "Looks up current retailer offers and returns a structured comparison with the best deal first.",
+            "supports": {},
             "tool_name": "price_compare_helper",
             "trigger_conditions": [
               "owner asks to compare prices for a product before deciding where to buy",

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -102,7 +102,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "2.0.1"
+    assert python_version == "2.0.2"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
Sync from the source-of-truth monorepo (`siglume/packages/contracts/sdk`).

**`ToolManual.supports`** — optional structured capability-flags dict (e.g. `{"reply_thread": false, "scheduled_one_time": true, "images_max": 4}`), serialized in `to_dict` and declared in `schemas/tool-manual.schema.json`. Surfaced verbatim on the API Store discovery responses (`market_get_capability`) so an agent can judge what a capability can/can't do **before** binding. Forward-compatible (defaults to `{}`); existing manuals unaffected.

Version bump 2.0.1 → 2.0.2 across all surfaces (pyproject, package.json, package-lock root, version.ts, _version.py, docs-contract test pin); CHANGELOG `[2.0.2]`.

After merge, tag `v2.0.2` to publish PyPI + npm.