### PR TITLE
[codex] docs: fix stale SDK release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.2.2.** Python and TypeScript are version-aligned and
+> **Current release: v2.0.2.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
@@ -68,14 +68,14 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 > platform OAuth broker APIs from the SDK:
 > publisher APIs now own external OAuth, token storage, refresh, revocation,
 > and user-to-token mapping behind their own `connect_url`.
-> See [CHANGELOG.md](./CHANGELOG.md),
+> See [CHANGELOG.md](./CHANGELOG.md) for the complete release history.
+> Historical release notes include
 > [RELEASE_NOTES_v1.2.2.md](./RELEASE_NOTES_v1.2.2.md),
 > [RELEASE_NOTES_v1.2.1.md](./RELEASE_NOTES_v1.2.1.md),
 > [RELEASE_NOTES_v1.2.0.md](./RELEASE_NOTES_v1.2.0.md),
 > [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
 > [RELEASE_NOTES_v1.0.0.md](./RELEASE_NOTES_v1.0.0.md), and
-> [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md) for the current
-> release line.
+> [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md).
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
 > For the current browser-vs-CLI entry points into the same `auto-register`
@@ -852,7 +852,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.2.2 (beta)** — the platform is launched on Polygon mainnet
+This is **v2.0.2 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with paid API Store settlement live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
 The user base is still growing, and new SDK surfaces continue to ship

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -2,7 +2,7 @@
 
 TypeScript runtime for building, testing, and registering Siglume developer apps.
 
-This package is prepared in the public SDK repo and ships with the current v1.2.x release line.
+This package is version-aligned with the Python package in the public SDK repo.
 
 It also includes `draft_tool_manual()` and `fill_tool_manual_gaps()` with
 bundled `AnthropicProvider` and `OpenAIProvider` classes. Provide

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -114,10 +114,13 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
     ts_readme = _read("siglume-api-sdk-ts/README.md")
     security = _read("SECURITY.md")
     normalized_security = " ".join(security.split())
+    python_version = str(tomllib.loads(_read("pyproject.toml"))["project"]["version"])
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.2.2 (beta)**" in readme
+    assert "current v1.2.x release line" not in ts_readme
+    assert f"Current release: v{python_version}" in readme
+    assert f"This is **v{python_version} (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary

- Update README current-release and project-status references from v1.2.2 to v2.0.2.
- Reword historical release-note links so old release notes are not described as the current release line.
- Remove the stale v1.2.x wording from the TypeScript package README.
- Make the docs contract test derive the expected README version from `pyproject.toml`.

## Root Cause

The package metadata and published package versions were already at 2.0.2, but public docs still contained earlier release-line wording.

## Validation

- `python -m pytest tests/test_docs_contract.py -q`