### PR TITLE
sync: v2.0.4 — async two-phase failure/edge completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-06-27
+
+### Changed
+
+- **`docs/async-two-phase-apis.md` — completeness pass on the failure/edge paths.**
+  A completeness audit found the happy path was correct but the failure paths an
+  async API actually hits were missing. Added:
+  - **Idempotent acceptance** — the accept leg must dedupe on the quoted token so a
+    platform retry returns the same `job_id` and never double-charges.
+  - **`get_result` for every state** — `running` (poll again), `succeeded`, `failed`,
+    and unknown/`expired`, all free, with concrete wire shapes.
+  - **Failure after acceptance** — settlement is final on acceptance, the platform does
+    **not** auto-refund, and refund/repair is the publisher's responsibility (declare it
+    in `ToolManual.refund_or_cancellation_note`).
+  - The **full accepted-status set** (`queued`/`accepted`/`processing`/`pending`/
+    `running`/`in_progress`/`deferred`/`scheduled`), the **poll** lifecycle (no
+    completion webhook), `job_id` retention, and the **one-tool-or-two** input-dispatch note.
+- **`examples/async_transcription.py`** now demonstrates idempotent acceptance (same
+  token ⇒ same `job_id`, one charge), the running/succeeded/failed/expired `get_result`
+  states, and a `refund_or_cancellation_note`.
+- Reconciled the remaining synchronous-only "not delivered" prose in `GETTING_STARTED.md`
+  and the `README.md` narrative with the async carve-out, and added `async_transcription.py`
+  to the README example-templates index. Extended the refund boundary in
+  `platform-api-boundary.md` / `pricing-and-billing.md` to the async accept-then-fail case.
+
 ## [2.0.3] - 2026-06-27
 
 ### Added

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -795,7 +795,10 @@ API owns the provider-specific action and the proof that it committed. The
 platform does not infer whether an X post, email, CRM write, booking, or other
 external action happened. Your live action response must return committed
 evidence only after the side effect committed; draft-only, preview, ambiguous,
-or `status="ready"` responses are not delivered results. Read
+or `status="ready"` responses are not delivered results. (A long-running action may
+instead *accept* the job and deliver later — `{accepted: true, job_id, status: "queued"}`
+is an accepted-deferred result, not a non-delivery; see
+[Async / long-running two-phase APIs](docs/async-two-phase-apis.md).) Read
 [Platform / API Responsibility Boundary](docs/platform-api-boundary.md) before
 building paid action APIs.
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,9 @@ product-specific side effect and the provider-specific proof that it committed.
 The platform does not infer whether an X post, email, CRM write, booking, or
 other external action happened. The live action response must return committed
 evidence only after the side effect committed; draft-only, preview, ambiguous,
-or `status="ready"` results are not delivered results. See
+or `status="ready"` results are not delivered results. (A long-running action may
+instead *accept* the job and deliver later via a free `get_result` — see
+[docs/async-two-phase-apis.md](./docs/async-two-phase-apis.md).) See
 [docs/platform-api-boundary.md](./docs/platform-api-boundary.md).
 
 Use `pricing_plan` to show buyer-facing operation prices in API Store and Game
@@ -756,7 +758,7 @@ your payment adapter without touching a live wallet.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `async_transcription.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 | Example | Permission | Runnable e2e | Description |
 |---|---|---|---|
@@ -767,6 +769,7 @@ your payment adapter without touching a live wallet.
 | [email_sender.py](./examples/email_sender.py) | `ACTION` | ✅ | Preview and send email with explicit approval and idempotency hints |
 | [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
 | [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
+| [async_transcription.py](./examples/async_transcription.py) | `ACTION` (prepay / async) | ✅ | Accept a long job (`quote → {accepted, job_id} → free get_result`), settling on acceptance, with idempotent accept + running/failed states |
 | [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
 | [metering_record.py](./examples/metering_record.py) | client | ✅ | Record usage events and preview invoice lines |
 | [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |

--- a/RELEASE_NOTES_v2.0.4.md
+++ b/RELEASE_NOTES_v2.0.4.md
@@ -1,0 +1,37 @@
+# v2.0.4 — async two-phase API docs: failure/edge completeness
+
+Documentation release. A completeness audit of the v2.0.3 async guide found the happy
+path correct but the **failure/edge paths missing** — the parts an async paid API
+actually hits in production. This release closes them so a developer can ship a
+**correct** async API, not just the happy path.
+
+## Highlights
+
+- **Idempotent acceptance.** The accept leg must dedupe on the quoted token: a platform
+  retry returns the **same `job_id`** and never enqueues a second job or double-charges.
+  (The v2.0.3 example accidentally taught a non-idempotent enqueue — now fixed and
+  asserted in the example's `main()`.)
+- **`get_result` for every state.** Documented and demonstrated the **running** (poll
+  again), **succeeded**, **failed**, and unknown/**expired** responses — all free
+  (`amount_minor: 0`, no `billingPreview`) — instead of only the success shape.
+- **Failure after acceptance.** Settlement is **final on acceptance**; if the job fails in
+  your worker the buyer is **already charged** and the platform does **not** auto-refund —
+  refund/repair is the publisher's responsibility. Report the failure via `get_result` and
+  declare your policy in `ToolManual.refund_or_cancellation_note`.
+- **Full accepted-status set.** `queued`, `accepted`, `processing`, `pending`, `running`,
+  `in_progress`, `deferred`, `scheduled` are all accepted-deferred (the real test is
+  `accepted: true` + a `job_id` + a non-terminal `status`).
+- **Polling lifecycle, `job_id` retention, and one-tool-or-two** input dispatch are now
+  spelled out (the agent polls `get_result`; there is no completion webhook).
+- Reconciled the remaining synchronous-only "not delivered" prose in `GETTING_STARTED.md`
+  and the `README.md` narrative with the async carve-out, added `async_transcription.py` to
+  the README example index, and extended the refund boundary in `platform-api-boundary.md`
+  and `pricing-and-billing.md` to the async accept-then-fail case.
+
+## Upgrade Notes
+
+No code changes are required. If you built an async API against v2.0.3, review two things:
+your accept leg must be **idempotent** (dedupe on the commit token), and your `get_result`
+must return a defined response for the **running** and **failed** states — otherwise a
+polling agent cannot distinguish "come back later" from "failed", and a worker failure
+silently keeps the buyer's money with no signal.

--- a/docs/async-two-phase-apis.md
+++ b/docs/async-two-phase-apis.md
@@ -102,16 +102,90 @@ platform reads it as *accepted, deferred* — not as a failure or a non-delivery
 |---|---|---|
 | `accepted` | yes — `true` | the job was admitted and will be worked |
 | `job_id` | yes | stable handle; the buyer's agent passes it back to your terminal op |
-| `status` | yes — `"queued"` (or `processing`/`running`/`pending`) | the job is not yet done |
+| `status` | yes — any non-terminal value (see below) | the job is not yet done |
 
 Set `receipt_summary.operation` to the **chargeable band** and `amount_minor` to the plan
 price — settlement happens on acceptance, because you have committed to doing the work.
+
+**Accepted non-terminal `status` values.** The platform treats any of these as
+accepted-deferred (mirrors the platform's `normalize_api_outcome`): `queued`, `accepted`,
+`processing`, `pending`, `running`, `in_progress`, `deferred`, `scheduled`. Use whichever
+your job system natively emits — they are equivalent. The real test is not the literal
+string but the triple **`accepted: true` + a `job_id` + a non-terminal `status`**.
 
 This is distinct from the non-delivery shapes in
 [Ambiguous results](./platform-api-boundary.md#ambiguous-results): `accepted: false`,
 `success: false`, a draft-only/`status: "ready"` body, or a band/amount that disagrees
 with the quote are **not** accepted. The async carve-out is narrow and explicit:
 `accepted: true` **with** a `job_id` **and** a non-terminal `status` ⇒ accepted-deferred.
+
+## Idempotent acceptance (leg 2 must not double-charge)
+
+Settlement happens on **acceptance**, so the accept leg must be idempotent: the platform
+can retry it (transient timeout, network error), and a naive accept leg would enqueue a
+**second** job and settle a **second** charge. Key the enqueue on the quoted
+`draftToken` / commit token (or the platform idempotency key): if a job already exists for
+that token, return the **same `job_id`** and the **same accepted envelope** verbatim — do
+not enqueue again and do not create a second settlement.
+
+> Rule: one quoted token ⇒ at most one accepted job ⇒ at most one charge. A retried action
+> with the same token is a no-op that re-returns the original `{accepted, job_id, status}`.
+> See [Platform / API boundary → Idempotency](./platform-api-boundary.md#idempotency-expectations).
+
+## Leg 3 states: running, done, failed, expired
+
+`get_result` is **free** (a `0`-priced key, no `billingPreview`) and read-only, so it is
+safe to call **any time and any number of times** after acceptance. For a multi-minute job
+the agent will usually call it **before** the work finishes, so you must define every state
+— not just success. All four are free (`amount_minor: 0`, no `billingPreview`):
+
+```jsonc
+// STILL RUNNING — the agent should poll again later. No artifacts yet.
+{ "success": true, "execution_kind": "action",
+  "output": { "job_id": "job_...", "status": "running", "progress": 0.4 },   // artifacts absent
+  "amount_minor": 0, "receipt_summary": { "operation": "get_result", "amount_minor": 0 } }
+
+// DONE — the real artifacts.
+{ "success": true, "execution_kind": "action",
+  "output": { "job_id": "job_...", "status": "succeeded", "artifacts": [ /* … */ ] },
+  "amount_minor": 0, "receipt_summary": { "operation": "get_result", "amount_minor": 0 } }
+
+// FAILED after acceptance — report failure HERE (still free; do NOT re-charge). See next section.
+{ "success": true, "execution_kind": "action",
+  "output": { "job_id": "job_...", "status": "failed", "error": { "code": "TRANSCODE_FAILED", "message": "…" } },
+  "amount_minor": 0, "receipt_summary": { "operation": "get_result", "amount_minor": 0 } }
+
+// UNKNOWN / EXPIRED job_id — you own retention; re-submission is a NEW paid job.
+{ "success": false, "execution_kind": "action",
+  "output": { "job_id": "job_...", "status": "expired" },
+  "amount_minor": 0, "receipt_summary": { "operation": "get_result", "amount_minor": 0 } }
+```
+
+`job_id` lifetime is **yours** to define — the platform does not retain results. Pick a
+retention window long enough for realistic collection (a long render/report may be fetched
+hours later) and document it. Tell the agent (in `result_hints`) to **poll** `get_result`
+until `status` is terminal; the platform does **not** push a "job finished" event (the
+`execution.*` webhooks fire on the *accept* leg, not on out-of-band worker completion).
+
+## When the job fails after you accepted (and charged)
+
+This is the single most important async-specific obligation. Because the platform settled
+on **acceptance**, a job that fails in your worker leaves the buyer **already charged**, and
+**the platform does NOT automatically refund it** — there is no platform refund/chargeback
+API. The synchronous "failed action ⇒ no charge" intuition does **not** apply here.
+
+So a failed accepted job is **your** responsibility to make right:
+
+- **Report the failure** through the free `get_result` leg (the `status: "failed"` shape
+  above) so the agent and owner can see it. Do not silently strand the job.
+- **Honor your refund/repair policy.** The platform will not reverse the charge for you. If
+  you intend to make the buyer whole, you must do it yourself (e.g. your own credit/reverse
+  payment, or a support-case resolution). Declare that policy up front in your
+  `ToolManual.refund_or_cancellation_note` so buyers know it before they pay.
+- **Prefer to fail at the quote/accept boundary.** Validate inputs, provider readiness, and
+  capacity in the **quote** leg (free) and reject there (`success:false`/`accepted:false`)
+  rather than accepting and charging for work you cannot complete. You only settle when you
+  return `accepted: true`, so accept conservatively.
 
 ## There is no "terminal" or "job" ExecutionKind
 
@@ -126,6 +200,15 @@ without a second charge.
 > Declare every terminal op as a `0`-priced key in `pricing_plan.items` (e.g.
 > `{"key": "get_result", "price_minor": 0}`). A free op that is missing from the plan
 > still runs free, but listing it keeps your plan self-documenting and your receipts valid.
+
+**One tool or two?** A single tool can serve both the enqueue and the `get_result` legs —
+dispatch on your **own input** (e.g. a `job_id` present ⇒ deliver; band params present ⇒
+enqueue), exactly as the worked example does. The platform does **not** route legs for you
+by `execution_kind`; leg selection is entirely your input dispatch, and the buyer's agent
+chooses which call to make from your `ToolManual`. (You may also publish two separate tools
+if you prefer.) Either way, make the `job_id` round-trip and the "result fetch is free"
+fact explicit in `summary_for_model` / `usage_hints` / `result_hints` and the `job_id`
+input description, or agents may never collect the result and the paid job is stranded.
 
 ## Worked example
 
@@ -143,9 +226,12 @@ item, a chargeable `transcribe_0_15` band, and a `0`-priced `get_result`). Its
 2. Buyer approves → platform calls **leg 2 (action)** with the same `draftToken` →
    you start the job and return `{accepted, job_id, status:"queued"}` → platform
    **settles** the charge and records the job as accepted.
-3. Your worker finishes the job out of band.
-4. Agent calls your **free terminal op** (`get_result` with the `job_id`) → **leg 3**
-   returns the artifacts → no charge.
+3. Your worker runs the job out of band. The agent **polls** your free terminal op
+   (`get_result` with the `job_id`) — the platform sends no "finished" event — and gets a
+   `running` response until the work completes. Every poll is free.
+4. When the job finishes, `get_result` returns the artifacts (`status: "succeeded"`) → no
+   charge. If it **failed**, `get_result` returns `status: "failed"` — the buyer was already
+   charged on acceptance, so honor your refund policy (see above).
 
 ## Checklist
 
@@ -157,13 +243,24 @@ Before publishing an async two-phase API, in addition to the
       **equals** a `pricing_plan.items[].key`. (One value, three places.)
 - [ ] The quote-leg `receipt_summary.operation` is `"quote"`/`"dry_run"` with `amount_minor=0` —
       it does **not** carry the chargeable band.
-- [ ] The action leg returns `{accepted: true, job_id, status: "queued"}` (not the finished
-      result) with the chargeable band + price in `receipt_summary`.
-- [ ] `job_id` is stable and is what the terminal op accepts.
+- [ ] The action leg returns `{accepted: true, job_id, <non-terminal status>}` (not the
+      finished result) with the chargeable band + price in `receipt_summary`. Any of
+      `queued`/`accepted`/`processing`/`pending`/`running`/`in_progress`/`deferred`/`scheduled`
+      counts.
+- [ ] **The accept leg is idempotent**: a retry with the same quoted token returns the
+      **same `job_id`** and does **not** enqueue a second job or settle a second charge.
+- [ ] `job_id` is stable, has a documented retention window, and is what the terminal op accepts.
 - [ ] The terminal op (`get_result`/`status`) is a `0`-priced `pricing_plan` key, returns
-      `amount_minor=0`, carries **no** `billingPreview`, and returns the real artifacts.
-- [ ] A genuine failure on any leg returns `success=false` / `accepted=false` — never a
-      silent `status:"queued"` for work you did not accept.
+      `amount_minor=0`, carries **no** `billingPreview`, and is safe to call any time.
+- [ ] `get_result` defines **all** states — `running` (poll again), `succeeded` (artifacts),
+      `failed`, and unknown/`expired` — not just success.
+- [ ] **Failure after acceptance**: you report it via `get_result` and honor your own
+      refund/repair policy (the platform does **not** auto-refund a settled charge); declare
+      that policy in `ToolManual.refund_or_cancellation_note`.
+- [ ] The `ToolManual` makes the `job_id` round-trip + "result fetch is free" explicit so
+      agents collect the result.
+- [ ] A genuine failure on the quote/accept leg returns `success=false` / `accepted=false` —
+      never a silent accepted `status` for work you did not accept.
 
 ## Related
 

--- a/docs/platform-api-boundary.md
+++ b/docs/platform-api-boundary.md
@@ -112,7 +112,11 @@ evidence.
 non-delivery: the platform settles on acceptance and the buyer collects the artifacts via a
 separate **free** terminal op (`get_result`/`status`). This is the *only* affirmative
 "not-yet-delivered" shape — `accepted: false`, `status: "ready"`, and draft/preview bodies
-remain non-deliveries. See [Async / long-running two-phase APIs](./async-two-phase-apis.md).
+remain non-deliveries. Settlement is **final on acceptance**: if the job later fails in your
+worker, the buyer has **already been charged** and the platform does **not** auto-refund —
+refund/repair is the publisher's responsibility (report the failure through `get_result` and
+honor your `ToolManual.refund_or_cancellation_note`). See
+[Async / long-running two-phase APIs](./async-two-phase-apis.md).
 
 ## Idempotency expectations
 

--- a/docs/pricing-and-billing.md
+++ b/docs/pricing-and-billing.md
@@ -192,6 +192,13 @@ provider fails after the paid live action starts. Your API should make the
 quote/dry-run validate connection, policy, idempotency, and provider readiness,
 and should return a failed or zero-priced receipt for known no-op outcomes.
 
+This applies with full force to **async** APIs, where settlement happens on
+**acceptance**: if you return `{accepted: true, job_id}` and the job later fails in your
+worker, the buyer is already charged and the platform does **not** auto-refund — you own
+the refund/repair. Accept conservatively (validate in the free quote leg) and declare your
+policy in `ToolManual.refund_or_cancellation_note`. See
+[Async / long-running two-phase APIs](./async-two-phase-apis.md).
+
 Siglume owns payment, authorization, pricing-plan lookup, idempotency keys,
 slot/retry state, and reconciliation state. Your API owns the external
 side effect and the provider-specific proof that it committed. The platform

--- a/examples/async_transcription.py
+++ b/examples/async_transcription.py
@@ -88,18 +88,38 @@ class AsyncTranscriptionApp(AppAdapter):
         params = ctx.input_params or {}
         job_id = params.get("job_id")
 
-        # LEG 3 — free terminal op: a job_id means "deliver the finished artifacts".
-        # No billingPreview, amount_minor=0, receipt_summary.operation is this op's own name.
+        # LEG 3 — free terminal op (get_result): a job_id means "deliver the result".
+        # Always free (amount_minor=0, no billingPreview); safe to poll any time. It must
+        # report EVERY state — running / succeeded / failed / unknown — not just success.
         if job_id:
-            artifacts = self._load_artifacts(str(job_id))
+            free_receipt = {"operation": "get_result", "amount_minor": 0, "currency": "JPY"}
+            state = self._job_state.get(str(job_id))
+            if state is None:
+                # Unknown / expired job_id. Re-submission would be a NEW paid job.
+                return ExecutionResult(
+                    success=False, execution_kind=ctx.execution_kind,
+                    output={"job_id": job_id, "status": "expired"},
+                    units_consumed=0, amount_minor=0, currency="JPY", receipt_summary=free_receipt,
+                )
+            if state["status"] == "running":
+                # Tell the agent to poll again; no artifacts yet.
+                return ExecutionResult(
+                    success=True, execution_kind=ctx.execution_kind,
+                    output={"job_id": job_id, "status": "running", "progress": state.get("progress", 0.0)},
+                    units_consumed=0, amount_minor=0, currency="JPY", receipt_summary=free_receipt,
+                )
+            if state["status"] == "failed":
+                # Settlement was final on acceptance — report the failure here (still free; do
+                # NOT re-charge) and honor your refund_or_cancellation_note out of band.
+                return ExecutionResult(
+                    success=True, execution_kind=ctx.execution_kind,
+                    output={"job_id": job_id, "status": "failed", "error": state.get("error", {})},
+                    units_consumed=0, amount_minor=0, currency="JPY", receipt_summary=free_receipt,
+                )
             return ExecutionResult(
-                success=True,
-                execution_kind=ctx.execution_kind,
-                output={"job_id": job_id, "status": "succeeded", "artifacts": artifacts},
-                units_consumed=0,
-                amount_minor=0,
-                currency="JPY",
-                receipt_summary={"operation": "get_result", "amount_minor": 0, "currency": "JPY"},
+                success=True, execution_kind=ctx.execution_kind,
+                output={"job_id": job_id, "status": "succeeded", "artifacts": state.get("artifacts", [])},
+                units_consumed=0, amount_minor=0, currency="JPY", receipt_summary=free_receipt,
             )
 
         duration_minutes = float(params.get("duration_minutes") or 12)
@@ -147,19 +167,45 @@ class AsyncTranscriptionApp(AppAdapter):
         return ["transcribe_audio", "get_transcription_result"]
 
     # --- stubs an external dev replaces with real infrastructure ---------------------------
+    def __init__(self) -> None:
+        super().__init__()
+        # Real impl: a durable queue + job store. In-memory here so the example runs.
+        self._jobs_by_token: dict[str, str] = {}   # commit token -> job_id (idempotency)
+        self._job_state: dict[str, dict] = {}       # job_id -> {status, artifacts/error/progress}
+
+    def _commit_token(self, params: dict) -> str:
+        # The platform injects the quoted draftToken as the commit token on the action leg.
+        # Key the enqueue on it so a retry is idempotent. Fall back to a deterministic key.
+        return str(
+            params.get("commit_token")
+            or params.get("draftToken")
+            or self._mint_draft_token(params)
+        )
+
     def _mint_draft_token(self, params: dict) -> str:
-        return "draft_" + str(abs(hash(str(sorted(params.items())))) % (10**12))
+        keyed = {k: v for k, v in params.items() if k not in ("commit_token", "draftToken", "dry_run", "execution_kind")}
+        return "draft_" + str(abs(hash(str(sorted(keyed.items())))) % (10**12))
 
     def _enqueue_job(self, params: dict, band: str) -> str:
-        # Real impl: push to a queue/worker and return a stable id. Stubbed here.
-        return "job_2872b04495de33bbd78cfa77"
+        # IDEMPOTENT: one commit token => at most one job => at most one charge. A retried
+        # action with the same token returns the SAME job_id and does NOT enqueue again.
+        token = self._commit_token(params)
+        existing = self._jobs_by_token.get(token)
+        if existing is not None:
+            return existing
+        job_id = "job_" + token[-24:]
+        self._jobs_by_token[token] = job_id
+        self._job_state[job_id] = {"status": "running", "progress": 0.0, "band": band}
+        # Real impl: push (job_id, params) to your worker queue here.
+        return job_id
 
-    def _load_artifacts(self, job_id: str) -> list[dict]:
-        # Real impl: fetch the finished job's outputs by id. Stubbed here.
-        return [
-            {"type": "transcript", "text": "本日の定例会議を始めます…"},
-            {"type": "srt", "text": "1\n00:00:00,000 --> 00:00:04,000\n本日の定例会議を始めます…\n"},
-        ]
+    # --- worker callbacks (your out-of-band worker calls these as the job progresses) ------
+    def _mark_succeeded(self, job_id: str, artifacts: list[dict]) -> None:
+        self._job_state[job_id] = {"status": "succeeded", "artifacts": artifacts}
+
+    def _mark_failed(self, job_id: str, error: dict) -> None:
+        # The buyer was already charged on acceptance; honor refund_or_cancellation_note.
+        self._job_state[job_id] = {"status": "failed", "error": error}
 
 
 def build_tool_manual() -> ToolManual:
@@ -167,8 +213,9 @@ def build_tool_manual() -> ToolManual:
         tool_name="async_transcription",
         job_to_be_done="Transcribe long audio asynchronously and deliver the transcript when the job completes.",
         summary_for_model=(
-            "Transcribes long audio. The first call accepts the job and returns a job_id (charged per length); "
-            "call again with that job_id to fetch the finished transcript for free."
+            "Transcribes long audio asynchronously. First call accepts the job and returns a job_id "
+            "(charged per length on acceptance). Call again with that job_id for FREE to poll: status=running "
+            "until done, then succeeded with the transcript. Always pass job_id back; result fetch never re-charges."
         ),
         trigger_conditions=[
             "owner wants a transcript of an audio/video file that is too long to transcribe inline",
@@ -195,7 +242,9 @@ def build_tool_manual() -> ToolManual:
             "type": "object",
             "properties": {
                 "summary": {"type": "string", "description": "One-line summary of the job state or transcript."},
-                "status": {"type": "string", "description": "ready (quote) | queued (accepted) | succeeded (result)."},
+                "status": {"type": "string", "description": "ready (quote) | queued (accepted) | running | succeeded | failed | expired."},
+                "error": {"type": "object", "description": "Present when status=failed; the buyer was charged on acceptance, so a refund follows the refund policy."},
+                "progress": {"type": "number", "description": "0..1 progress while status=running."},
                 "accepted": {"type": "boolean", "description": "True when a long job was accepted and queued."},
                 "job_id": {"type": "string", "description": "Stable job handle; pass it back to fetch the transcript."},
                 "artifacts": {"type": "array", "description": "Transcript artifacts, returned by the free get_result call."},
@@ -206,43 +255,80 @@ def build_tool_manual() -> ToolManual:
             "additionalProperties": True,
         },
         usage_hints=[
-            "First call starts the job and returns job_id; it is charged per audio length.",
-            "Then call again with job_id (no audio_url) to fetch the transcript for free.",
+            "First call starts the job and returns job_id; it is charged per audio length, on acceptance.",
+            "Then call again with the same job_id (no audio_url) to poll for free until status=succeeded.",
+            "Retrying the start with the same audio is safe — it returns the same job_id and does not re-charge.",
         ],
         result_hints=[
-            "When status is queued, tell the owner the job was accepted and you will fetch the result with the job_id.",
-            "When artifacts are present, show the transcript; the get_result call is free.",
+            "When status is queued/running, tell the owner the job was accepted and keep polling get_result with the job_id (free).",
+            "When status is succeeded and artifacts are present, show the transcript.",
+            "When status is failed, tell the owner the job failed; they were charged on acceptance and a refund follows the refund policy.",
         ],
-        error_hints=["If a job_id is unknown or expired, ask the owner to re-submit the audio."],
+        error_hints=[
+            "status=expired means the job_id is unknown/aged out; re-submitting the audio is a NEW paid job, so confirm with the owner first.",
+        ],
         approval_summary_template="Transcribe the audio (~{duration_minutes} min) and charge the per-length price.",
         idempotency_support=True,
-        side_effect_summary="Starts an asynchronous transcription job and charges the per-length band on acceptance.",
+        side_effect_summary="Starts an asynchronous transcription job and charges the per-length band on acceptance; the result fetch is free.",
+        refund_or_cancellation_note=(
+            "Charged on acceptance. If a job fails after acceptance, the platform does not auto-refund; "
+            "we issue a credit/refund for the failed run per our support policy. Re-submission is a new paid job."
+        ),
         currency="JPY",
         jurisdiction="JP",
     )
 
 
 async def main() -> None:
-    harness = AppTestHarness(AsyncTranscriptionApp())
+    app = AsyncTranscriptionApp()
+    harness = AppTestHarness(app)
     ok, issues = validate_tool_manual(build_tool_manual())
     print("tool_manual_valid:", ok, len(issues))
     print("manifest_issues:", harness.validate_manifest())
 
+    args = {"audio_url": "https://x/clip.mp3", "duration_minutes": 12}
+
     # Leg 1: quote — the chargeable band must be in output.billingPreview.operation.
-    quote = await harness.execute_quote(task_type="transcribe_audio", input_params={"audio_url": "https://x/clip.mp3", "duration_minutes": 12})
+    quote = await harness.execute_quote(task_type="transcribe_audio", input_params=args)
     band = quote.output["billingPreview"]["operation"]
     print("quote band:", band, "| quote receipt op:", quote.receipt_summary["operation"])
     assert band == "transcribe_0_15" and quote.receipt_summary["operation"] == "quote"
 
     # Leg 2: action — accept the job; receipt op equals the quoted band; charged on acceptance.
-    action = await harness.execute_action(task_type="transcribe_audio", input_params={"audio_url": "https://x/clip.mp3", "duration_minutes": 12})
-    print("action accepted:", action.output["accepted"], "| job_id:", action.output["job_id"], "| action receipt op:", action.receipt_summary["operation"])
+    action = await harness.execute_action(task_type="transcribe_audio", input_params=args)
+    job_id = action.output["job_id"]
+    print("action accepted:", action.output["accepted"], "| job_id:", job_id, "| action receipt op:", action.receipt_summary["operation"])
     assert action.output["status"] == "queued" and action.receipt_summary["operation"] == band
 
-    # Leg 3: get_result — free terminal op, no billingPreview, returns artifacts.
-    result = await harness.execute_action(task_type="get_transcription_result", input_params={"job_id": action.output["job_id"]})
-    print("result op:", result.receipt_summary["operation"], "| amount_minor:", result.amount_minor, "| artifacts:", len(result.output["artifacts"]))
-    assert result.receipt_summary["operation"] == "get_result" and result.amount_minor == 0
+    # Idempotency: a retried action with the same quoted token returns the SAME job_id and
+    # does NOT enqueue a second job or settle a second charge.
+    retry = await harness.execute_action(task_type="transcribe_audio", input_params=args)
+    print("retry job_id == original:", retry.output["job_id"] == job_id, "| jobs enqueued:", len(app._jobs_by_token))
+    assert retry.output["job_id"] == job_id and len(app._jobs_by_token) == 1
+
+    # Leg 3 while STILL RUNNING — free poll, no artifacts yet.
+    running = await harness.execute_action(task_type="get_transcription_result", input_params={"job_id": job_id})
+    print("poll status:", running.output["status"], "| amount_minor:", running.amount_minor)
+    assert running.output["status"] == "running" and running.amount_minor == 0
+
+    # The out-of-band worker finishes the job.
+    app._mark_succeeded(job_id, [{"type": "transcript", "text": "本日の定例会議を始めます…"}])
+
+    # Leg 3 DONE — free, returns artifacts.
+    result = await harness.execute_action(task_type="get_transcription_result", input_params={"job_id": job_id})
+    print("result status:", result.output["status"], "| amount_minor:", result.amount_minor, "| artifacts:", len(result.output["artifacts"]))
+    assert result.output["status"] == "succeeded" and result.receipt_summary["operation"] == "get_result" and result.amount_minor == 0
+
+    # FAILED-after-acceptance path — reported free via get_result (the buyer keeps the charge).
+    app._mark_failed(job_id, {"code": "TRANSCODE_FAILED", "message": "unsupported codec"})
+    failed = await harness.execute_action(task_type="get_transcription_result", input_params={"job_id": job_id})
+    print("failed status:", failed.output["status"], "| amount_minor:", failed.amount_minor)
+    assert failed.output["status"] == "failed" and failed.amount_minor == 0
+
+    # UNKNOWN / expired job_id — free, success=false.
+    expired = await harness.execute_action(task_type="get_transcription_result", input_params={"job_id": "job_unknown"})
+    print("unknown status:", expired.output["status"], "| success:", expired.success, "| amount_minor:", expired.amount_minor)
+    assert expired.output["status"] == "expired" and expired.success is False and expired.amount_minor == 0
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "2.0.3"
+version = "2.0.4"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "2.0.3";
+export const SDK_VERSION = "2.0.4";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "2.0.3"
+SDK_VERSION = "2.0.4"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -102,7 +102,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "2.0.3"
+    assert python_version == "2.0.4"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")


### PR DESCRIPTION
Mirrors `packages/contracts/sdk` from source for **v2.0.4**: idempotent acceptance, `get_result` running/succeeded/failed/expired states, failure-after-acceptance (settlement final on acceptance, publisher owns refund), full accepted-status set, poll lifecycle, one-tool-or-two dispatch. Example updated (idempotency + 4 states). GETTING_STARTED/README/boundary/pricing carve-outs reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)