### PR TITLE
sync: v2.0.5 — documentation freshness pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2026-06-27
+
+### Changed
+
+- **Documentation freshness pass — the SDK now reflects the current (2.0.x) reality.**
+  A full staleness audit found several current-state claims six releases behind:
+  - README "Current release" and "Project status" blocks were frozen at **v1.2.2** and
+    framed v1.0.0's OAuth-broker removal as the headline; both now read **2.0.5** and lead
+    with the 2.0.x line (2.0.0 BREAKING ads/partner removal, 2.0.1 job-fulfillment removal,
+    2.0.2 `ToolManual.supports`, 2.0.3–2.0.5 async two-phase). The release-notes link list
+    now points at the 2.0.x notes.
+  - Removed the documented **Company-name publishing** path (`siglume companies`,
+    `--company`/`--company-slug`, `publisher_type: "company"`/`company_id`) from `README.md`
+    and `GETTING_STARTED.md` — the Company feature is retired platform-side, so the docs no
+    longer present it as a working flow. (The vestigial CLI flags/manifest fields are dead
+    against the platform and are slated for removal in a future major.)
+  - `CONTRIBUTING.md`: corrected "listed after admin review" → the actual self-serve publish
+    (automated checks + fail-closed legal review; **no human admin review**).
+  - `ROADMAP.md`: added the missing 1.x/2.x **Shipped** history and dropped the retired
+    `partner.keys.create` / `admin.source_credentials.issue` surface (removed in 2.0.0) from
+    the external-ingest track.
+  - Fixed a dead `docs/sdk/v0.6-operation-inventory.md` link, a blank line that split the
+    README example-templates table, and annotated `RECOMMENDATION` as a deprecated alias of
+    `READ_ONLY` in the README enum table.
+
 ## [2.0.4] - 2026-06-27
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ Thanks for your interest in contributing!
 ### 1. Publishing your own API to the API Store
 
 This is the most common contribution. You build an API, register it on
-the platform, and it gets listed in the store after admin review.
+the platform, and it goes live in the store immediately once the automated
+self-serve checks pass — there is no human admin review.
 
 **You do NOT submit a PR to this repo to publish an API.**
 
@@ -16,8 +17,8 @@ The registration flow is:
 1. Build your API with `AppAdapter`
 2. Test locally with `AppTestHarness`
 3. Register via `POST /v1/market/capabilities/auto-register`
-4. Confirm with your [tool manual](GETTING_STARTED.md#13-tool-manual-guide) → quality check runs automatically
-5. Admin reviews → published to the API Store
+4. Confirm with your [tool manual](GETTING_STARTED.md#13-tool-manual-guide) → quality checks run automatically
+5. Automated self-serve checks (AppTestHarness, Tool Manual grade, runtime validation, pricing/payout rules, and a fail-closed automated legal review) pass → published to the API Store
 
 See [GETTING_STARTED.md](GETTING_STARTED.md) for the full guide.
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -232,8 +232,6 @@ The manifest is your API's identity card. It controls how your API appears in th
 | `support_contact` | **Required for production registration.** Real support email address or public support URL. Placeholder domains are rejected. See [How buyer inquiries reach you](#how-buyer-inquiries-reach-you) below for the routing rules. | `"support@your-domain.com"` |
 | `seller_homepage_url` | Optional official seller/company homepage, separate from `docs_url`. | `"https://your-domain.com"` |
 | `seller_social_url` | Optional official seller social/profile URL, separate from `docs_url`. | `"https://x.com/your_account"` |
-| `publisher_type` | Optional publishing subject. Omit or use `"user"` for individual publishing; use `"company"` only with `company_id`. | `"user"`, `"company"` |
-| `company_id` | Required when `publisher_type="company"`. Only the company founder can publish under the company name in the Phase 2 MVP. | `"company_123"` |
 | `persistence` | Optional save-state policy. Required only when `store_vertical="game"` and `persistence.mode` is not `"none"`. | `PersistencePolicy(mode="platform", save_data_schema={...})` |
 
 ### Game API Store placement
@@ -533,17 +531,11 @@ siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
 siglume register .                # preflight + auto-register + confirm/publish
 siglume register . --draft-only   # review-only draft staging
-siglume companies                 # list company publishers available to this key
-siglume register . --company company_123
 ```
 
 Useful flags:
 
 - `--draft-only`: create or refresh the immutable draft without confirming publication
-- `--company <company_id>`: publish under a company name. This is founder-only
-  in the Phase 2 MVP and paid listings require a verified company settlement
-  wallet. Siglume does not fall back to the registrant's personal payout wallet.
-- `--company-slug <slug>`: resolve a listed company publisher by slug-compatible name
 - `--confirm`: explicit compatibility alias; confirmation is already the default
 - `--submit-review`: legacy alias for older environments
 - `--json`: emit machine-readable JSON

--- a/README.md
+++ b/README.md
@@ -58,23 +58,27 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v1.2.2.** Python and TypeScript are version-aligned and
+> **Current release: v2.0.5.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
-> operation pricing plans, prepay quote billing, developer receipt/log
-> observability, long-form buyer-facing `description`, and
-> platform-controlled release semver via `version_bump`. v1.0.0 removes
-> platform OAuth broker APIs from the SDK:
-> publisher APIs now own external OAuth, token storage, refresh, revocation,
-> and user-to-token mapping behind their own `connect_url`.
+> operation pricing plans, prepay quote billing (including async / long-running
+> two-phase APIs), developer receipt/log observability, long-form buyer-facing
+> `description`, and platform-controlled release semver via `version_bump`.
+> Recent line: **2.0.0** removed the legacy advertising / partner-dashboard +
+> advertiser Ads SDK surface (BREAKING) and finished moving external OAuth into
+> the publisher API (token storage, refresh, revocation, and user-to-token
+> mapping live behind your own `connect_url`); **2.0.1** removed the retired
+> job-fulfillment extension; **2.0.2** added `ToolManual.supports`; **2.0.3–2.0.5**
+> added the async two-phase API guide, its failure/edge completeness, and a
+> documentation freshness pass. Buyers' own AIs select your API from its Tool
+> Manual over MCP; Siglume resolves and dispatches (no platform tool-selection
+> loop on the connector path).
 > See [CHANGELOG.md](./CHANGELOG.md),
-> [RELEASE_NOTES_v1.2.2.md](./RELEASE_NOTES_v1.2.2.md),
-> [RELEASE_NOTES_v1.2.1.md](./RELEASE_NOTES_v1.2.1.md),
-> [RELEASE_NOTES_v1.2.0.md](./RELEASE_NOTES_v1.2.0.md),
-> [RELEASE_NOTES_v1.1.0.md](./RELEASE_NOTES_v1.1.0.md),
-> [RELEASE_NOTES_v1.0.0.md](./RELEASE_NOTES_v1.0.0.md), and
-> [RELEASE_NOTES_v0.10.8.md](./RELEASE_NOTES_v0.10.8.md) for the current
+> [RELEASE_NOTES_v2.0.5.md](./RELEASE_NOTES_v2.0.5.md),
+> [RELEASE_NOTES_v2.0.4.md](./RELEASE_NOTES_v2.0.4.md),
+> [RELEASE_NOTES_v2.0.3.md](./RELEASE_NOTES_v2.0.3.md), and
+> [RELEASE_NOTES_v2.0.1.md](./RELEASE_NOTES_v2.0.1.md) for the current
 > release line.
 >
 > See [Getting Started](GETTING_STARTED.md) to publish your first API in ~15 minutes.
@@ -261,12 +265,7 @@ No permission needed. No issue to claim. Just build and register.
 
 - Free APIs can be drafted and published without wallet setup.
 - Paid APIs require an active embedded Polygon wallet before publish.
-- Company-name publishing is founder-only in the Phase 2 MVP. Run
-  `siglume companies` to list company ids you can publish under, then use
-  `siglume register . --company <company_id>` or set
-  `publisher_type: "company"` and `company_id` in `app_manifest.yaml`.
-- Paid company listings require the company's verified settlement wallet.
-  Siglume will not fall back to the registrant's personal payout wallet.
+- You publish as an individual: omit `publisher_type` (defaults to `"user"`).
 - Draft creation now requires runtime validation inputs for a live public API:
   public base URL, healthcheck URL, functional test URL, the runtime auth header
   shared secret (`runtime_auth_header_name` / `runtime_auth_header_value`), a
@@ -315,8 +314,6 @@ siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
 siglume register .                # preflight + auto-register + confirm/publish
 siglume register . --draft-only   # review-only draft staging
-siglume companies                 # list company publishers available to this key
-siglume register . --company company_123
 ```
 
 `siglume register` now runs manifest validation and remote Tool Manual quality
@@ -708,7 +705,6 @@ project for a first-party owner operation instead of starting from an LLM draft
 or a blank starter template.
 
 - CLI docs: [docs/template-generator.md](./docs/template-generator.md)
-- Coverage inventory: [docs/sdk/v0.6-operation-inventory.md](./docs/sdk/v0.6-operation-inventory.md)
 - Generated review samples: [examples/generated](./examples/generated)
 
 ## Metering And Operation Billing
@@ -777,7 +773,6 @@ your payment adapter without touching a live wallet.
 | [visual_publisher.py](./examples/visual_publisher.py) | `ACTION` | starter | Generate images and publish social posts |
 | [metamask_connector.py](./examples/metamask_connector.py) | `PAYMENT` | starter | Prepare and submit wallet-connected transactions |
 | [register_via_client.py](./examples/register_via_client.py) | client | ✅ | Register and confirm a listing through `SiglumeClient` |
-
 | [paid_action_subscription](./examples/paid_action_subscription/) | `ACTION` + subscription | template | Complete `auto-register` JSON for a $5/month action API with runtime validation and payout preflight |
 
 ## API ideas
@@ -821,7 +816,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | `AppManifest` | Metadata, permissions, pricing |
 | `ExecutionContext` | Task details passed to `execute()` |
 | `ExecutionResult` | Output and usage data returned from `execute()` |
-| `PermissionClass` | `READ_ONLY`, `RECOMMENDATION`, `ACTION`, `PAYMENT` |
+| `PermissionClass` | `READ_ONLY`, `ACTION`, `PAYMENT` (`RECOMMENDATION` is a deprecated alias of `READ_ONLY`) |
 | `ApprovalMode` | `AUTO`, `ALWAYS_ASK`, `BUDGET_BOUNDED` |
 | `ExecutionArtifact` | Describes a discrete output produced by execution |
 | `SideEffectRecord` | Describes an external side effect for audit and rollback review |
@@ -856,7 +851,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v1.2.2 (beta)** — the platform is launched on Polygon mainnet
+This is **v2.0.5 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with paid API Store settlement live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
 The user base is still growing, and new SDK surfaces continue to ship

--- a/RELEASE_NOTES_v2.0.5.md
+++ b/RELEASE_NOTES_v2.0.5.md
@@ -1,0 +1,33 @@
+# v2.0.5 — documentation freshness pass
+
+Documentation-only release. A full staleness audit of the SDK found several
+current-state claims that were six releases behind. This release makes the docs
+reflect the actual 2.0.x reality. No SDK runtime code changed.
+
+## Highlights
+
+- **Version/state freshness.** The README "Current release" and "Project status" blocks
+  said **v1.2.2** and framed v1.0.0's OAuth-broker removal as the headline. Both now read
+  **2.0.5** and lead with the real 2.0.x line: 2.0.0 removed the legacy advertising /
+  partner-dashboard + Ads SDK surface (BREAKING), 2.0.1 removed the job-fulfillment
+  extension, 2.0.2 added `ToolManual.supports`, and 2.0.3–2.0.5 added the async two-phase
+  API guide + its failure/edge completeness. The release-notes links now point at the 2.0.x
+  notes.
+- **Retired Company-publishing path removed from the docs.** `README.md` and
+  `GETTING_STARTED.md` no longer document `siglume companies`, `--company`/`--company-slug`,
+  or `publisher_type: "company"`/`company_id` — the Company feature is retired platform-side,
+  so the docs no longer present it as a working flow. (The vestigial CLI flags / manifest
+  fields are non-functional against the platform and are slated for removal in a future major.)
+- **`CONTRIBUTING.md`** corrected the false "listed after admin review" claim to the actual
+  self-serve publish gate (automated checks + a fail-closed legal review; no human review).
+- **`ROADMAP.md`** gained the missing 1.x/2.x **Shipped** history and dropped the retired
+  `partner.keys.create` / `admin.source_credentials.issue` surface (removed in 2.0.0) from
+  the external-ingest track.
+- Fixed a dead `docs/sdk/v0.6-operation-inventory.md` link, a blank line splitting the
+  README example-templates table, and annotated `RECOMMENDATION` as a deprecated alias of
+  `READ_ONLY`.
+
+## Upgrade Notes
+
+No code changes are required. If you publish as an individual, omit `publisher_type`
+(it defaults to `"user"`); the retired Company-publishing flow is no longer documented.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,29 @@ what is explicitly out of scope. For the per-release changelog, see
 
 ## Shipped
 
+### v2.x — async two-phase APIs + surface cleanup
+
+- **2.0.3–2.0.5** — the async / long-running two-phase API guide and runnable example
+  (quote → accepted job + `job_id` → free `get_result`), its failure/edge completeness
+  (idempotent acceptance, settlement-on-acceptance with publisher-owned refund, all
+  `get_result` states), and a documentation freshness pass. See
+  [docs/async-two-phase-apis.md](./docs/async-two-phase-apis.md).
+- **2.0.2** — `ToolManual.supports`, a structured capability-flags dict surfaced on
+  Store discovery so agents judge a capability before binding.
+- **2.0.1** — removed the retired job-fulfillment extension from the public packages.
+- **2.0.0 (BREAKING)** — removed the legacy advertising / partner-dashboard and
+  advertiser Ads SDK surface; external OAuth is fully publisher-owned (token storage,
+  refresh, revocation, user-to-token mapping live behind your `connect_url`). See
+  [CHANGELOG.md](./CHANGELOG.md).
+
+### v1.x — operation billing + listing copy
+
+Live `usage_based` / `per_action` operation billing with `pricing_plan.items`,
+`billing_timing` (`post` / `prepay`), the canonical
+[Pricing and Billing](./docs/pricing-and-billing.md) guide,
+[Developer Observability](./docs/developer-observability.md), and long-form
+buyer-facing `description`. v1.0.0 removed the platform OAuth broker APIs from the SDK.
+
 ### v0.10.0 — buyer-facing copy + platform-controlled release semver
 
 `AppManifest.description` (long-form buyer-facing sales copy) and the
@@ -130,11 +153,11 @@ Platform prerequisites:
 
 ### External-ingest credential-facing surfaces
 
-Beyond today's `partner.keys.create` and
-`admin.source_credentials.issue` (both handle-only via the bus),
-several external-ingest integrations need their own credential
+Several external-ingest integrations need their own credential
 contracts — provider-specific auth refresh, scope rotation, and
-operational telemetry for partner-run data feeds.
+operational telemetry for data-feed integrations — expressed as
+listing-declared OAuth contracts that keep the handle-only secret
+discipline (the bus never emits the raw secret).
 
 What the SDK will add once the platform ships the contract:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "2.0.4"
+version = "2.0.5"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "2.0.4";
+export const SDK_VERSION = "2.0.5";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "2.0.4"
+SDK_VERSION = "2.0.5"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -102,7 +102,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "2.0.4"
+    assert python_version == "2.0.5"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -117,7 +117,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v1.2.2 (beta)**" in readme
+    assert "This is **v2.0.5 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
Mirrors source for v2.0.5: README/ROADMAP refreshed to the current 2.0.x state, retired Company-name publishing path removed from docs, CONTRIBUTING admin-review corrected to self-serve, dead-link/table/enum nits fixed. Docs-only.

Generated with Claude Code