### PR TITLE
docs: document runtime identity headers

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1108,6 +1108,32 @@ per-action / prepay APIs it is the trust boundary on live side-effect requests.
 Keep it in the Git-ignored `runtime_validation.json`, use a strong random
 value, never reuse your master API key, and rotate it if it leaks.
 
+### Runtime invocation identity headers
+
+Production runtime calls include Siglume identity context alongside the runtime
+auth header. Verify `X-Siglume-Auth` (or your configured
+`runtime_auth_header_name`) first; then use the identity headers to select the
+right tenant, connected account, or publisher-side token record.
+
+| Header | How to use it |
+|---|---|
+| `X-Siglume-Platform-User-Id` | Buyer / agent-owner platform user id. Use this for per-user tenant mapping. |
+| `X-Siglume-Agent-Id` | Agent id executing the call. |
+| `X-Siglume-Intent-Id` | Execution intent id for audit logs and idempotency correlation. |
+| `X-Siglume-Binding-Id` | Installed-tool binding id. |
+| `X-Siglume-Listing-Id` | Listing id being invoked. |
+
+Do not read `X-Siglume-Owner-Id`; `X-Siglume-Owner-Id` is not a supported
+runtime header. If `X-Siglume-Platform-User-Id` is required for your API and is
+missing, fail closed instead of falling back to a shared default user.
+
+`X-Siglume-Identity-Token`, when present, is an opaque Siglume context token on
+the API Store runtime path. It is not currently a public JWT/JWKS verification
+contract. Treat the runtime auth header as the channel trust boundary; after it
+matches, treat `X-Siglume-Platform-User-Id` as the PF-provided buyer identity.
+Do not require publishers to verify a JWKS until the SDK documents that issuer,
+audience, key endpoint, and rotation behavior.
+
 `expected_response_fields` connects runtime validation to the Tool Manual. If
 your runtime returns `status`, `postText`, `draftToken`, and `dailyLimit`, then
 those fields must be in `tool_manual.output_schema.properties`, and the fields

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ No permission needed. No issue to claim. Just build and register.
   - declare the provider in `required_connected_accounts` with `managed_by: "api", connect_url: "https://api.example.com/oauth/start"`
   - implement authorization, token storage, refresh, revocation, and user-to-token mapping in the publisher API
   - Siglume passes identity context during invocation but never stores or leases external user tokens
+  - runtime identity headers are `X-Siglume-Platform-User-Id` for the buyer / agent owner and `X-Siglume-Agent-Id` for the executing agent; `X-Siglume-Owner-Id` is not a supported runtime header
 - Siglume blocks draft creation if the public API cannot be reached or the
   functional test does not match the declared response shape.
 - Siglume also blocks draft creation when the Tool Manual contract is incomplete

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,14 @@ Handle it accordingly:
   your API source repository.
 - Have your API runtime treat the incoming header as the trust boundary: reject
   any `invoke_url` request whose header does not match the configured secret.
+- After the runtime auth header matches, treat `X-Siglume-Platform-User-Id` as
+  the PF-provided buyer / agent-owner user id for tenant and connected-account
+  mapping. `X-Siglume-Owner-Id` is not a supported runtime header; do not fall
+  back to a shared default user when the platform user id is missing.
+- `X-Siglume-Identity-Token`, when present on API Store runtime calls, is an
+  opaque Siglume context token. It is not currently a public JWT/JWKS
+  verification contract, so do not make JWKS verification a required publisher
+  runtime dependency until this SDK documents that contract.
 - Rotate the secret if it is ever exposed (shell history, screenshots, logs,
   commits, or chat). Rotating means generating a new value and re-registering /
   updating the listing so Siglume sends the new secret.

--- a/docs/connected-accounts.md
+++ b/docs/connected-accounts.md
@@ -10,7 +10,40 @@ Publisher APIs own every external OAuth flow:
 - map the Siglume platform user identity to the publisher-side token record.
 
 Siglume does not store, refresh, lease, or expose external-service user tokens.
-During runtime invocation Siglume sends publisher APIs Siglume identity headers only.
+During runtime invocation Siglume sends publisher APIs Siglume identity headers
+only.
+
+## Runtime identity headers
+
+When Siglume calls your `invoke_url` or action endpoint, authenticate the call
+with your configured runtime auth header first:
+
+- `runtime_auth_header_name` / `runtime_auth_header_value`, commonly
+  `X-Siglume-Auth: <your-runtime-secret>`
+
+After that shared-secret check passes, use these Siglume-provided identity
+headers to map the call to your own tenant or OAuth token record:
+
+| Header | Meaning |
+|---|---|
+| `X-Siglume-Platform-User-Id` | Stable Siglume platform user id for the buyer / agent owner on whose behalf the tool is running. This is the id to map to your publisher-side account or token record. |
+| `X-Siglume-Agent-Id` | Siglume agent id executing the call. |
+| `X-Siglume-Intent-Id` | Platform execution intent id for audit and idempotency correlation. |
+| `X-Siglume-Binding-Id` | Installed-tool binding id. |
+| `X-Siglume-Listing-Id` | Product listing id being invoked. |
+
+`X-Siglume-Owner-Id` is not a supported runtime header. Do not fall back to a
+shared default owner when `X-Siglume-Platform-User-Id` is missing. For
+per-user state, external OAuth, or paid side effects, fail closed and return an
+auth/identity error instead.
+
+Siglume may also attach `X-Siglume-Identity-Token`. On the API Store runtime
+path this is an opaque Siglume context token, not a public JWT/JWKS
+verification contract. Publisher runtimes should treat `X-Siglume-Auth` as the
+required channel authentication and then trust `X-Siglume-Platform-User-Id` as
+PF-provided identity for that authenticated request. If Siglume later makes
+JWT/JWKS verification mandatory, this SDK will document the issuer, audience,
+JWKS URL, and rotation contract explicitly.
 
 Declare external authorization requirements with API-managed metadata:
 

--- a/docs/pricing-and-billing.md
+++ b/docs/pricing-and-billing.md
@@ -224,6 +224,21 @@ separate **free** terminal op (`get_result`/`status`, a `0`-priced plan key with
 envelope is an *accepted, deferred* result — it is **not** one of the non-delivery shapes
 above. See [Async / long-running two-phase APIs](./async-two-phase-apis.md).
 
+If a paid live action fails with a recoverable delivery result such as
+`DRAFT_NOT_COMMITTED`, the platform does not mark the direct payment requirement
+as spent. The buyer/client should retry the execute step with the same
+`direct_payment_requirement_id` and the same API input after the publisher-side
+issue is fixed. Do not create a new direct payment requirement for that retry.
+The existing requirement and request hash bind the retry to the already
+confirmed payment, so a successful retry reuses the paid requirement and does
+not create a second payment.
+
+If the action is permanently impossible to commit, return a clear non-retriable
+failure from the runtime and handle any customer adjustment outside the
+automatic prepay path. Siglume records the platform failure/reconciliation state,
+but it does not automatically refund a confirmed on-chain payment merely because
+the publisher API could not commit its product-specific side effect.
+
 ## Choosing Between usage_based And per_action
 
 Use `per_action` when the price is tied to a named operation/request type:
@@ -293,6 +308,10 @@ Before publishing operation-based billing:
 - [ ] Free/no-op operations return `amount_minor=0`.
 - [ ] Irreversible side effects use `billing_timing="prepay"`.
 - [ ] The quote/dry-run path returns `billingPreview.operation` and `draftToken`.
+- [ ] Free preview, status, health, or no-op operations return `amount_minor=0`
+      and either no `billingPreview` or a `billingPreview.operation` matching a
+      `0`-priced `pricing_plan` item. If the preview returns a positive-priced
+      operation such as `start_job`, the platform will prepay that operation.
 - [ ] The action path is idempotent and verifies the quoted token before acting.
 - [ ] The action path returns committed provider evidence only after the side
       effect committed.

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -287,6 +287,10 @@ The intended advanced flow is:
    - manifest hints
    - Tool Manual files
    - deployment endpoints and runtime auth header secret settings
+   - runtime identity handling: verify `X-Siglume-Auth`, then map
+     `X-Siglume-Platform-User-Id` to your publisher-side tenant or token record
+     and use `X-Siglume-Agent-Id` for agent-scoped audit. Do not use
+     `X-Siglume-Owner-Id`; it is not a supported runtime header.
    - external OAuth `connect_url` metadata when the API requires it
 3. It generates the registration payload.
 4. If only one language is present in the buyer-facing listing text

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -81,6 +81,11 @@ includes runtime checks, contract checks, external OAuth declaration checks, pri
 rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.
 
+At production runtime, verify your configured runtime auth header first
+(commonly `X-Siglume-Auth`). Then map `X-Siglume-Platform-User-Id` to the
+buyer / agent-owner tenant or token record and use `X-Siglume-Agent-Id` for
+agent-scoped audit. `X-Siglume-Owner-Id` is not a supported runtime header.
+
 ## Usage-Based And Per-Action Billing
 
 For the canonical pricing reference, see

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -306,8 +306,37 @@ def test_pricing_docs_match_live_operation_billing_contract() -> None:
     assert "not delivered results" in docs
     assert "committed provider evidence" in docs
     assert "same committed provider id" in docs
+    assert "same `direct_payment_requirement_id`" in normalized_docs
+    assert "does not create a second payment" in normalized_docs
+    assert "DRAFT_NOT_COMMITTED" in docs
     assert "Do not describe a `usage_based` or `per_action` listing as free just because" in docs
     assert schema["properties"]["billing_timing"]["enum"] == ["post", "prepay"]
+
+
+def test_runtime_identity_header_contract_is_documented() -> None:
+    docs = "\n".join(
+        [
+            _read("README.md"),
+            _read("GETTING_STARTED.md"),
+            _read("SECURITY.md"),
+            _read("docs/connected-accounts.md"),
+            _read("docs/publish-flow.md"),
+            _read("siglume-api-sdk-ts/README.md"),
+        ]
+    )
+    normalized_docs = " ".join(docs.split())
+
+    assert "X-Siglume-Auth" in docs
+    assert "X-Siglume-Platform-User-Id" in docs
+    assert "X-Siglume-Agent-Id" in docs
+    assert "X-Siglume-Intent-Id" in docs
+    assert "X-Siglume-Binding-Id" in docs
+    assert "X-Siglume-Listing-Id" in docs
+    assert "`X-Siglume-Owner-Id` is not a supported runtime header" in docs
+    assert "fail closed" in docs
+    assert "X-Siglume-Identity-Token" in docs
+    assert "not currently a public JWT/JWKS verification contract" in normalized_docs
+    assert "runtime auth header as the channel trust boundary" in normalized_docs
 
 
 def test_developer_observability_docs_explain_logs_receipts_and_privacy() -> None:


### PR DESCRIPTION
﻿## Summary
- document the runtime identity headers sent to publisher runtimes (`X-Siglume-Platform-User-Id`, `X-Siglume-Agent-Id`, execution context ids)
- clarify that `X-Siglume-Owner-Id` is not supported and runtimes should fail closed instead of falling back to a shared owner
- document the current `X-Siglume-Identity-Token` trust boundary and recoverable prepay retry semantics for `DRAFT_NOT_COMMITTED`
- add docs contract coverage so the public SDK keeps this contract visible

## Validation
- `D:\Users\taihei2\AppData\Local\Programs\Python\Python311\python.exe -m pytest tests\test_docs_contract.py -q`
