### PR TITLE
Support private registration confirmation in SDK docs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -530,20 +530,23 @@ siglume validate .
 siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
 siglume register .                # preflight + auto-register + confirm/publish
+siglume register . --private-confirm # confirm release, keep listing hidden for production testing
 siglume register . --draft-only   # review-only draft staging
 ```
 
 Useful flags:
 
 - `--draft-only`: create or refresh the immutable draft without confirming publication
+- `--private-confirm`: create the executable release but keep the listing hidden so the seller can test it in production before publishing
 - `--confirm`: explicit compatibility alias; confirmation is already the default
 - `--submit-review`: legacy alias for older environments
 - `--json`: emit machine-readable JSON
 
 Coding agents may run `siglume validate .`, `siglume score . --remote`,
-`siglume preflight .`, and `siglume register . --draft-only` to create the
-review draft. They should not run `siglume register .` unless the human
-explicitly approves immediate publish.
+`siglume preflight .`, and `siglume register . --private-confirm` to create a
+non-public, production-testable release. Use `--draft-only` when you only want
+an immutable review draft. They should not run plain `siglume register .` unless
+the human explicitly approves immediate public publish.
 
 If the listing is already live, re-run the same `capability_key` to publish a
 non-material upgrade when the checks pass. Use `--draft-only` if you
@@ -562,9 +565,11 @@ draft; it does not edit the manual. See [Section 13](#13-tool-manual-guide).
 - Portal route: use `/owner/publish` to inspect the immutable CLI /
   automation result; submitted content is not editable in the portal
 - CLI / engine route: send the final tool manual during `auto-register`, then
-  use `confirm-auto-register` only to approve the immutable draft
+  use `confirm-auto-register` only to approve the immutable draft. Pass
+  `visibility: "private"` when you need to test in production while the listing
+  remains hidden.
 - Canonical schema: `schemas/tool-manual.schema.json`
-- Canonical publish gate: `confirm-auto-register`
+- Canonical confirmation gate: `confirm-auto-register`
 - You must send the full `tool_manual` during `auto-register`
 - SDK / HTTP automation can include `source_url` plus optional
   `source_context` to register directly from GitHub provenance
@@ -974,24 +979,19 @@ Open the `review_url` returned by the CLI, or go to
 `https://siglume.com/owner/publish`. Submitted listing content is read-only in
 the portal. If you need to change the API contract, update the local project and
 rerun `siglume register .` with the same `capability_key`. Use
-`siglume register . --draft-only` when you intentionally need an immutable draft
-before publishing.
+`siglume register . --private-confirm` when you want to test the confirmed
+release in production while it stays hidden, or `--draft-only` when you
+intentionally need an immutable draft before confirming.
 
-### Step 3: Legacy/manual direct REST sandbox fallback
+### Step 3: Manual direct REST sandbox fallback
 
-The direct sandbox REST endpoints currently use a normal signed-in browser
-session token. This is a beta/manual testing surface, not the recommended
-automation path. Do not use browser tokens in docs, CI, coding-engine prompts,
-or production scripts. Do not paste browser session tokens or production API
-keys into a coding-agent chat. If credentials are needed, run the command
-locally or use a short-lived, project-scoped CLI token.
-
-If you must test the sandbox endpoints manually, sign in to siglume.com and copy
-the browser session token from DevTools -> Application -> Cookies.
+The direct sandbox REST endpoint accepts the same `SIGLUME_API_KEY` / CLI token
+style as `auto-register`. This is a beta/manual testing surface; for normal
+diagnostics prefer `siglume dev tail`.
 
 ```bash
 curl -X POST https://siglume.com/v1/market/sandbox/sessions \
-  -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN" \
+  -H "Authorization: Bearer $SIGLUME_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "agent_id": "YOUR_AGENT_ID",
@@ -1005,12 +1005,12 @@ Then verify the sandbox run through usage data:
 
 ```bash
 curl "https://siglume.com/v1/market/usage?environment=sandbox&capability_key=my-api" \
-  -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN"
+  -H "Authorization: Bearer $SIGLUME_API_KEY"
 ```
 
 For normal developer diagnostics, prefer `siglume dev tail` or
 `siglume dev tail --listing-id LISTING_ID`; those commands expose recent
-execution receipts without relying on browser-session sandbox endpoints.
+execution receipts without relying on raw REST calls.
 
 Sandbox mode is isolated from live data. No real payments or side effects occur.
 When you are ready to go live, publish through `siglume register .` and the
@@ -1941,9 +1941,15 @@ Example request payload:
 
 ```json
 {
-  "approved": true
+  "approved": true,
+  "visibility": "private"
 }
 ```
+
+Use `visibility: "private"` for production testing before public launch. The
+server creates the `CapabilityRelease` and runtime adapter, but the listing stays
+hidden from the API Store. Use `visibility: "public"` or omit the field when you
+are ready to publish.
 
 Example response:
 
@@ -2069,12 +2075,12 @@ Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` explicitly before using these helper
 ### Sandbox testing with public endpoints
 
 After confirmation, create a sandbox session for your capability key only if you
-need the manual beta sandbox route. These endpoints currently require a
-signed-in browser session token, not `SIGLUME_API_KEY`.
+need the manual beta sandbox route. This endpoint accepts the same
+`SIGLUME_API_KEY` / CLI token style as `auto-register`.
 
 ```bash
 curl -X POST https://siglume.com/v1/market/sandbox/sessions \
-  -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN" \
+  -H "Authorization: Bearer $SIGLUME_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "agent_id": "YOUR_AGENT_ID",
@@ -2086,7 +2092,7 @@ Then verify the sandbox run through usage data:
 
 ```bash
 curl "https://siglume.com/v1/market/usage?environment=sandbox&capability_key=price-compare-helper" \
-  -H "Authorization: Bearer $SIGLUME_BROWSER_TOKEN"
+  -H "Authorization: Bearer $SIGLUME_API_KEY"
 ```
 
 For published listings, use `siglume dev tail --listing-id LISTING_ID` to view

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Constraints:
 - Keep runtime_validation.json, .env, and real secrets Git-ignored.
 - Do not put real secrets in source code or committed docs.
 - Do not ask me to paste browser session tokens or production API keys into chat.
-- Do not run `siglume register .` unless I explicitly approve immediate publish; use `siglume register . --draft-only` for review-only staging.
+- Do not run `siglume register .` unless I explicitly approve immediate public publish; use `siglume register . --private-confirm` when I want production testing while the listing stays hidden, or `siglume register . --draft-only` for review-only staging.
 - Make the project pass:
   siglume test .
   siglume score . --offline
@@ -193,9 +193,10 @@ This is the main use case. You build an API, register it, and earn revenue.
 4. Keep `tool_manual.json` and the local, Git-ignored `runtime_validation.json` next to your adapter
 5. Run `siglume test .` and `siglume score . --offline`
 6. Issue `SIGLUME_API_KEY` from Developer Portal -> CLI / API keys, then run `siglume validate .`, `siglume score . --remote`, and `siglume preflight .`
-7. Run `siglume register .` to auto-register and publish when the checks pass
-8. Use `siglume register . --draft-only` instead when you explicitly want an immutable review draft
-9. Review the result in the developer portal or CLI output
+7. Run `siglume register . --private-confirm` when you want to confirm the release and test it in production while the listing stays hidden
+8. Run `siglume register .` to auto-register and publish when the checks pass and immediate public launch is approved
+9. Use `siglume register . --draft-only` instead when you explicitly want an immutable review draft
+10. Review the result in the developer portal or CLI output
 11. Agent owners subscribe → you earn 93.4% of revenue (settlement mechanism: see [PAYMENT_MIGRATION.md](./PAYMENT_MIGRATION.md))
 ```
 
@@ -262,7 +263,7 @@ No permission needed. No issue to claim. Just build and register.
 
 | Route | Best for | Auth | Notes |
 | --- | --- | --- | --- |
-| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json` and local Git-ignored `runtime_validation.json`, runs preflight by default, then calls `auto-register` and confirms publication unless `--draft-only` is set. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to publish an upgrade when checks pass. |
+| CLI / SDK / automation | Registration and upgrades | `SIGLUME_API_KEY` or `~/.siglume/credentials.toml` | This is the canonical registration route. `siglume register` reads `tool_manual.json` and local Git-ignored `runtime_validation.json`, runs preflight by default, then calls `auto-register` and confirms publication unless `--private-confirm` or `--draft-only` is set. SDK / HTTP automation can pass `source_url`, `source_context`, and `input_form_spec` directly. Re-run the same `capability_key` to publish an upgrade when checks pass. |
 | Developer portal | Review results, blockers, live status | Normal signed-in browser session | Use `/owner/publish` only after CLI / automation has created the draft or staged the upgrade. Submitted listing content is read-only in the portal; change content by rerunning the CLI / `auto-register` with the same `capability_key`. Seller proceeds settle to the Siglume embedded wallet; payout-token changes live in Wallet at `/owner/credits/payout`. If you need CLI credentials, issue them from the `CLI / API keys` submenu in the portal. |
 
 #### Current publish prerequisites
@@ -289,8 +290,10 @@ No permission needed. No issue to claim. Just build and register.
   - paid APIs must satisfy minimum price and verified Polygon payout readiness
 - The canonical agent contract is the Tool Manual in
   `schemas/tool-manual.schema.json`.
-- `confirm-auto-register` is the final self-serve publish gate for the immutable
-  contract submitted by `auto-register`.
+- `confirm-auto-register` is the final self-serve confirmation gate for the
+  immutable contract submitted by `auto-register`. It publishes by default, or
+  keeps the listing hidden for seller-owned production testing when confirmed
+  with `visibility: "private"`.
 - Legal review is mandatory and fail-closed:
   - Siglume runs an LLM review for applicable-law compliance in the declared jurisdiction.
   - Siglume runs an LLM review for public-order / morals compliance.
@@ -318,14 +321,18 @@ siglume validate .
 siglume score . --remote
 siglume preflight .              # checks blockers without creating a draft
 siglume register .                # preflight + auto-register + confirm/publish
+siglume register . --private-confirm # confirm release, keep listing hidden for production testing
 siglume register . --draft-only   # review-only draft staging
 ```
 
 `siglume register` now runs manifest validation and remote Tool Manual quality
 preview before auto-registering. It confirms and publishes by default when the
-self-serve checks pass. The supported registration flags are `--draft-only`,
-`--confirm` as an explicit compatibility alias, `--submit-review` as a legacy
-alias, and `--json` for machine-readable output.
+self-serve checks pass. Use `--private-confirm` to create the executable release
+without public API Store visibility; the seller can then create a sandbox session
+and test against production before publishing. The supported registration flags
+are `--private-confirm`, `--draft-only`, `--confirm` as an explicit
+compatibility alias, `--submit-review` as a legacy alias, and `--json` for
+machine-readable output.
 
 For upgrades, run the same commands again with the same `capability_key`.
 `siglume register` publishes the next release immediately when the checks pass;

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -52,12 +52,16 @@ There is no normal human review step in the self-serve publish flow anymore.
    mandatory LLM legal checks.
 9. If the checks pass, `siglume register .` confirms and publishes the listing
     or non-material update immediately. Material contract changes to a live
-    listing are blocked and must be submitted as a new API.
+     listing are blocked and must be submitted as a new API.
 10. Use `siglume register . --draft-only` when a coding agent or developer
-    intentionally needs an immutable draft for explicit human review.
-11. The draft can then be published by rerunning plain `siglume register .` or
-    calling `confirm-auto-register`.
-12. After live or sandbox execution, use `siglume dev tail` or
+     intentionally needs an immutable draft for explicit human review.
+11. Use `siglume register . --private-confirm` or
+    `confirm-auto-register` with `visibility: "private"` when the seller needs
+    to test the confirmed release in production while the listing stays hidden.
+12. The hidden confirmed listing can then be published by rerunning plain
+    `siglume register .` or calling `confirm-auto-register` with
+    `visibility: "public"`.
+13. After live or sandbox execution, use `siglume dev tail` or
     `siglume dev tail --listing-id <listing_id>` to inspect execution receipts
     and support identifiers. See [Developer Observability](developer-observability.md).
 
@@ -83,7 +87,8 @@ There is no normal human review step in the self-serve publish flow anymore.
  8. Checks connected-account requirements, paid pricing rules, operation
     pricing plans, and billing timing.
 9. Persists a private draft only if those checks pass. The CLI then confirms it
-   by default unless `--draft-only` was requested.
+   by default unless `--draft-only` was requested. `--private-confirm` creates
+   the executable release but leaves the listing hidden.
 10. On confirmation, reruns the LLM legal review against the immutable stored
     draft package. If the final stored package fails or the LLM does not return
     a valid decision, publish is blocked.
@@ -307,10 +312,12 @@ The intended advanced flow is:
    - `runtime_validation`
    - external OAuth `connect_url` metadata when required
    - optional `input_form_spec`
-6. `siglume register .` confirms and publishes by default when immediate
-   publish is approved.
-7. Use `siglume register . --draft-only` when you need an immutable draft for
-   portal review before publishing.
+6. `siglume register . --private-confirm` confirms the release without public
+   API Store visibility so the seller can test it in production.
+7. `siglume register .` confirms and publishes by default when immediate
+   public publish is approved.
+8. Use `siglume register . --draft-only` when you need an immutable draft for
+   portal review before confirming.
 
 This is the recommended path for AI-assisted registration because it avoids
 manual browser form entry and keeps the registration contract close to the
@@ -341,10 +348,11 @@ then show the API-key production loop:
 siglume validate .
 siglume score . --remote
 siglume preflight .
-siglume register . --draft-only
+siglume register . --private-confirm
 
-Do not run plain siglume register . unless I explicitly approve immediate
-publish.
+Do not run plain siglume register . unless I explicitly approve immediate public
+publish. Use siglume register . --draft-only instead of --private-confirm only
+when I ask for a review draft without creating the executable release.
 ```
 
 ## Where the schema lives

--- a/openapi/developer-surface.yaml
+++ b/openapi/developer-surface.yaml
@@ -491,15 +491,18 @@ paths:
   /market/capabilities/{listingId}/confirm-auto-register:
     post:
       operationId: confirmAutoRegister
-      summary: Confirm auto-registered listing and publish immediately
+      summary: Confirm auto-registered listing for public or private availability
       description: |
         Confirms the auto-registered listing, runs quality check on the tool manual,
-        creates a CapabilityRelease, and publishes immediately when the
-        runtime, contract, pricing, payout, and mandatory LLM legal checks all pass.
-        This is the canonical publish gate for the immutable agent contract
-        submitted by auto-register. New integrations must put final manifest,
-        tool_manual, and input_form_spec content in auto-register; current SDKs
-        confirm with approved=true only and do not send post-draft content edits.
+        and creates a CapabilityRelease when the runtime, contract, pricing,
+        payout, and mandatory LLM legal checks all pass. Pass
+        `visibility: "private"` (or `publish: false`) to keep the listing
+        hidden for seller-owned production testing. Omit it or pass
+        `visibility: "public"` to publish. This is the canonical gate for the
+        immutable agent contract submitted by auto-register. New integrations
+        must put final manifest, tool_manual, and input_form_spec content in
+        auto-register; current SDKs confirm with approved=true plus optional
+        visibility, and do not send post-draft content edits.
       tags: [Capabilities]
       parameters:
         - name: listingId
@@ -518,6 +521,18 @@ paths:
                 approved:
                   type: boolean
                   description: Must be true to confirm
+                visibility:
+                  type: string
+                  enum: [public, private]
+                  default: public
+                  description: |
+                    `public` publishes the listing to the API Store. `private`
+                    creates the executable release but keeps the listing hidden
+                    so the seller can test it in production before publishing.
+                publish:
+                  type: boolean
+                  deprecated: true
+                  description: Compatibility alias. Use `visibility`; false maps to private and true maps to public.
                 version_bump:
                   type: string
                   enum: [patch, minor, major]
@@ -579,7 +594,7 @@ paths:
                       $ref: '#/components/schemas/ToolManual'
       responses:
         '200':
-          description: Listing confirmed and published
+          description: Listing confirmed for public or private availability
           content:
             application/json:
               schema:
@@ -1855,6 +1870,10 @@ components:
           type: string
         status:
           type: string
+        visibility:
+          type: string
+          enum: [public, private]
+          nullable: true
         message:
           type: string
         checklist:

--- a/siglume-api-sdk-ts/README.md
+++ b/siglume-api-sdk-ts/README.md
@@ -66,6 +66,7 @@ siglume validate .
 siglume score . --remote
 siglume preflight .         # checks blockers without creating a draft
 siglume register .          # preflight + auto-register + confirm/publish
+siglume register . --private-confirm # confirm release, keep listing hidden for production testing
 siglume register . --draft-only # review-only draft staging
 ```
 
@@ -75,8 +76,9 @@ Git-ignored because they hold the runtime auth header shared secret. SDK / HTTP 
 `source_url`, `source_context`, and `input_form_spec` directly to
 `auto-register`. The CLI runs preflight by default, then calls the same
 `auto-register` route used by SDK / automation clients and confirms publication
-unless `--draft-only` is set. Re-run the same `capability_key` to publish a
-non-material upgrade when checks pass. The server-side publish gate
+unless `--draft-only` is set. Use `--private-confirm` to create the executable
+release while keeping the listing hidden for seller-owned production testing.
+Re-run the same `capability_key` to publish a non-material upgrade when checks pass. The server-side publish gate
 includes runtime checks, contract checks, external OAuth declaration checks, pricing / payout
 rules, and a mandatory fail-closed LLM legal review for law compliance plus
 public-order / morals compliance.

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -298,6 +298,9 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
         draft_only: draftOnly,
         submit_review: options.submitReview,
       }, deps);
+      if (privateConfirm && report.confirmation && !(report.confirmation as { visibility?: unknown }).visibility) {
+        (report.confirmation as { visibility?: string }).visibility = "private";
+      }
       if (options.json) {
         emit(stdout, renderJson(report));
       } else {

--- a/siglume-api-sdk-ts/src/cli/index.ts
+++ b/siglume-api-sdk-ts/src/cli/index.ts
@@ -265,24 +265,36 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
   program
     .command("register")
     .option("--confirm", "explicitly confirm the registration; this is the default unless --draft-only is set", false)
+    .option("--private-confirm", "confirm the registration for private production testing without publishing it", false)
     .option("--draft-only", "create or refresh the draft without confirming publication", false)
     .option("--submit-review", "legacy alias: publish immediately if your environment still routes through submit-review", false)
     .option("--json", "emit machine-readable JSON", false)
     .argument("[path]", ".", "project path")
     .action(async (
       path: string,
-      options: { confirm?: boolean; draftOnly?: boolean; submitReview?: boolean; json?: boolean; ["draft-only"]?: boolean; ["submit-review"]?: boolean },
+      options: { confirm?: boolean; privateConfirm?: boolean; draftOnly?: boolean; submitReview?: boolean; json?: boolean; ["private-confirm"]?: boolean; ["draft-only"]?: boolean; ["submit-review"]?: boolean },
     ) => {
       const draftOnly = Boolean(options.draftOnly);
+      const privateConfirm = Boolean(options.privateConfirm);
       if (draftOnly && options.confirm) {
         throw new SiglumeProjectError("--draft-only cannot be combined with --confirm.");
+      }
+      if (draftOnly && privateConfirm) {
+        throw new SiglumeProjectError("--draft-only cannot be combined with --private-confirm.");
+      }
+      if (options.confirm && privateConfirm) {
+        throw new SiglumeProjectError("--confirm cannot be combined with --private-confirm.");
       }
       if (draftOnly && options.submitReview) {
         throw new SiglumeProjectError("--draft-only cannot be combined with --submit-review.");
       }
-      const shouldConfirm = Boolean(options.confirm) || (!draftOnly && !options.submitReview);
+      if (privateConfirm && options.submitReview) {
+        throw new SiglumeProjectError("--private-confirm cannot be combined with --submit-review.");
+      }
+      const shouldConfirm = Boolean(options.confirm) || privateConfirm || (!draftOnly && !options.submitReview);
       const report = await runRegistration(path, {
         confirm: shouldConfirm,
+        confirm_visibility: privateConfirm ? "private" : "public",
         draft_only: draftOnly,
         submit_review: options.submitReview,
       }, deps);
@@ -298,8 +310,12 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
           trace_id?: string | null;
           request_id?: string | null;
         };
-        const published = Boolean(report.confirmation || report.review);
-        if (published && receipt.registration_mode === "upgrade") {
+        const confirmationSummary = report.confirmation as { visibility?: string | null } | undefined;
+        const privatelyConfirmed = confirmationSummary?.visibility === "private";
+        const published = !privatelyConfirmed && Boolean(report.confirmation || report.review);
+        if (privatelyConfirmed) {
+          emit(stdout, "Registration privately confirmed.");
+        } else if (published && receipt.registration_mode === "upgrade") {
           emit(stdout, "Upgrade registered.");
         } else if (published) {
           emit(stdout, "Registration accepted.");
@@ -319,10 +335,12 @@ export async function runCli(argv: string[], deps: CliRunDependencies = {}): Pro
         if (report.confirmation) {
           const confirmation = report.confirmation as {
             status?: string | null;
+            visibility?: string | null;
             release?: { release_status?: string | null } | null;
           };
-          emit(stdout, "Listing published.");
+          emit(stdout, confirmation.visibility === "private" ? "Listing confirmed privately for production testing." : "Listing published.");
           if (confirmation.status) emit(stdout, `confirmation_status: ${confirmation.status}`);
+          if (confirmation.visibility) emit(stdout, `confirmation_visibility: ${confirmation.visibility}`);
           if (confirmation.release?.release_status) emit(stdout, `release_status: ${confirmation.release.release_status}`);
         } else if (report.review) {
           const review = report.review as { status?: string | null };

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -613,7 +613,7 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
 
 export async function runRegistration(
   path = ".",
-  options: { confirm?: boolean; draft_only?: boolean; submit_review?: boolean } = {},
+  options: { confirm?: boolean; confirm_visibility?: "public" | "private"; draft_only?: boolean; submit_review?: boolean } = {},
   deps: CliProjectDependencies = {},
 ): Promise<Record<string, unknown>> {
   const project = await loadProject(path);
@@ -646,7 +646,9 @@ export async function runRegistration(
   }
   const shouldConfirm = Boolean(options.confirm) || (options.confirm === undefined && !options.draft_only && !options.submit_review);
   if (shouldConfirm) {
-    result.confirmation = toJsonable(await client.confirm_registration(receipt.listing_id));
+    result.confirmation = toJsonable(await client.confirm_registration(receipt.listing_id, {
+      visibility: options.confirm_visibility ?? "public",
+    }));
     if (options.submit_review) {
       result.submit_review_skipped = true;
     }

--- a/siglume-api-sdk-ts/src/client.ts
+++ b/siglume-api-sdk-ts/src/client.ts
@@ -274,7 +274,12 @@ export interface SiglumeClientShape {
   ): Promise<AutoRegistrationReceipt>;
   confirm_registration(
     listing_id: string,
-    options?: { manifest?: AppManifest | Record<string, unknown>; tool_manual?: ToolManual | Record<string, unknown> },
+    options?: {
+      manifest?: AppManifest | Record<string, unknown>;
+      tool_manual?: ToolManual | Record<string, unknown>;
+      version_bump?: "patch" | "minor" | "major";
+      visibility?: "public" | "private";
+    },
   ): Promise<RegistrationConfirmation>;
   preview_quality_score(tool_manual: ToolManual | Record<string, unknown>): Promise<ToolManualQualityReport>;
   submit_review(listing_id: string): Promise<AppListingRecord>;
@@ -1989,6 +1994,7 @@ export class SiglumeClient implements SiglumeClientShape {
       manifest?: AppManifest | Record<string, unknown>;
       tool_manual?: ToolManual | Record<string, unknown>;
       version_bump?: "patch" | "minor" | "major";
+      visibility?: "public" | "private";
     } = {},
   ): Promise<RegistrationConfirmation> {
     // Registration content is immutable after auto-register. Keep the
@@ -1996,8 +2002,12 @@ export class SiglumeClient implements SiglumeClientShape {
     // post-draft overrides. `version_bump` (optional) opts into a
     // minor/major semver bump on the newly-created CapabilityRelease;
     // platform defaults to "patch" when omitted.
-    const { version_bump: versionBump } = options;
+    const { version_bump: versionBump, visibility = "public" } = options;
     const payload: Record<string, unknown> = { approved: true };
+    if (visibility !== "public" && visibility !== "private") {
+      throw new Error(`visibility must be one of ["public","private"], got ${JSON.stringify(visibility)}`);
+    }
+    payload.visibility = visibility;
     if (versionBump !== undefined) {
       const allowed = ["patch", "minor", "major"] as const;
       if (!(allowed as readonly string[]).includes(versionBump)) {
@@ -2017,6 +2027,7 @@ export class SiglumeClient implements SiglumeClientShape {
     return {
       listing_id: String(data.listing_id ?? listing_id),
       status: String(data.status ?? ""),
+      visibility: stringOrNull(data.visibility),
       message: stringOrNull(data.message),
       checklist,
       release: toRecord(data.release),

--- a/siglume-api-sdk-ts/src/types.ts
+++ b/siglume-api-sdk-ts/src/types.ts
@@ -432,6 +432,7 @@ export interface RegistrationQuality {
 export interface RegistrationConfirmation {
   listing_id: string;
   status: string;
+  visibility?: string | null;
   message?: string | null;
   checklist?: Record<string, boolean>;
   release: Record<string, unknown>;

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -40,6 +40,7 @@ function createMockClient() {
       return {
         listing_id: "lst_123",
         status: "active",
+        visibility: "public",
         release: { release_status: "published" },
         quality: {
           overall_score: 84,
@@ -651,6 +652,46 @@ describe("siglume CLI", () => {
     expect(stdout.join("\n")).not.toContain("Listing published.");
   });
 
+  it("confirms privately when --private-confirm is set", async () => {
+    const projectDir = await createTestProject();
+    const stdout: string[] = [];
+    let capturedVisibility: unknown;
+    const clientFactory = () => ({
+      ...createMockClient(),
+      async confirm_registration(_listingId: string, options?: { visibility?: string }) {
+        capturedVisibility = options?.visibility;
+        return {
+          listing_id: "lst_123",
+          status: "hidden",
+          visibility: "private",
+          release: { release_status: "published" },
+          quality: {
+            overall_score: 92,
+            grade: "A",
+            issues: [],
+            improvement_suggestions: [],
+            raw: {},
+          },
+          raw: {},
+        };
+      },
+    });
+
+    const registerExit = await runCli(["register", projectDir, "--private-confirm"], {
+      stdout: (line) => stdout.push(line),
+      client_factory: clientFactory as unknown as (api_key: string, base_url?: string) => SiglumeClientShape,
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
+
+    expect(registerExit).toBe(0);
+    expect(capturedVisibility).toBe("private");
+    expect(stdout.join("\n")).toContain("Registration privately confirmed.");
+    expect(stdout.join("\n")).toContain("Listing confirmed privately for production testing.");
+    expect(stdout.join("\n")).toContain("confirmation_status: hidden");
+    expect(stdout.join("\n")).toContain("confirmation_visibility: private");
+    expect(stdout.join("\n")).not.toContain("Listing published.");
+  });
+
   it("rejects --draft-only combined with publish flags", async () => {
     const projectDir = await createTestProject();
     const stderr: string[] = [];
@@ -663,11 +704,17 @@ describe("siglume CLI", () => {
       stderr: (line) => stderr.push(line),
       env: { SIGLUME_API_KEY: "sig_test_key" },
     });
+    const privateConfirmExit = await runCli(["register", projectDir, "--draft-only", "--private-confirm"], {
+      stderr: (line) => stderr.push(line),
+      env: { SIGLUME_API_KEY: "sig_test_key" },
+    });
 
     expect(confirmExit).toBe(1);
     expect(submitExit).toBe(1);
+    expect(privateConfirmExit).toBe(1);
     expect(stderr.join("\n")).toContain("--draft-only cannot be combined with --confirm.");
     expect(stderr.join("\n")).toContain("--draft-only cannot be combined with --submit-review.");
+    expect(stderr.join("\n")).toContain("--draft-only cannot be combined with --private-confirm.");
   });
 
   it("runs preflight without creating a draft", async () => {

--- a/siglume-api-sdk-ts/test/cli.test.ts
+++ b/siglume-api-sdk-ts/test/cli.test.ts
@@ -663,7 +663,6 @@ describe("siglume CLI", () => {
         return {
           listing_id: "lst_123",
           status: "hidden",
-          visibility: "private",
           release: { release_status: "published" },
           quality: {
             overall_score: 92,

--- a/siglume-api-sdk-ts/test/client-extra.test.ts
+++ b/siglume-api-sdk-ts/test/client-extra.test.ts
@@ -167,7 +167,7 @@ describe("SiglumeClient extra branches", () => {
     expect(receipt.trace_id).toBe("trc_1");
     expect(requests[0]?.body.source_url).toBe("https://github.com/example/repo");
     expect(requests[0]?.body.source_code).toBeUndefined();
-    expect(requests[1]?.body).toEqual({ approved: true });
+    expect(requests[1]?.body).toEqual({ approved: true, visibility: "public" });
     expect(confirmation.status).toBe("active");
     expect((confirmation.release as { release_status?: string }).release_status).toBe("published");
     expect(confirmation.quality.grade).toBe("B");

--- a/siglume-api-sdk-ts/test/client.test.ts
+++ b/siglume-api-sdk-ts/test/client.test.ts
@@ -232,11 +232,14 @@ describe("SiglumeClient", () => {
           );
         }
         if (url.pathname === "/v1/market/capabilities/lst_123/confirm-auto-register") {
+          expect(body.approved).toBe(true);
+          expect(body.visibility).toBe("public");
           return new Response(
             JSON.stringify(
               envelope({
                 listing_id: "lst_123",
                 status: "active",
+                visibility: "public",
                 message: "Listing published automatically after the self-serve checks passed.",
                 checklist: { docs_url: true, seller_onboarding: true },
                 release: { release_id: "rel_123", release_status: "published" },
@@ -266,6 +269,7 @@ describe("SiglumeClient", () => {
     expect(receipt.listing_status).toBe("active");
     expect(confirmation.listing_id).toBe("lst_123");
     expect(confirmation.status).toBe("active");
+    expect(confirmation.visibility).toBe("public");
     expect(confirmation.message).toBe("Listing published automatically after the self-serve checks passed.");
     expect(confirmation.checklist).toEqual({ docs_url: true, seller_onboarding: true });
     expect((confirmation.release as { release_status?: string }).release_status).toBe("published");
@@ -273,6 +277,39 @@ describe("SiglumeClient", () => {
     expect(confirmation.trace_id).toBe("trc_confirm");
     expect(requests[0]?.path).toBe("/v1/market/capabilities/auto-register");
     expect(requests[1]?.path).toBe("/v1/market/capabilities/lst_123/confirm-auto-register");
+  });
+
+  it("confirms registration privately when requested", async () => {
+    const client = new SiglumeClient({
+      api_key: "sig_test_key",
+      base_url: "https://api.example.test/v1",
+      fetch: async (input, init) => {
+        const url = requestUrl(input);
+        const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+        expect(url.pathname).toBe("/v1/market/capabilities/lst_123/confirm-auto-register");
+        expect(body).toEqual({ approved: true, visibility: "private" });
+        return new Response(
+          JSON.stringify(
+            envelope({
+              listing_id: "lst_123",
+              status: "hidden",
+              visibility: "private",
+              message: "Listing confirmed privately.",
+              checklist: { docs_url: true },
+              release: { release_id: "rel_123", release_status: "published" },
+              quality: { overall_score: 91, grade: "A", issues: [], improvement_suggestions: [] },
+            }),
+          ),
+          { status: 200 },
+        );
+      },
+    });
+
+    const confirmation = await client.confirm_registration("lst_123", { visibility: "private" });
+
+    expect(confirmation.status).toBe("hidden");
+    expect(confirmation.visibility).toBe("private");
+    expect((confirmation.release as { release_id?: string }).release_id).toBe("rel_123");
   });
 
   it("requires an explicit listing currency before auto_register", async () => {

--- a/siglume_api_sdk/cli/commands/register_cmd.py
+++ b/siglume_api_sdk/cli/commands/register_cmd.py
@@ -60,6 +60,8 @@ def register_command(
         submit_review=submit_review,
     )
     result["local_prompt_injection_scan"] = scan_result
+    if private_confirm and isinstance(result.get("confirmation"), dict) and not result["confirmation"].get("visibility"):
+        result["confirmation"]["visibility"] = "private"
     if json_output:
         click.echo(render_json(result))
         return

--- a/siglume_api_sdk/cli/commands/register_cmd.py
+++ b/siglume_api_sdk/cli/commands/register_cmd.py
@@ -8,6 +8,7 @@ from siglume_api_sdk.cli.project import render_json, run_registration
 
 @click.command("register")
 @click.option("--confirm", is_flag=True, help="Explicitly confirm the registration. This is the default unless --draft-only is set.")
+@click.option("--private-confirm", is_flag=True, help="Confirm the registration for private production testing without publishing it.")
 @click.option("--draft-only", is_flag=True, help="Create or refresh the draft without confirming publication.")
 @click.option("--submit-review", is_flag=True, help="Legacy alias: publish immediately if your environment still routes through submit-review.")
 @click.option("--yes", is_flag=True, help="Skip local scan confirmation prompts.")
@@ -15,6 +16,7 @@ from siglume_api_sdk.cli.project import render_json, run_registration
 @click.argument("path", required=False, default=".")
 def register_command(
     confirm: bool,
+    private_confirm: bool,
     draft_only: bool,
     submit_review: bool,
     yes: bool,
@@ -23,12 +25,21 @@ def register_command(
 ) -> None:
     if draft_only and confirm:
         raise click.ClickException("--draft-only cannot be combined with --confirm.")
+    if draft_only and private_confirm:
+        raise click.ClickException("--draft-only cannot be combined with --private-confirm.")
+    if confirm and private_confirm:
+        raise click.ClickException("--confirm cannot be combined with --private-confirm.")
     if draft_only and submit_review:
         raise click.ClickException("--draft-only cannot be combined with --submit-review.")
+    if private_confirm and submit_review:
+        raise click.ClickException("--private-confirm cannot be combined with --submit-review.")
 
-    should_confirm = confirm or (not draft_only and not submit_review)
+    should_confirm = confirm or private_confirm or (not draft_only and not submit_review)
+    confirm_visibility = "private" if private_confirm else "public"
     scan_result = scan_path(path)
-    risky_publish = scan_result["risk_level"] != "clean" and (should_confirm or submit_review)
+    risky_publish = scan_result["risk_level"] != "clean" and (
+        (confirm_visibility == "public" and should_confirm) or submit_review
+    )
     if risky_publish and not yes and json_output:
         raise click.ClickException(
             "Local prompt-injection scan found suspicious capability metadata; "
@@ -45,6 +56,7 @@ def register_command(
     result = run_registration(
         path,
         confirm=should_confirm,
+        confirm_visibility=confirm_visibility,
         submit_review=submit_review,
     )
     result["local_prompt_injection_scan"] = scan_result
@@ -54,8 +66,14 @@ def register_command(
 
     receipt = result["receipt"]
     registration_mode = receipt.get("registration_mode")
-    published = "confirmation" in result or "review" in result
-    if published and registration_mode == "upgrade":
+    confirmation_visibility = None
+    if isinstance(result.get("confirmation"), dict):
+        confirmation_visibility = result["confirmation"].get("visibility")
+    published = confirmation_visibility != "private" and ("confirmation" in result or "review" in result)
+    privately_confirmed = confirmation_visibility == "private"
+    if privately_confirmed:
+        click.secho("Registration privately confirmed.", fg="green")
+    elif published and registration_mode == "upgrade":
         click.secho("Upgrade registered.", fg="green")
     elif published:
         click.secho("Registration accepted.", fg="green")
@@ -83,8 +101,13 @@ def register_command(
     if "confirmation" in result:
         confirmation = result["confirmation"]
         quality = confirmation["quality"]
-        click.secho("Listing published.", fg="green")
+        if confirmation.get("visibility") == "private":
+            click.secho("Listing confirmed privately for production testing.", fg="green")
+        else:
+            click.secho("Listing published.", fg="green")
         click.echo(f"confirmation_status: {confirmation['status']}")
+        if confirmation.get("visibility"):
+            click.echo(f"confirmation_visibility: {confirmation['visibility']}")
         release = confirmation.get("release")
         if isinstance(release, dict) and release.get("release_status"):
             click.echo(f"release_status: {release['release_status']}")

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -1499,6 +1499,7 @@ def run_registration(
     path: str | Path,
     *,
     confirm: bool,
+    confirm_visibility: str = "public",
     submit_review: bool,
 ) -> dict[str, Any]:
     project = load_project(path)
@@ -1522,7 +1523,7 @@ def run_registration(
         if portal_preflight is not None:
             result["developer_portal_preflight"] = portal_preflight
         if confirm:
-            confirmation = client.confirm_registration(receipt.listing_id)
+            confirmation = client.confirm_registration(receipt.listing_id, visibility=confirm_visibility)
             result["confirmation"] = to_jsonable(confirmation)
             if submit_review:
                 result["submit_review_skipped"] = True

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -220,7 +220,6 @@ class RegistrationQuality:
 class RegistrationConfirmation:
     listing_id: str
     status: str
-    visibility: str | None = None
     release: dict[str, Any] = field(default_factory=dict)
     quality: RegistrationQuality = field(default_factory=RegistrationQuality)
     trace_id: str | None = None
@@ -228,6 +227,7 @@ class RegistrationConfirmation:
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
     message: str = ""
     checklist: dict[str, bool] = field(default_factory=dict)
+    visibility: str | None = None
 
 
 @dataclass

--- a/siglume_api_sdk/client.py
+++ b/siglume_api_sdk/client.py
@@ -220,6 +220,7 @@ class RegistrationQuality:
 class RegistrationConfirmation:
     listing_id: str
     status: str
+    visibility: str | None = None
     release: dict[str, Any] = field(default_factory=dict)
     quality: RegistrationQuality = field(default_factory=RegistrationQuality)
     trace_id: str | None = None
@@ -2570,12 +2571,18 @@ class SiglumeClient:
         manifest: "AppManifest | Mapping[str, Any] | None" = None,
         tool_manual: "ToolManual | Mapping[str, Any] | None" = None,
         version_bump: str | None = None,
+        visibility: str = "public",
     ) -> RegistrationConfirmation:
         # Registration content is immutable after auto-register. Keep the
         # historical keyword arguments source-compatible, but do not send them
         # as post-draft overrides.
         _ = (manifest, tool_manual)
         payload: dict[str, Any] = {"approved": True}
+        if visibility not in ("public", "private"):
+            raise SiglumeClientError(
+                f"visibility must be one of ['public', 'private'], got {visibility!r}"
+            )
+        payload["visibility"] = visibility
         if version_bump is not None:
             # Platform accepts "patch" (default), "minor", or "major". Any
             # other value is rejected server-side. Validate client-side too
@@ -2596,6 +2603,7 @@ class SiglumeClient:
         return RegistrationConfirmation(
             listing_id=str(data.get("listing_id") or listing_id),
             status=str(data.get("status") or ""),
+            visibility=_string_or_none(data.get("visibility")),
             message=str(data.get("message") or ""),
             checklist={str(key): bool(value) for key, value in _to_dict(data.get("checklist")).items()},
             release=_to_dict(data.get("release")),

--- a/siglume_api_sdk_client.ts
+++ b/siglume_api_sdk_client.ts
@@ -76,6 +76,7 @@ export interface RegistrationQuality {
 export interface RegistrationConfirmation {
   listing_id: string;
   status: string;
+  visibility?: string | null;
   release: Record<string, unknown>;
   quality: RegistrationQuality;
   trace_id?: string | null;

--- a/tests/cassettes/auto_register_flow.json
+++ b/tests/cassettes/auto_register_flow.json
@@ -159,12 +159,13 @@
         "headers": {
           "accept": "application/json",
           "authorization": "Bearer <REDACTED>",
-          "content-length": "17",
+          "content-length": "39",
           "content-type": "application/json",
           "user-agent": "siglume-api-sdk/fixture"
         },
         "body": {
-          "approved": true
+          "approved": true,
+          "visibility": "public"
         }
       },
       "response": {
@@ -180,6 +181,7 @@
             },
             "listing_id": "lst_123",
             "message": "Listing published automatically after the self-serve checks passed.",
+            "visibility": "public",
             "quality": {
               "grade": "B",
               "improvement_suggestions": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -728,11 +728,13 @@ def test_register_human_output_includes_review_and_trace_metadata(monkeypatch, t
                 request_id="req_reg",
             )
 
-        def confirm_registration(self, listing_id: str):
+        def confirm_registration(self, listing_id: str, **kwargs):
             assert listing_id == "lst_123"
+            assert kwargs == {"visibility": "public"}
             return SimpleNamespace(
                 listing_id=listing_id,
                 status="active",
+                visibility="public",
                 release={"release_status": "published"},
                 quality=SimpleNamespace(overall_score=91, grade="A"),
             )
@@ -786,7 +788,7 @@ def test_register_draft_only_stops_after_auto_register(monkeypatch, tmp_path) ->
         def auto_register(self, manifest, tool_manual, **kwargs):
             return SimpleNamespace(listing_id="lst_draft", status="draft")
 
-        def confirm_registration(self, listing_id: str):
+        def confirm_registration(self, listing_id: str, **kwargs):
             raise AssertionError("draft-only must not confirm registration")
 
     monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
@@ -800,6 +802,69 @@ def test_register_draft_only_stops_after_auto_register(monkeypatch, tmp_path) ->
     assert "Listing published." not in result.output
 
 
+def test_register_private_confirm_keeps_listing_non_public(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "private-confirm"
+    _write_register_project(project_dir)
+
+    class FakeClient:
+        captured_visibility: str | None = None
+
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def preview_quality_score(self, manual):
+            from siglume_api_sdk import ToolManualQualityReport
+
+            return ToolManualQualityReport(
+                overall_score=92,
+                grade="A",
+                issues=[],
+                keyword_coverage_estimate=72,
+                improvement_suggestions=[],
+                publishable=True,
+                validation_ok=True,
+            )
+
+        def auto_register(self, manifest, tool_manual, **kwargs):
+            return SimpleNamespace(
+                listing_id="lst_private",
+                status="draft",
+                registration_mode="create",
+                listing_status="draft",
+            )
+
+        def confirm_registration(self, listing_id: str, **kwargs):
+            assert listing_id == "lst_private"
+            FakeClient.captured_visibility = kwargs.get("visibility")
+            return SimpleNamespace(
+                listing_id=listing_id,
+                status="hidden",
+                visibility="private",
+                release={"release_status": "published"},
+                quality=SimpleNamespace(overall_score=92, grade="A"),
+            )
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+    monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
+
+    result = runner.invoke(main, ["register", str(project_dir), "--private-confirm"])
+
+    assert result.exit_code == 0, result.output
+    assert FakeClient.captured_visibility == "private"
+    assert "Registration privately confirmed." in result.output
+    assert "Listing confirmed privately for production testing." in result.output
+    assert "confirmation_status: hidden" in result.output
+    assert "confirmation_visibility: private" in result.output
+    assert "Listing published." not in result.output
+
+
 def test_register_draft_only_conflicts_with_publish_flags(tmp_path) -> None:
     runner = CliRunner()
     project_dir = tmp_path / "draft-only-conflict"
@@ -807,11 +872,14 @@ def test_register_draft_only_conflicts_with_publish_flags(tmp_path) -> None:
 
     confirm_result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--confirm"])
     submit_result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--submit-review"])
+    private_confirm_result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--private-confirm"])
 
     assert confirm_result.exit_code == 1
     assert "--draft-only cannot be combined with --confirm" in confirm_result.output
     assert submit_result.exit_code == 1
     assert "--draft-only cannot be combined with --submit-review" in submit_result.output
+    assert private_confirm_result.exit_code == 1
+    assert "--draft-only cannot be combined with --private-confirm" in private_confirm_result.output
 
 
 def test_register_submit_review_human_output_uses_publish_wording(monkeypatch, tmp_path) -> None:
@@ -901,11 +969,13 @@ def test_register_confirm_human_output_includes_release_status(monkeypatch, tmp_
                 request_id="req_confirm_reg",
             )
 
-        def confirm_registration(self, listing_id: str):
+        def confirm_registration(self, listing_id: str, **kwargs):
             assert listing_id == "lst_confirm"
+            assert kwargs == {"visibility": "public"}
             return {
                 "listing_id": listing_id,
                 "status": "active",
+                "visibility": "public",
                 "release": {"release_status": "published"},
                 "quality": {"overall_score": 84, "grade": "B"},
             }
@@ -1297,10 +1367,11 @@ def test_register_support_and_usage_commands(monkeypatch, tmp_path) -> None:
                 validation_ok=True,
             )
 
-        def confirm_registration(self, listing_id: str):
+        def confirm_registration(self, listing_id: str, **kwargs):
             return SimpleNamespace(
                 listing_id=listing_id,
                 status="active",
+                visibility=kwargs.get("visibility"),
                 quality=SimpleNamespace(overall_score=85, grade="B"),
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -846,7 +846,6 @@ def test_register_private_confirm_keeps_listing_non_public(monkeypatch, tmp_path
             return SimpleNamespace(
                 listing_id=listing_id,
                 status="hidden",
-                visibility="private",
                 release={"release_status": "published"},
                 quality=SimpleNamespace(overall_score=92, grade="A"),
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -302,6 +302,7 @@ def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: P
 
         if request.url.path == "/v1/market/capabilities/lst_123/confirm-auto-register":
             assert body["approved"] is True
+            assert body["visibility"] == "public"
             assert "overrides" not in body
             return httpx.Response(
                 200,
@@ -309,6 +310,7 @@ def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: P
                     {
                         "listing_id": "lst_123",
                         "status": "active",
+                        "visibility": "public",
                         "message": "Listing published automatically after the self-serve checks passed.",
                         "checklist": {"docs_url": True, "seller_onboarding": True},
                         "release": {"release_id": "rel_123", "release_status": "published"},
@@ -352,6 +354,7 @@ def test_auto_register_and_confirm_registration_return_typed_objects(tmp_path: P
     assert receipt.listing_status == "active"
     assert confirmation.listing_id == "lst_123"
     assert confirmation.status == "active"
+    assert confirmation.visibility == "public"
     assert confirmation.message.startswith("Listing published automatically")
     assert confirmation.checklist["docs_url"] is True
     assert confirmation.quality.overall_score == 84
@@ -370,6 +373,43 @@ def test_confirm_registration_rejects_non_string_version_bump() -> None:
     with build_client(handler) as client:
         with pytest.raises(SiglumeClientError, match="version_bump must be one of"):
             client.confirm_registration("lst_123", version_bump=[])  # type: ignore[arg-type]
+
+
+def test_confirm_registration_accepts_private_visibility() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        assert request.url.path == "/v1/market/capabilities/lst_123/confirm-auto-register"
+        assert body == {"approved": True, "visibility": "private"}
+        return httpx.Response(
+            200,
+            json=envelope(
+                {
+                    "listing_id": "lst_123",
+                    "status": "hidden",
+                    "visibility": "private",
+                    "message": "Listing confirmed privately.",
+                    "checklist": {"docs_url": True},
+                    "release": {"release_id": "rel_123", "release_status": "published"},
+                    "quality": {"overall_score": 88, "grade": "A", "issues": [], "improvement_suggestions": []},
+                }
+            ),
+        )
+
+    with build_client(handler) as client:
+        confirmation = client.confirm_registration("lst_123", visibility="private")
+
+    assert confirmation.status == "hidden"
+    assert confirmation.visibility == "private"
+    assert confirmation.release["release_id"] == "rel_123"
+
+
+def test_confirm_registration_rejects_invalid_visibility() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Validation should fail before transport: {request.method} {request.url}")
+
+    with build_client(handler) as client:
+        with pytest.raises(SiglumeClientError, match="visibility must be one of"):
+            client.confirm_registration("lst_123", visibility="team")  # type: ignore[arg-type]
 
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,8 @@ from siglume_api_sdk import (  # noqa: E402
     PersistenceMode,
     PersistencePolicy,
     PriceModel,
+    RegistrationConfirmation,
+    RegistrationQuality,
     ListingCurrency,
     SiglumeAPIError,
     SiglumeClient,
@@ -39,6 +41,20 @@ def envelope(data, *, trace_id: str = "trc_test", request_id: str = "req_test") 
         "meta": {"request_id": request_id, "trace_id": trace_id},
         "error": None,
     }
+
+
+def test_registration_confirmation_positional_order_is_compatible() -> None:
+    quality = RegistrationQuality(overall_score=90, grade="A")
+    confirmation = RegistrationConfirmation(
+        "lst_123",
+        "active",
+        {"release_status": "published"},
+        quality,
+    )
+
+    assert confirmation.release == {"release_status": "published"}
+    assert confirmation.quality is quality
+    assert confirmation.visibility is None
 
 
 def build_manifest() -> AppManifest:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -75,7 +75,8 @@ def test_readme_keeps_coding_agent_prompt() -> None:
     assert "Start as a FREE and READ_ONLY API" in readme
     assert "siglume preflight ." in readme
     assert "siglume register . --draft-only" in readme
-    assert "Do not run `siglume register .` unless I explicitly approve immediate publish" in readme
+    assert "Do not run `siglume register .` unless I explicitly approve immediate public publish" in readme
+    assert "siglume register . --private-confirm" in readme
     assert "## Default beginner path" in agent_guide
     assert "Start with a free, read-only API" in agent_guide
     assert "Do not run plain siglume register . unless I explicitly approve immediate" in agent_guide
@@ -88,7 +89,7 @@ def test_docs_do_not_advertise_removed_register_flags() -> None:
             _read("README.md"),
             _read("GETTING_STARTED.md"),
             _read("docs/publish-flow.md"),
-            _read("release-notes/RELEASE_NOTES_v0.7.5.md"),
+            _read_optional("release-notes/RELEASE_NOTES_v0.7.5.md"),
         ]
     )
 
@@ -179,7 +180,9 @@ def test_public_docs_keep_submitted_registration_content_immutable() -> None:
     assert '"overrides": {' not in docs
     assert "Submitted listing content is read-only in the portal." in docs
     assert "confirmation approves the submitted draft but does\n  not edit its content" in docs
-    assert "current SDKs\n        confirm with approved=true only" in openapi
+    assert 'visibility: "private"' in openapi
+    assert "approved=true plus optional\n        visibility" in openapi
+    assert "do not send post-draft content edits" in openapi
     assert "deprecated: true" in openapi
 
 


### PR DESCRIPTION
Documents and exposes private registration confirmation in the public SDK so developers can test a confirmed production release while the listing remains hidden.\n\nVerification:\n- pytest tests/test_client.py tests/test_cli.py tests/test_docs_contract.py -q\n- npm exec vitest run test/client.test.ts test/cli.test.ts\n- npm run typecheck