### PR TITLE
release: prepare v3.1.0 private confirmation SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-29
+
+### Added
+
+- **Private registration confirmation.** Python and TypeScript CLIs now support
+  `siglume register . --private-confirm`, which runs the normal registration
+  checks and creates an executable release while keeping the listing hidden for
+  seller production testing.
+- `confirm_registration(..., visibility="private")` in Python and
+  `confirm_registration(listingId, { visibility: "private" })` in TypeScript.
+  The default remains public confirmation.
+
+### Changed
+
+- Publish-flow docs now describe the safe production-testing path:
+  use `--private-confirm` first, test the hidden confirmed release in production,
+  then rerun plain `siglume register .` only when public launch is approved.
+
+### Fixed
+
+- The CLI result normalization keeps private-confirm wording stable even when an
+  older server response omits the confirmation visibility field.
+- Python `RegistrationConfirmation` keeps positional compatibility while adding
+  the optional `visibility` field.
+
 ## [3.0.0] - 2026-06-27
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v3.0.0.** Python and TypeScript are version-aligned and
+> **Current release: v3.1.0.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
@@ -75,10 +75,14 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 > publishing surface — `AppManifest.publisher_type` / `company_id`, the
 > `siglume companies` command, the `--company` / `--company-slug` register flags,
 > and the company listing/approval client methods (BREAKING; individual
-> publishing is unaffected — just drop those fields). Buyers' own AIs select
+> publishing is unaffected — just drop those fields); **3.1.0** added
+> private confirmation so `siglume register . --private-confirm` creates an
+> executable release while keeping the listing hidden for production testing.
+> Buyers' own AIs select
 > your API from its Tool Manual over MCP; Siglume resolves and dispatches (no
 > platform tool-selection loop on the connector path).
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v3.1.0.md](./release-notes/RELEASE_NOTES_v3.1.0.md),
 > [RELEASE_NOTES_v3.0.0.md](./release-notes/RELEASE_NOTES_v3.0.0.md),
 > [RELEASE_NOTES_v2.0.5.md](./release-notes/RELEASE_NOTES_v2.0.5.md),
 > [RELEASE_NOTES_v2.0.4.md](./release-notes/RELEASE_NOTES_v2.0.4.md), and
@@ -863,7 +867,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v3.0.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v3.1.0 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with paid API Store settlement live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
 The user base is still growing, and new SDK surfaces continue to ship

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "3.0.0"
+version = "3.1.0"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/release-notes/RELEASE_NOTES_v3.1.0.md
+++ b/release-notes/RELEASE_NOTES_v3.1.0.md
@@ -1,0 +1,24 @@
+# v3.1.0 - private registration confirmation
+
+This release ships the SDK side of Siglume's private confirmation flow.
+Publishers can now confirm an auto-registered API, create the executable
+release, and test it in production while the listing stays hidden from the
+public catalog.
+
+## Highlights
+
+- `siglume register . --private-confirm` runs the normal preflight and
+  auto-register path, then confirms the release privately instead of publishing
+  the listing.
+- Python clients can call
+  `confirm_registration(listing_id, visibility="private")`.
+- TypeScript clients can call
+  `confirm_registration(listingId, { visibility: "private" })`.
+- Docs now describe the intended flow: private-confirm, test in production, then
+  rerun plain `siglume register .` only when public launch is approved.
+
+## Upgrade Notes
+
+The default behavior is unchanged: `siglume register .` still confirms and
+publishes publicly when all checks pass. Use `--private-confirm` when you need a
+hidden production-testing step.

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "3.0.0";
+export const SDK_VERSION = "3.1.0";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "3.0.0"
+SDK_VERSION = "3.1.0"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -103,7 +103,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "3.0.0"
+    assert python_version == "3.1.0"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -118,7 +118,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v3.0.0 (beta)**" in readme
+    assert "This is **v3.1.0 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security


### PR DESCRIPTION
## Summary
- bump Python and TypeScript SDK versions to 3.1.0
- add release notes and changelog for private registration confirmation
- update README release metadata and runtime SDK version constants

## Validation
- py -3.11 -m pytest -q
- py -3.11 scripts/contract_sync.py
- npm run typecheck
- npm run test -- --coverage.enabled=false
- npm run build
- npm run pack:check