### PR TITLE
[codex] release v3.1.1 artifact delivery docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-06-29
+
+### Added
+
+- **Artifact delivery docs.** Added `docs/artifact-delivery.md` to make the
+  output-custody contract explicit: Siglume brokers the request and response but
+  does not host output bytes. Publishers host artifacts themselves and choose
+  either Model B (immediate `ExecutionArtifact.external_url`, such as a
+  presigned object-store GET) or Model A (durable `job_id` plus a free
+  `get_result` operation as documented in the async two-phase guide).
+
+### Changed
+
+- Clarified that `external_url` can point to publisher-hosted download bytes,
+  not only provider permalinks, and cross-linked the async two-phase guide as
+  the canonical Model A claim-ticket pattern.
+- Documented the retrieval identity rule for publisher-hosted artifacts:
+  validate `owner_user_id` from `ExecutionContext` together with the
+  publisher-issued durable id (`job_id`, `media_id`, or `artifact_id`), reject
+  missing/sentinel owners, and do not treat `siglume-handle` file inputs as an
+  output-custody mechanism.
+
 ## [3.1.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v3.1.0.** Python and TypeScript are version-aligned and
+> **Current release: v3.1.1.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
@@ -77,11 +77,15 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 > and the company listing/approval client methods (BREAKING; individual
 > publishing is unaffected — just drop those fields); **3.1.0** added
 > private confirmation so `siglume register . --private-confirm` creates an
-> executable release while keeping the listing hidden for production testing.
+> executable release while keeping the listing hidden for production testing;
+> **3.1.1** documents publisher-hosted artifact delivery: immediate
+> `external_url` links or async `job_id` claim tickets, with retrieval scoped to
+> `owner_user_id` plus the publisher's durable id.
 > Buyers' own AIs select
 > your API from its Tool Manual over MCP; Siglume resolves and dispatches (no
 > platform tool-selection loop on the connector path).
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v3.1.1.md](./release-notes/RELEASE_NOTES_v3.1.1.md),
 > [RELEASE_NOTES_v3.1.0.md](./release-notes/RELEASE_NOTES_v3.1.0.md),
 > [RELEASE_NOTES_v3.0.0.md](./release-notes/RELEASE_NOTES_v3.0.0.md),
 > [RELEASE_NOTES_v2.0.5.md](./release-notes/RELEASE_NOTES_v2.0.5.md),
@@ -821,6 +825,7 @@ See [API_IDEAS.md](API_IDEAS.md) for more ideas.
 | [Dry Run and Approval](docs/dry-run-and-approval.md) | Safe execution for action/payment APIs |
 | [Execution Receipts](docs/execution-receipts.md) | What to return after execution, and the result wire shape |
 | [Async / Long-Running Two-Phase APIs](docs/async-two-phase-apis.md) | Accept a long job (`quote → accepted+job_id → free get_result`) and settle on acceptance |
+| [Artifact Delivery](docs/artifact-delivery.md) | Where output bytes live (you host them), with Model B `external_url` links and Model A async `job_id` claim tickets scoped by `owner_user_id` |
 | [API Manifest Schema](schemas/app-manifest.schema.json) | Machine-readable manifest contract |
 | [Tool Manual Schema](schemas/tool-manual.schema.json) | Machine-readable tool manual contract |
 
@@ -867,7 +872,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v3.1.0 (beta)** — the platform is launched on Polygon mainnet
+This is **v3.1.1 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with paid API Store settlement live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
 The user base is still growing, and new SDK surfaces continue to ship

--- a/docs/artifact-delivery.md
+++ b/docs/artifact-delivery.md
@@ -1,0 +1,87 @@
+# Artifact delivery: where your output bytes live, and how the buyer fetches them
+
+**Siglume does not host your output files.** The platform brokers the *request* and relays
+your *response*; it never stores, hosts, or re-serves the bytes a buyer downloads. So if your
+API produces a file — a rendered video, a transcript, a converted document — **you host it and
+return a reference**. There is no platform-side artifact store to depend on.
+
+You have **two first-class delivery models**, and you choose freely between them by how long the
+work takes. Both are publisher-self-hosted; neither is more "official" than the other.
+
+| | **Model B — immediate link** | **Model A — async claim-ticket** |
+|---|---|---|
+| Use when | The result is ready within the invoke timeout (1–20s) | The work outlives the request (long transcode, batch render, multi-minute analysis) |
+| What you return | `ExecutionArtifact.external_url` → a link to bytes **you** host | An accepted-job envelope with a durable `job_id`; the buyer collects later via a free `get_result` |
+| Retrieval | The buyer opens the URL returned for this execution | The buyer polls a free terminal op with the `job_id` |
+| Retention / signing | Yours — keep the URL short-lived, and re-mint it only after an owner check if you expose a reissue path | Yours — define a retention window and re-issue links on each `get_result` |
+| Full spec | This page + [Execution Receipts](./execution-receipts.md) | [Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md) |
+
+## Model B — immediate link (`external_url`)
+
+When your result is ready inline, return a link to it in `ExecutionArtifact.external_url`
+(see [Execution Receipts → ExecutionArtifact](./execution-receipts.md#executionartifact)).
+`external_url` is **not** limited to a public permalink on a third-party provider — it is equally
+the place to return a **download link to bytes you host yourself**, e.g. an S3 (or any object
+store) **presigned GET URL** with a short TTL:
+
+```python
+ExecutionArtifact(
+    artifact_type="video",
+    external_url=presigned_get_url,   # https://<your-bucket>.s3.<region>.amazonaws.com/key?...&X-Amz-Expires=3600
+    title="Edited clip (30s)",
+)
+```
+
+Host the object in your own bucket, mint the presigned URL at response time so it is always
+fresh, and return it. The platform relays the URL to the agent and never fetches the bytes
+itself. Treat a presigned URL as a short-lived bearer URL: anyone who has it can use it until
+it expires. If you need a longer retrieval window, store the artifact under
+`(owner_user_id, artifact_id)` and expose a free reissue/status path that verifies the owner
+before minting a fresh `external_url`.
+
+## Model A — async claim-ticket (durable `job_id` + free `get_result`)
+
+When the work cannot finish inside the invoke window, do not block — **accept the job, settle the
+charge, and deliver later**. Return a durable `job_id`; the buyer keeps it and later calls a
+**free** terminal operation (`get_result`) to collect the artifacts. This is the *claim-ticket*
+model: the `job_id` is the ticket, redeemable at any time within a retention window **you**
+define, **from any session** — the buyer can leave the chat and come back for the result.
+Storage, retention, and URL signing all stay with you; the platform retains nothing.
+
+The full contract — the three legs, the wire shape, retention, and the failed-job obligation —
+lives in **[Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md)**; that pattern *is*
+Model A. Inside `get_result`, deliver each artifact exactly as in Model B — an `external_url` to
+bytes you host — re-issued fresh on every poll.
+
+## Ownership & identity — all you need for secure, session-independent retrieval
+
+Artifact retrieval often happens *later* and *from another session*. The rule that keeps a
+buyer's artifacts private is: **scope every durable lookup or URL reissue on the owner plus
+your own durable id.**
+
+- The platform stamps **`owner_user_id`** (and `agent_id`) onto every `ExecutionContext`
+  (see the [type reference](../siglume-api-types.ts)). You do **not** authenticate the buyer
+  yourself — the platform already has, and hands you their identity on each call.
+- **You** issue the durable id — `job_id`, `media_id`, or `artifact_id`.
+- Store every durable artifact record keyed by **`(owner_user_id, your_id)`**, and on every
+  `get_result`, status, or signed-URL reissue path look it up by **both**. A request carrying
+  someone else's `job_id` then returns nothing, because it does not match the caller's
+  `owner_user_id`.
+
+That pairing — **`owner_user_id` (from the platform) + a durable id (from you)** — *is* the whole
+identity contract for publisher-hosted retrieval. It gives you secure collection that survives
+the buyer leaving the chat, **with no platform-hosted artifact store**. Reject the empty /
+sentinel owner (`owner_user_id` missing, or the literal `"siglume"`) before serving or
+reissuing anything.
+
+> **Inputs use a different mechanism — do not confuse them.** A buyer *sending* a file *into*
+> your API uses the MCP file-input handle (`{"format": "siglume-handle"}`; see
+> [Core Concepts → MCP file inputs](./sdk-core-concepts.md#mcp-file-inputs)). Siglume brokers
+> that **input** for the current call only and does not persist it. There is **no** matching
+> platform-hosted mechanism for **outputs** — outputs are always Model A or Model B above.
+
+## Related
+
+- [Execution Receipts](./execution-receipts.md) — the `ExecutionArtifact` / `external_url` shape (Model B).
+- [Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md) — the full claim-ticket contract (Model A).
+- [Platform / API Responsibility Boundary](./platform-api-boundary.md) — what Siglume owns vs what you own.

--- a/docs/async-two-phase-apis.md
+++ b/docs/async-two-phase-apis.md
@@ -18,6 +18,11 @@ first — everything there still applies.
 > [Platform / API boundary](./platform-api-boundary.md). Async is only for work that
 > outlives the request.
 
+> This async pattern is **Model A** in [Artifact Delivery](./artifact-delivery.md) — the
+> durable-`job_id` claim-ticket delivery model. That page frames *where output bytes live*
+> (you host them, the platform does not) and contrasts Model A with Model B (an immediate
+> `external_url` link), scoping both on `owner_user_id` + your durable id.
+
 ## The three legs at a glance
 
 | Leg | `execution_kind` | `output` carries | `receipt_summary.operation` | `amount_minor` | Charged? |

--- a/docs/execution-receipts.md
+++ b/docs/execution-receipts.md
@@ -89,7 +89,7 @@ Describes what was produced.
 |-------|----------|-------------|
 | `artifact_type` | yes | e.g. "image", "social_post", "calendar_event" |
 | `external_id` | no | Provider-side ID (tweet ID, event ID, etc.) |
-| `external_url` | no | Link to the artifact on the provider |
+| `external_url` | no | Link to the artifact — a provider permalink, **or** a download link to bytes you host yourself (e.g. an S3 presigned GET). See [Artifact Delivery](./artifact-delivery.md). |
 | `title` | no | Human-readable label |
 | `summary` | no | Brief description |
 | `metadata` | no | Extra provider-specific data |

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -168,4 +168,5 @@ such as images and documents; the current decoded size limit is 25 MB.
 - [Permission Scopes](./permission-scopes.md) - how to choose the minimum safe tier
 - [Dry Run and Approval](./dry-run-and-approval.md) - safe execution for `ACTION` / `PAYMENT` tiers
 - [Execution Receipts](./execution-receipts.md) - what to return after execution
+- [Artifact Delivery](./artifact-delivery.md) - where output bytes live (you host them), with Model B `external_url` links and Model A async `job_id` claim tickets scoped by `owner_user_id`
 - [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) - open-source decision logic used after you publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "3.1.0"
+version = "3.1.1"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/release-notes/RELEASE_NOTES_v3.1.1.md
+++ b/release-notes/RELEASE_NOTES_v3.1.1.md
@@ -1,0 +1,24 @@
+# v3.1.1 - artifact delivery docs
+
+This release documents the official artifact-delivery contract for APIs that
+produce output files.
+
+## Highlights
+
+- Added `docs/artifact-delivery.md`.
+- Clarified that Siglume does not host output bytes. Publishers host the bytes
+  themselves and return references.
+- Documented the two supported delivery models:
+  - **Model B:** return an immediate `ExecutionArtifact.external_url`, such as a
+    short-lived presigned object-store GET URL.
+  - **Model A:** return a durable `job_id` and let the buyer collect later
+    through a free `get_result` operation.
+- Cross-linked the async two-phase guide as the canonical Model A claim-ticket
+  pattern.
+- Clarified that `siglume-handle` is for input file transport only, not output
+  custody.
+
+## Upgrade Notes
+
+No Python or TypeScript runtime behavior changes. This is a documentation
+release that makes the publisher-hosted output custody model explicit.

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "3.1.0";
+export const SDK_VERSION = "3.1.1";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "3.1.0"
+SDK_VERSION = "3.1.1"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -103,7 +103,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "3.1.0"
+    assert python_version == "3.1.1"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -118,7 +118,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v3.1.0 (beta)**" in readme
+    assert "This is **v3.1.1 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security
@@ -383,3 +383,32 @@ def test_developer_observability_docs_explain_logs_receipts_and_privacy() -> Non
     assert "def list_execution_receipts" in client
     assert "def list_listing_recent_receipts" in client
     assert "list_installed_tool_receipts" in ts_client
+
+
+def test_artifact_delivery_docs_pin_publisher_hosted_output_contract() -> None:
+    artifact_delivery = _read("docs/artifact-delivery.md")
+    execution_receipts = _read("docs/execution-receipts.md")
+    async_two_phase = _read("docs/async-two-phase-apis.md")
+    sdk_core = _read("docs/sdk-core-concepts.md")
+    readme = _read("README.md")
+    normalized = " ".join(artifact_delivery.split())
+
+    assert "Siglume does not host your output files." in artifact_delivery
+    assert "There is no platform-side artifact store to depend on." in artifact_delivery
+    assert "Model B" in artifact_delivery
+    assert "Model A" in artifact_delivery
+    assert "ExecutionArtifact.external_url" in artifact_delivery
+    assert "presigned GET URL" in artifact_delivery
+    assert "durable `job_id`" in artifact_delivery
+    assert "free `get_result`" in artifact_delivery
+    assert "(owner_user_id, artifact_id)" in artifact_delivery
+    assert "`owner_user_id` (from the platform) + a durable id (from you)" in artifact_delivery
+    assert 'the literal `"siglume"`' in artifact_delivery
+    assert "`{\"format\": \"siglume-handle\"}`" in artifact_delivery
+    assert "platform-hosted mechanism for **outputs**" in normalized
+    assert "outputs are always Model A or Model B" in normalized
+
+    assert "Artifact Delivery" in readme
+    assert "download link to bytes you host yourself" in execution_receipts
+    assert "This async pattern is **Model A**" in async_two_phase
+    assert "Artifact Delivery" in sdk_core


### PR DESCRIPTION
## Summary

- Add `docs/artifact-delivery.md` documenting publisher-hosted output custody, Model B immediate `external_url` delivery, and Model A async `job_id` claim-ticket delivery.
- Clarify related docs so `external_url` includes publisher-hosted download links, and cross-link the async two-phase guide as Model A.
- Prepare the public SDK release as `v3.1.1` across Python and TypeScript metadata, changelog, release notes, and docs-contract coverage.

## Why

This makes the public SDK docs match the platform boundary: Siglume brokers the request and response, but publishers host output bytes and return references. Retrieval is scoped by `owner_user_id` plus the publisher-issued durable id; `siglume-handle` remains input-only.

## Validation

- `D:\Users\taihei2\AppData\Local\Programs\Python\Python311\python.exe -m pytest tests\test_docs_contract.py -q`
- `git diff --check`
- `npm --prefix siglume-api-sdk-ts run typecheck`
- `py -3.11 -m build`
- `npm --prefix siglume-api-sdk-ts run test -- --coverage.enabled=false`
- `npm --prefix siglume-api-sdk-ts run build`
- `py -3.11 -m twine check dist\*`
- `npm --prefix siglume-api-sdk-ts run pack:check`