### PR TITLE
[codex] release v3.1.2 artifact delivery examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2026-06-29
+
+### Added
+
+- **Copy-pasteable artifact delivery recipes.** Expanded
+  `docs/artifact-delivery.md` with a complete Model B `execute()` example,
+  boto3 `put_object` / `generate_presigned_url` guidance, Model A skeleton,
+  free reissue/get-result states, and a security checklist.
+- **Runnable signed-URL artifact example.** Added
+  `examples/artifact_delivery_presigned.py`, a runnable `AppAdapter` that
+  returns both `ExecutionArtifact.external_url` and `output.download_url`, stores
+  artifacts by `(owner_user_id, artifact_id)`, and exposes a free owner-scoped
+  `get_artifact` reissue operation.
+
+### Changed
+
+- Clarified the live-runtime identity bridge: production HTTP calls receive
+  `X-Siglume-Platform-User-Id`, while the SDK runtime and `AppTestHarness`
+  surface that same value as `ExecutionContext.owner_user_id`.
+- Cross-linked artifact delivery from Getting Started and the platform/API
+  boundary, and documented that `siglume-handle` remains input-only.
+- Relaxed the Model A wording so large/binary async results are typically
+  returned via `external_url`, while small text artifacts may be returned inline
+  when that is the product contract. `examples/async_transcription.py` now
+  states that its inline transcript is intentionally simplified.
+
 ## [3.1.1] - 2026-06-29
 
 ### Added

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -797,7 +797,10 @@ instead *accept* the job and deliver later — `{accepted: true, job_id, status:
 is an accepted-deferred result, not a non-delivery; see
 [Async / long-running two-phase APIs](docs/async-two-phase-apis.md).) Read
 [Platform / API Responsibility Boundary](docs/platform-api-boundary.md) before
-building paid action APIs.
+building paid action APIs. If your API returns files, read
+[Artifact Delivery](docs/artifact-delivery.md): output bytes are publisher-hosted,
+and durable retrieval must be scoped by `X-Siglume-Platform-User-Id` /
+`ExecutionContext.owner_user_id` plus your `artifact_id` or `job_id`.
 
 ### Generic reward payouts through MCP
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 
 > 🎬 **Demo recording in progress** — the image above is a placeholder. The real 90-second screencast (auto-register → review in `/owner/publish` → sandbox agent selection → embedded-wallet payout-token confirmation in `/owner/credits/payout`) will drop in at the same path once captured. See [docs/demo-capture-guide.md](./docs/demo-capture-guide.md) for the script.
 
-> **Current release: v3.1.1.** Python and TypeScript are version-aligned and
+> **Current release: v3.1.2.** Python and TypeScript are version-aligned and
 > cover the current production registration surface: explicit Tool Manual input,
 > runtime validation, publisher-owned external OAuth, paid payout readiness,
 > capability bundles, webhooks, usage metering, typed Web3 settlement helpers,
@@ -80,11 +80,13 @@ Siglume's public SDK targets the **Agent API Store**: you publish an API once, a
 > executable release while keeping the listing hidden for production testing;
 > **3.1.1** documents publisher-hosted artifact delivery: immediate
 > `external_url` links or async `job_id` claim tickets, with retrieval scoped to
-> `owner_user_id` plus the publisher's durable id.
+> `owner_user_id` plus the publisher's durable id; **3.1.2** adds copy-pasteable
+> artifact delivery recipes and a runnable signed-URL example.
 > Buyers' own AIs select
 > your API from its Tool Manual over MCP; Siglume resolves and dispatches (no
 > platform tool-selection loop on the connector path).
 > See [CHANGELOG.md](./CHANGELOG.md),
+> [RELEASE_NOTES_v3.1.2.md](./release-notes/RELEASE_NOTES_v3.1.2.md),
 > [RELEASE_NOTES_v3.1.1.md](./release-notes/RELEASE_NOTES_v3.1.1.md),
 > [RELEASE_NOTES_v3.1.0.md](./release-notes/RELEASE_NOTES_v3.1.0.md),
 > [RELEASE_NOTES_v3.0.0.md](./release-notes/RELEASE_NOTES_v3.0.0.md),
@@ -774,7 +776,7 @@ your payment adapter without touching a live wallet.
 
 ## Example templates
 
-`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `async_transcription.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
+`hello_echo.py`, `hello_price_compare.py`, `x_publisher.py`, `calendar_sync.py`, `email_sender.py`, `translation_hub.py`, `payment_quote.py`, `async_transcription.py`, `artifact_delivery_presigned.py`, `polygon_mandate_adapter.py`, and `embedded_wallet_payment.ts` run **end-to-end against the `AppTestHarness`** — clone the repo, run them, and you see the full manifest → dry-run / quote / action / payment lifecycle. `agent_behavior_adapter.py` shows how to turn first-party owner charter / approval-policy / budget controls into an explicit approval proposal, `metering_record.py` shows usage-event ingest plus deterministic invoice previewing, and the Web3 examples show typed settlement reads plus local mandate / receipt simulation. `visual_publisher.py` and `metamask_connector.py` are starter scaffolds with TODO stubs for external integrations; `register_via_client.py` shows the typed HTTP client flow.
 
 | Example | Permission | Runnable e2e | Description |
 |---|---|---|---|
@@ -786,6 +788,7 @@ your payment adapter without touching a live wallet.
 | [translation_hub.py](./examples/translation_hub.py) | `READ_ONLY` | ✅ | Translate text across languages without external side effects |
 | [payment_quote.py](./examples/payment_quote.py) | `PAYMENT` | ✅ | Preview, quote, and complete a USD payment flow |
 | [async_transcription.py](./examples/async_transcription.py) | `ACTION` (prepay / async) | ✅ | Accept a long job (`quote → {accepted, job_id} → free get_result`), settling on acceptance, with idempotent accept + running/failed states |
+| [artifact_delivery_presigned.py](./examples/artifact_delivery_presigned.py) | `ACTION` | ✅ | Return publisher-hosted artifacts via signed `external_url` links and a free owner-scoped reissue op |
 | [agent_behavior_adapter.py](./examples/agent_behavior_adapter.py) | `ACTION` | ✅ | Propose charter / approval-policy / budget changes for owner review |
 | [metering_record.py](./examples/metering_record.py) | client | ✅ | Record usage events and preview invoice lines |
 | [polygon_mandate_adapter.py](./examples/polygon_mandate_adapter.py) | `PAYMENT` | ✅ | Simulate a Polygon mandate payment with embedded-wallet settlement receipts |
@@ -872,7 +875,7 @@ write a strong tool manual, and let the value speak for itself.
 
 ## Project status
 
-This is **v3.1.1 (beta)** — the platform is launched on Polygon mainnet
+This is **v3.1.2 (beta)** — the platform is launched on Polygon mainnet
 (chainId 137) with paid API Store settlement live on-chain, and the SDK has
 reached parity with the production registration and operation surface.
 The user base is still growing, and new SDK surfaces continue to ship

--- a/docs/artifact-delivery.md
+++ b/docs/artifact-delivery.md
@@ -2,58 +2,146 @@
 
 **Siglume does not host your output files.** The platform brokers the *request* and relays
 your *response*; it never stores, hosts, or re-serves the bytes a buyer downloads. So if your
-API produces a file — a rendered video, a transcript, a converted document — **you host it and
+API produces a file - a rendered video, a transcript, a converted document - **you host it and
 return a reference**. There is no platform-side artifact store to depend on.
 
 You have **two first-class delivery models**, and you choose freely between them by how long the
 work takes. Both are publisher-self-hosted; neither is more "official" than the other.
 
-| | **Model B — immediate link** | **Model A — async claim-ticket** |
+| | **Model B - immediate link** | **Model A - async claim-ticket** |
 |---|---|---|
-| Use when | The result is ready within the invoke timeout (1–20s) | The work outlives the request (long transcode, batch render, multi-minute analysis) |
-| What you return | `ExecutionArtifact.external_url` → a link to bytes **you** host | An accepted-job envelope with a durable `job_id`; the buyer collects later via a free `get_result` |
+| Use when | The result is ready within the invoke timeout (1-20s) | The work outlives the request (long transcode, batch render, multi-minute analysis) |
+| What you return | `ExecutionArtifact.external_url` -> a link to bytes **you** host | An accepted-job envelope with a durable `job_id`; the buyer collects later via a free `get_result` |
 | Retrieval | The buyer opens the URL returned for this execution | The buyer polls a free terminal op with the `job_id` |
-| Retention / signing | Yours — keep the URL short-lived, and re-mint it only after an owner check if you expose a reissue path | Yours — define a retention window and re-issue links on each `get_result` |
+| Retention / signing | Yours - keep the URL short-lived, and re-mint it only after an owner check if you expose a reissue path | Yours - define a retention window and re-issue links on each `get_result` |
 | Full spec | This page + [Execution Receipts](./execution-receipts.md) | [Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md) |
 
-## Model B — immediate link (`external_url`)
+## Model B - immediate link (`external_url`)
 
 When your result is ready inline, return a link to it in `ExecutionArtifact.external_url`
-(see [Execution Receipts → ExecutionArtifact](./execution-receipts.md#executionartifact)).
-`external_url` is **not** limited to a public permalink on a third-party provider — it is equally
+(see [Execution Receipts -> ExecutionArtifact](./execution-receipts.md#executionartifact)).
+`external_url` is **not** limited to a public permalink on a third-party provider - it is equally
 the place to return a **download link to bytes you host yourself**, e.g. an S3 (or any object
-store) **presigned GET URL** with a short TTL:
+store) **presigned GET URL** with a short TTL.
+
+Return the same URL in both places:
+
+- `artifacts=[ExecutionArtifact(..., external_url=download_url)]` for the structured receipt.
+- `output["download_url"] = download_url` for the agent/human-facing result body.
+
+The agent normally presents the link to the buyer. It does not need to fetch or proxy the bytes.
+
+### Complete `execute()` example
 
 ```python
-ExecutionArtifact(
-    artifact_type="video",
-    external_url=presigned_get_url,   # https://<your-bucket>.s3.<region>.amazonaws.com/key?...&X-Amz-Expires=3600
-    title="Edited clip (30s)",
-)
+import os
+import uuid
+import boto3
+
+from siglume_api_sdk import ExecutionArtifact, ExecutionKind, ExecutionResult
+
+s3 = boto3.client("s3")
+BUCKET = os.environ["ARTIFACT_BUCKET"]
+
+
+def render_report(params: dict) -> bytes:
+    title = params.get("title") or "Siglume artifact"
+    return f"# {title}\n\nRendered report body.\n".encode("utf-8")
+
+
+async def execute(self, ctx):
+    if ctx.execution_kind == ExecutionKind.DRY_RUN:
+        return ExecutionResult(success=True, output={"summary": "Would render and return a signed download link."})
+
+    artifact_id = f"art_{uuid.uuid4().hex}"
+    key = f"artifacts/{artifact_id}.md"
+    body = render_report(ctx.input_params)
+    content_type = "text/markdown; charset=utf-8"
+
+    s3.put_object(Bucket=BUCKET, Key=key, Body=body, ContentType=content_type)
+    download_url = s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": BUCKET, "Key": key},
+        ExpiresIn=3600,
+    )
+
+    artifact = ExecutionArtifact(
+        artifact_type="document",
+        external_id=artifact_id,
+        external_url=download_url,
+        title="Rendered report",
+        metadata={"content_type": content_type, "expires_in_seconds": 3600},
+    )
+    return ExecutionResult(
+        success=True,
+        output={
+            "summary": "Rendered report is ready.",
+            "artifact_id": artifact_id,
+            "download_url": download_url,
+            "download_expires_in_seconds": 3600,
+        },
+        artifacts=[artifact],  # artifacts is a list; return one item per output file
+        receipt_summary={"action": "artifact_rendered", "artifact_id": artifact_id},
+    )
 ```
 
-Host the object in your own bucket, mint the presigned URL at response time so it is always
-fresh, and return it. The platform relays the URL to the agent and never fetches the bytes
-itself. Treat a presigned URL as a short-lived bearer URL: anyone who has it can use it until
-it expires. If you need a longer retrieval window, store the artifact under
-`(owner_user_id, artifact_id)` and expose a free reissue/status path that verifies the owner
-before minting a fresh `external_url`.
+Use instance role, workload identity, or environment-provided credentials. Do **not** hard-code
+object-store access keys in your adapter, Tool Manual, runtime validation, or git repo. S3 is only
+an example; Cloudflare R2, Google Cloud Storage, Azure Blob, or any object store is fine. The
+Siglume contract is only that `external_url` is an HTTPS GET link to bytes you host.
 
-## Model A — async claim-ticket (durable `job_id` + free `get_result`)
+Treat every presigned URL as a short-lived bearer URL: anyone who has it can use it until it
+expires. The default example TTL is `ExpiresIn=3600` (one hour). If you need a longer retrieval
+window, store the artifact under `(owner_user_id, artifact_id)` and expose a free `0`-priced
+reissue/status operation that verifies the owner before minting a fresh `external_url`.
 
-When the work cannot finish inside the invoke window, do not block — **accept the job, settle the
+### Reissue states for Model B
+
+For a durable `artifact_id`, make `get_artifact` / `reissue_artifact_url` a free operation.
+It should always look up by `(owner_user_id, artifact_id)`, never by `artifact_id` alone.
+
+| State | Response |
+|---|---|
+| found + fresh | Return `status: "found"`, a new `download_url`, and an `ExecutionArtifact.external_url`. |
+| not ready | Return `status: "not_ready"` and no URL. |
+| expired | Return `success: false`, `status: "expired"` and no URL. |
+| unknown or wrong owner | Return the same empty/expired shape; do not reveal whether the id exists for another owner. |
+
+## Model A - async claim-ticket (durable `job_id` + free `get_result`)
+
+When the work cannot finish inside the invoke window, do not block - **accept the job, settle the
 charge, and deliver later**. Return a durable `job_id`; the buyer keeps it and later calls a
 **free** terminal operation (`get_result`) to collect the artifacts. This is the *claim-ticket*
 model: the `job_id` is the ticket, redeemable at any time within a retention window **you**
-define, **from any session** — the buyer can leave the chat and come back for the result.
+define, **from any session** - the buyer can leave the chat and come back for the result.
 Storage, retention, and URL signing all stay with you; the platform retains nothing.
 
-The full contract — the three legs, the wire shape, retention, and the failed-job obligation —
+The full contract - the three legs, the wire shape, retention, and the failed-job obligation -
 lives in **[Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md)**; that pattern *is*
-Model A. Inside `get_result`, deliver each artifact exactly as in Model B — an `external_url` to
-bytes you host — re-issued fresh on every poll.
+Model A. Inside `get_result`, you typically deliver large/binary artifacts exactly as in Model B:
+an `external_url` to bytes you host, re-issued fresh on every poll. Small text artifacts can be
+returned inline when that is the product contract; [`examples/async_transcription.py`](../examples/async_transcription.py)
+does that for brevity, while [`examples/artifact_delivery_presigned.py`](../examples/artifact_delivery_presigned.py)
+shows the signed-URL pattern.
 
-## Ownership & identity — all you need for secure, session-independent retrieval
+Minimal skeleton:
+
+```python
+if "job_id" not in params:
+    job_id = enqueue_job(owner_user_id=ctx.owner_user_id, params=params)
+    return ExecutionResult(success=True, output={"accepted": True, "job_id": job_id, "status": "queued"})
+record = jobs.get((ctx.owner_user_id, params["job_id"]))
+if record is None:
+    return ExecutionResult(success=False, output={"status": "expired", "job_id": params["job_id"]})
+url = sign_get_url(record.object_key)
+return ExecutionResult(success=True, output={"status": "succeeded", "download_url": url}, artifacts=[ExecutionArtifact(artifact_type="document", external_id=params["job_id"], external_url=url)])
+```
+
+Settlement is final on acceptance. If your worker fails after accepting and charging, report
+`status: "failed"` through the free `get_result` operation and honor your own refund/repair
+policy. The platform does not auto-refund accepted async jobs.
+
+## Ownership & identity - all you need for secure, session-independent retrieval
 
 Artifact retrieval often happens *later* and *from another session*. The rule that keeps a
 buyer's artifacts private is: **scope every durable lookup or URL reissue on the owner plus
@@ -61,27 +149,70 @@ your own durable id.**
 
 - The platform stamps **`owner_user_id`** (and `agent_id`) onto every `ExecutionContext`
   (see the [type reference](../siglume-api-types.ts)). You do **not** authenticate the buyer
-  yourself — the platform already has, and hands you their identity on each call.
-- **You** issue the durable id — `job_id`, `media_id`, or `artifact_id`.
+  yourself - the platform already has, and hands you their identity on each call.
+- In a live HTTP deployment, the buyer identity arrives as the runtime header
+  **`X-Siglume-Platform-User-Id`**. The SDK runtime / `AppTestHarness` surfaces that value as
+  `ExecutionContext.owner_user_id`. After validating your runtime auth header, map
+  `X-Siglume-Platform-User-Id` to the same storage key you use in SDK code:
+  `(owner_user_id, artifact_id)` or `(owner_user_id, job_id)`. See
+  [Connected Accounts -> Runtime identity headers](./connected-accounts.md#runtime-identity-headers)
+  and [Getting Started -> Runtime invocation identity headers](../GETTING_STARTED.md#runtime-invocation-identity-headers).
+- **You** issue the durable id - `job_id` for Model A or `artifact_id` for Model B. If your API
+  uses another name such as `media_id`, document it as your publisher-defined durable id and
+  still scope it with `owner_user_id`.
 - Store every durable artifact record keyed by **`(owner_user_id, your_id)`**, and on every
   `get_result`, status, or signed-URL reissue path look it up by **both**. A request carrying
-  someone else's `job_id` then returns nothing, because it does not match the caller's
-  `owner_user_id`.
+  someone else's `job_id` or `artifact_id` then returns nothing, because it does not match the
+  caller's `owner_user_id`.
 
-That pairing — **`owner_user_id` (from the platform) + a durable id (from you)** — *is* the whole
+That pairing - **`owner_user_id` (from the platform) + a durable id (from you)** - is the whole
 identity contract for publisher-hosted retrieval. It gives you secure collection that survives
 the buyer leaving the chat, **with no platform-hosted artifact store**. Reject the empty /
 sentinel owner (`owner_user_id` missing, or the literal `"siglume"`) before serving or
 reissuing anything.
 
-> **Inputs use a different mechanism — do not confuse them.** A buyer *sending* a file *into*
-> your API uses the MCP file-input handle (`{"format": "siglume-handle"}`; see
-> [Core Concepts → MCP file inputs](./sdk-core-concepts.md#mcp-file-inputs)). Siglume brokers
-> that **input** for the current call only and does not persist it. There is **no** matching
-> platform-hosted mechanism for **outputs** — outputs are always Model A or Model B above.
+```python
+def valid_owner(owner_user_id: str | None) -> bool:
+    return bool(owner_user_id and owner_user_id.strip() and owner_user_id != "siglume")
+
+
+def lookup_for_reissue(ctx, artifact_id: str):
+    if not valid_owner(ctx.owner_user_id):
+        return {"success": False, "status": "unauthorized"}
+    record = artifact_store.get((ctx.owner_user_id, artifact_id))
+    if record is None:
+        return {"success": False, "status": "expired"}  # unknown or wrong owner
+    return {"success": True, "status": "found", "record": record}
+```
+
+## Security checklist
+
+- Use a short TTL for signed URLs; `ExpiresIn=3600` is a reasonable default.
+- Validate `owner_user_id` and your durable id together before every `get_result` or URL reissue.
+- Reject missing, empty, or sentinel owners such as `"siglume"` before serving anything.
+- Do not log signed URLs, object-store credentials, or raw file bytes.
+- Return only HTTPS GET links in `external_url`.
+- Set `ContentType` when writing the object so browsers and agents display it correctly.
+- Make reissue/get-result operations free (`0`-priced) and read-only.
+
+## Worked example
+
+See [`examples/artifact_delivery_presigned.py`](../examples/artifact_delivery_presigned.py) for
+a runnable `AppAdapter` that implements Model B with a signed URL plus a free `get_artifact`
+reissue operation. The example stores artifact records by `(owner_user_id, artifact_id)`, rejects
+empty / `"siglume"` owners, returns `expired` for unknown or wrong-owner ids, and includes both
+`ExecutionArtifact.external_url` and `output.download_url`.
+
+## Inputs use a different mechanism - do not confuse them
+
+A buyer *sending* a file *into* your API uses the MCP file-input handle
+(`{"format": "siglume-handle"}`; see [Core Concepts -> MCP file inputs](./sdk-core-concepts.md#mcp-file-inputs)).
+Siglume brokers that **input** for the current call only and does not persist it. There is **no**
+matching platform-hosted mechanism for **outputs** - outputs are always Model A or Model B above.
 
 ## Related
 
-- [Execution Receipts](./execution-receipts.md) — the `ExecutionArtifact` / `external_url` shape (Model B).
-- [Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md) — the full claim-ticket contract (Model A).
-- [Platform / API Responsibility Boundary](./platform-api-boundary.md) — what Siglume owns vs what you own.
+- [Execution Receipts](./execution-receipts.md) - the `ExecutionArtifact` / `external_url` shape (Model B).
+- [Async / Long-Running Two-Phase APIs](./async-two-phase-apis.md) - the full claim-ticket contract (Model A).
+- [Connected Accounts](./connected-accounts.md) - runtime identity headers and tenant/token mapping.
+- [Platform / API Responsibility Boundary](./platform-api-boundary.md) - what Siglume owns vs what you own.

--- a/docs/platform-api-boundary.md
+++ b/docs/platform-api-boundary.md
@@ -31,6 +31,9 @@ side effects, including:
   other provider-specific action
 - OAuth, token refresh, provider leases, rate limits, and provider errors
 - making the action endpoint idempotent for retries
+- hosting any output files you produce, minting signed download URLs, and
+  enforcing owner-scoped retrieval for those artifacts (see
+  [Artifact Delivery](./artifact-delivery.md))
 - returning a clear result when the action committed
 - returning a clear failure or no-op result when the action did not commit
 

--- a/examples/artifact_delivery_presigned.py
+++ b/examples/artifact_delivery_presigned.py
@@ -1,0 +1,382 @@
+"""Example: publisher-hosted artifact delivery with signed download URLs.
+
+This demonstrates Model B from docs/artifact-delivery.md:
+
+  1. render an artifact inside the action call;
+  2. store bytes in publisher-owned object storage;
+  3. return both output.download_url and ExecutionArtifact.external_url;
+  4. allow a later free get_artifact call to reissue a fresh URL, scoped by
+     (owner_user_id, artifact_id).
+
+The object store below is an in-memory stand-in with boto3-compatible method
+names so this example runs offline. In production, replace DemoObjectStore with
+`boto3.client("s3")`, Cloudflare R2, GCS, Azure Blob, or another HTTPS object
+store.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from siglume_api_sdk import (  # noqa: E402
+    AppAdapter,
+    AppCategory,
+    AppManifest,
+    AppTestHarness,
+    ApprovalMode,
+    ExecutionArtifact,
+    ExecutionContext,
+    ExecutionKind,
+    ExecutionResult,
+    PermissionClass,
+    PriceModel,
+    ToolManual,
+    ToolManualPermissionClass,
+    validate_tool_manual,
+)
+
+
+BUCKET = "demo-artifacts"
+SIGNED_URL_TTL_SECONDS = 3600
+
+
+class DemoObjectStore:
+    """Tiny offline object store with the boto3 methods used in the docs."""
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], dict[str, object]] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str) -> None:
+        self.objects[(Bucket, Key)] = {"body": Body, "content_type": ContentType}
+
+    def generate_presigned_url(self, ClientMethod: str, *, Params: dict[str, str], ExpiresIn: int) -> str:
+        if ClientMethod != "get_object":
+            raise ValueError("Only get_object is supported in this example")
+        bucket = Params["Bucket"]
+        key = Params["Key"]
+        if (bucket, key) not in self.objects:
+            raise KeyError(f"missing object: {bucket}/{key}")
+        signature = hashlib.sha256(f"{bucket}:{key}:{ExpiresIn}".encode("utf-8")).hexdigest()[:16]
+        return (
+            f"https://object-store.example/{quote(bucket)}/{quote(key)}"
+            f"?X-Amz-Expires={ExpiresIn}&X-Amz-Signature={signature}"
+        )
+
+
+class ArtifactDeliveryPresignedApp(AppAdapter):
+    def __init__(self, store: DemoObjectStore | None = None) -> None:
+        super().__init__()
+        self.store = store or DemoObjectStore()
+        self._artifacts: dict[tuple[str, str], dict[str, object]] = {}
+
+    def manifest(self) -> AppManifest:
+        return AppManifest(
+            capability_key="artifact-delivery-presigned",
+            name="Artifact Delivery Presigned",
+            job_to_be_done="Render a small report, store it in publisher object storage, and return a signed download link.",
+            category=AppCategory.DOCUMENT,
+            store_vertical="api",
+            permission_class=PermissionClass.ACTION,
+            approval_mode=ApprovalMode.ALWAYS_ASK,
+            dry_run_supported=True,
+            required_connected_accounts=[],
+            price_model=PriceModel.FREE,
+            currency="USD",
+            allow_free_trial=False,
+            jurisdiction="US",
+            short_description="Return publisher-hosted artifacts with signed URLs.",
+            example_prompts=[
+                "Render a report and give me the download link.",
+                "Refresh the download link for artifact art_demo_123.",
+            ],
+        )
+
+    async def execute(self, ctx: ExecutionContext) -> ExecutionResult:
+        params = ctx.input_params or {}
+        operation = str(params.get("operation") or ("get_artifact" if params.get("artifact_id") else "render"))
+        if operation == "get_artifact" or ctx.task_type == "get_artifact":
+            return self._get_artifact(ctx, str(params.get("artifact_id") or ""))
+        return self._render_artifact(ctx)
+
+    def supported_task_types(self) -> list[str]:
+        return ["render_artifact", "get_artifact"]
+
+    def _render_artifact(self, ctx: ExecutionContext) -> ExecutionResult:
+        if not self._valid_owner(ctx.owner_user_id):
+            return self._identity_error(ctx)
+
+        title = str(ctx.input_params.get("title") or "Weekly artifact report")
+        if ctx.execution_kind == ExecutionKind.DRY_RUN:
+            return ExecutionResult(
+                success=True,
+                execution_kind=ctx.execution_kind,
+                output={"summary": f"Would render '{title}' and return a signed download link.", "status": "ready"},
+                needs_approval=True,
+                approval_prompt=f"Render '{title}' and create a one-hour signed download link.",
+            )
+
+        body = self._render_report(title=title, owner_user_id=ctx.owner_user_id)
+        artifact_id = self._artifact_id(ctx.owner_user_id, title, body)
+        owner_hash = hashlib.sha256(ctx.owner_user_id.encode("utf-8")).hexdigest()[:16]
+        key = f"artifacts/{owner_hash}/{artifact_id}.md"
+        content_type = "text/markdown; charset=utf-8"
+
+        self.store.put_object(Bucket=BUCKET, Key=key, Body=body, ContentType=content_type)
+        self._artifacts[(ctx.owner_user_id, artifact_id)] = {
+            "bucket": BUCKET,
+            "key": key,
+            "title": title,
+            "content_type": content_type,
+            "status": "ready",
+        }
+        download_url = self._signed_url(BUCKET, key)
+        artifact = ExecutionArtifact(
+            artifact_type="document",
+            external_id=artifact_id,
+            external_url=download_url,
+            title=title,
+            metadata={"content_type": content_type, "expires_in_seconds": SIGNED_URL_TTL_SECONDS},
+        )
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": f"Rendered '{title}'.",
+                "status": "found",
+                "artifact_id": artifact_id,
+                "download_url": download_url,
+                "download_expires_in_seconds": SIGNED_URL_TTL_SECONDS,
+            },
+            artifacts=[artifact],
+            receipt_summary={"action": "artifact_rendered", "artifact_id": artifact_id},
+        )
+
+    def _get_artifact(self, ctx: ExecutionContext, artifact_id: str) -> ExecutionResult:
+        if not self._valid_owner(ctx.owner_user_id):
+            return self._identity_error(ctx)
+
+        free_receipt = {"operation": "get_artifact", "amount_minor": 0, "currency": "USD"}
+        record = self._artifacts.get((ctx.owner_user_id, artifact_id))
+        if record is None:
+            # Unknown and wrong-owner ids return the same empty shape.
+            return ExecutionResult(
+                success=False,
+                execution_kind=ctx.execution_kind,
+                output={"summary": "Artifact is unavailable or expired.", "status": "expired", "artifact_id": artifact_id},
+                units_consumed=0,
+                amount_minor=0,
+                currency="USD",
+                receipt_summary=free_receipt,
+            )
+        if record.get("status") == "not_ready":
+            return ExecutionResult(
+                success=True,
+                execution_kind=ctx.execution_kind,
+                output={"summary": "Artifact is not ready yet.", "status": "not_ready", "artifact_id": artifact_id},
+                units_consumed=0,
+                amount_minor=0,
+                currency="USD",
+                receipt_summary=free_receipt,
+            )
+        if record.get("status") == "expired":
+            return ExecutionResult(
+                success=False,
+                execution_kind=ctx.execution_kind,
+                output={"summary": "Artifact retention expired.", "status": "expired", "artifact_id": artifact_id},
+                units_consumed=0,
+                amount_minor=0,
+                currency="USD",
+                receipt_summary=free_receipt,
+            )
+
+        download_url = self._signed_url(str(record["bucket"]), str(record["key"]))
+        artifact = ExecutionArtifact(
+            artifact_type="document",
+            external_id=artifact_id,
+            external_url=download_url,
+            title=str(record["title"]),
+            metadata={
+                "content_type": str(record["content_type"]),
+                "expires_in_seconds": SIGNED_URL_TTL_SECONDS,
+            },
+        )
+        return ExecutionResult(
+            success=True,
+            execution_kind=ctx.execution_kind,
+            output={
+                "summary": "Fresh download link issued.",
+                "status": "found",
+                "artifact_id": artifact_id,
+                "download_url": download_url,
+                "download_expires_in_seconds": SIGNED_URL_TTL_SECONDS,
+            },
+            units_consumed=0,
+            amount_minor=0,
+            currency="USD",
+            artifacts=[artifact],
+            receipt_summary=free_receipt,
+        )
+
+    def _signed_url(self, bucket: str, key: str) -> str:
+        return self.store.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=SIGNED_URL_TTL_SECONDS,
+        )
+
+    @staticmethod
+    def _render_report(*, title: str, owner_user_id: str) -> bytes:
+        return f"# {title}\n\nOwner-scoped artifact for {owner_user_id}.\n".encode("utf-8")
+
+    @staticmethod
+    def _artifact_id(owner_user_id: str, title: str, body: bytes) -> str:
+        digest = hashlib.sha256(owner_user_id.encode("utf-8") + title.encode("utf-8") + body).hexdigest()[:16]
+        return f"art_{digest}"
+
+    @staticmethod
+    def _valid_owner(owner_user_id: str | None) -> bool:
+        return bool(owner_user_id and owner_user_id.strip() and owner_user_id != "siglume")
+
+    @staticmethod
+    def _identity_error(ctx: ExecutionContext) -> ExecutionResult:
+        return ExecutionResult(
+            success=False,
+            execution_kind=ctx.execution_kind,
+            output={"summary": "Missing platform user identity.", "status": "unauthorized"},
+            units_consumed=0,
+            amount_minor=0,
+            currency="USD",
+            receipt_summary={"operation": "identity_check", "amount_minor": 0, "currency": "USD"},
+        )
+
+
+def build_tool_manual() -> ToolManual:
+    return ToolManual(
+        tool_name="artifact_delivery_presigned",
+        job_to_be_done="Render a report artifact, return a signed HTTPS download link, and refresh that link later for the same owner.",
+        summary_for_model=(
+            "Renders a publisher-hosted report and returns both output.download_url and "
+            "ExecutionArtifact.external_url. Use get_artifact with artifact_id to refresh the "
+            "signed URL for free. The API scopes retrieval by owner_user_id plus artifact_id."
+        ),
+        trigger_conditions=[
+            "owner asks to generate, render, export, or download a file-like report",
+            "agent has an artifact_id from this API and needs a fresh download link",
+            "owner needs a publisher-hosted output file rather than inline text",
+        ],
+        do_not_use_when=[
+            "the requested result is short plain text that should be returned inline",
+            "the owner is asking to upload a file into the API rather than download an output artifact",
+        ],
+        permission_class=ToolManualPermissionClass.ACTION,
+        dry_run_supported=True,
+        requires_connected_accounts=[],
+        input_schema={
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["render", "get_artifact"],
+                    "description": "render creates a new artifact; get_artifact reissues a signed URL for an existing artifact_id.",
+                    "default": "render",
+                },
+                "title": {"type": "string", "description": "Report title when operation=render."},
+                "artifact_id": {"type": "string", "description": "Publisher-issued artifact id when operation=get_artifact."},
+            },
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Human-readable result summary."},
+                "status": {"type": "string", "description": "ready | found | not_ready | expired | unauthorized."},
+                "artifact_id": {"type": "string", "description": "Durable publisher artifact id."},
+                "download_url": {"type": "string", "description": "Short-lived HTTPS GET URL to bytes hosted by the publisher."},
+                "download_expires_in_seconds": {"type": "integer", "description": "Signed URL TTL, default 3600 seconds."},
+            },
+            "required": ["summary", "status"],
+            "additionalProperties": False,
+        },
+        usage_hints=[
+            "Use operation=render to create a new artifact and return a signed URL.",
+            "Use operation=get_artifact with artifact_id to refresh a signed URL for free.",
+            "Never ask the user for owner_user_id; Siglume supplies it as runtime identity.",
+        ],
+        result_hints=[
+            "Show download_url to the owner as the link to fetch the artifact.",
+            "If status=expired, explain that the artifact id is unavailable or outside retention.",
+            "If status=unauthorized, fail closed; do not expose any artifact details.",
+        ],
+        error_hints=[
+            "Unknown and wrong-owner artifact ids both return expired, so do not infer ownership.",
+            "If a signed URL expires, call get_artifact again instead of reusing the stale URL.",
+        ],
+        approval_summary_template="Render report artifact '{title}' and return a signed download link.",
+        preview_schema={
+            "type": "object",
+            "properties": {"summary": {"type": "string", "description": "Preview of the artifact render."}},
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+        idempotency_support=True,
+        side_effect_summary="Writes a rendered report into publisher-owned object storage and returns a short-lived HTTPS download link.",
+        jurisdiction="US",
+    )
+
+
+async def run_artifact_delivery_example() -> list[str]:
+    app = ArtifactDeliveryPresignedApp()
+    harness = AppTestHarness(app)
+    ok, issues = validate_tool_manual(build_tool_manual())
+    output = [f"tool_manual_valid: {ok} {len(issues)}", f"manifest_issues: {len(harness.validate_manifest())}"]
+
+    dry_run = await harness.dry_run(task_type="render_artifact", input_params={"title": "Demo report"})
+    output.append(f"dry_run: {dry_run.success} {dry_run.output['status']}")
+
+    action = await harness.execute_action(task_type="render_artifact", input_params={"title": "Demo report"})
+    artifact_id = action.output["artifact_id"]
+    output.append(f"action: {action.success} {action.output['status']} artifacts={len(action.artifacts)}")
+    output.append(f"download_url_present: {str(action.output['download_url']).startswith('https://')}")
+
+    reissue = await harness.execute_action(task_type="get_artifact", input_params={"operation": "get_artifact", "artifact_id": artifact_id})
+    output.append(f"reissue: {reissue.success} {reissue.output['status']} amount={reissue.amount_minor}")
+
+    from siglume_api_sdk import ExecutionContext  # noqa: WPS433
+
+    wrong_owner = await app.execute(
+        ExecutionContext(
+            agent_id="test-agent-001",
+            owner_user_id="other-owner-001",
+            task_type="get_artifact",
+            input_params={"artifact_id": artifact_id},
+            execution_kind=ExecutionKind.ACTION,
+        )
+    )
+    output.append(f"wrong_owner: {wrong_owner.success} {wrong_owner.output['status']}")
+
+    sentinel_owner = await app.execute(
+        ExecutionContext(
+            agent_id="test-agent-001",
+            owner_user_id="siglume",
+            task_type="get_artifact",
+            input_params={"artifact_id": artifact_id},
+            execution_kind=ExecutionKind.ACTION,
+        )
+    )
+    output.append(f"sentinel_owner: {sentinel_owner.success} {sentinel_owner.output['status']}")
+    return output
+
+
+async def main() -> None:
+    for line in await run_artifact_delivery_example():
+        print(line)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/async_transcription.py
+++ b/examples/async_transcription.py
@@ -14,6 +14,10 @@ The three legs this adapter implements:
 
 The chargeable band lives in output.billingPreview.operation on the QUOTE leg, and the SAME
 value must reappear as the ACTION-leg receipt_summary.operation and as a pricing_plan key.
+
+For a real large transcript file, host the output yourself and return an external_url as shown
+in examples/artifact_delivery_presigned.py. This runnable example returns small transcript text
+inline to keep the async billing/state machine focused.
 """
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siglume-api-sdk"
-version = "3.1.1"
+version = "3.1.2"
 description = "SDK for building agent APIs on the Siglume Agent API Store"
 readme = "README.md"
 license = "MIT"

--- a/release-notes/RELEASE_NOTES_v3.1.2.md
+++ b/release-notes/RELEASE_NOTES_v3.1.2.md
@@ -1,0 +1,26 @@
+# v3.1.2 - runnable artifact delivery example
+
+This release turns the artifact delivery guide from a conceptual overview into
+a copy-pasteable implementation path.
+
+## Highlights
+
+- Expanded `docs/artifact-delivery.md` with:
+  - a complete Model B `execute()` example using `ExecutionResult.artifacts`
+    plus `output.download_url`;
+  - the boto3 recipe for `put_object` and `generate_presigned_url`;
+  - the production identity bridge from `X-Siglume-Platform-User-Id` to
+    `ExecutionContext.owner_user_id`;
+  - free reissue/get-result state handling and a security checklist.
+- Added `examples/artifact_delivery_presigned.py`, a runnable offline example
+  showing publisher-hosted artifacts, signed URL reissue, owner+artifact lookup,
+  missing/sentinel owner rejection, and wrong-owner/unknown-id expiry behavior.
+- Registered the new example in README and example tests.
+- Clarified that `examples/async_transcription.py` returns small text inline for
+  brevity; large/binary async artifacts should generally use `external_url`.
+
+## Upgrade Notes
+
+No runtime API changes. This is a docs and example patch release. Python and
+TypeScript package versions are bumped to `3.1.2` so PyPI and npm remain
+version-aligned.

--- a/siglume-api-sdk-ts/package-lock.json
+++ b/siglume-api-sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@siglume/api-sdk",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/siglume-api-sdk-ts/package.json
+++ b/siglume-api-sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siglume/api-sdk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "TypeScript runtime for building and testing Siglume developer apps",
   "license": "MIT",
   "repository": {

--- a/siglume-api-sdk-ts/src/version.ts
+++ b/siglume-api-sdk-ts/src/version.ts
@@ -1,2 +1,2 @@
-export const SDK_VERSION = "3.1.1";
+export const SDK_VERSION = "3.1.2";
 export const SDK_USER_AGENT = `siglume-api-sdk-ts/${SDK_VERSION}`;

--- a/siglume_api_sdk/_version.py
+++ b/siglume_api_sdk/_version.py
@@ -2,5 +2,5 @@
 from __future__ import annotations
 
 
-SDK_VERSION = "3.1.1"
+SDK_VERSION = "3.1.2"
 SDK_USER_AGENT = f"siglume-api-sdk/{SDK_VERSION}"

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -103,7 +103,7 @@ def test_package_runtime_versions_match_release_metadata() -> None:
     python_version = str(pyproject["project"]["version"])
     ts_version = str(package_json["version"])
 
-    assert python_version == "3.1.1"
+    assert python_version == "3.1.2"
     assert ts_version == python_version
     assert f'SDK_VERSION = "{python_version}"' in _read("siglume_api_sdk/_version.py")
     assert f'export const SDK_VERSION = "{ts_version}";' in _read("siglume-api-sdk-ts/src/version.ts")
@@ -118,7 +118,7 @@ def test_onboarding_docs_match_generated_scaffold_and_no_key_first_loop() -> Non
 
     assert "v0.5.0 is out" not in readme
     assert "current v0.5 release line" not in ts_readme
-    assert "This is **v3.1.1 (beta)**" in readme
+    assert "This is **v3.1.2 (beta)**" in readme
     assert "Production releases are published by GitHub Actions with PyPI Trusted" in security
     assert "Do not create a PyPI API token or local `.pypirc` for the normal release path." in normalized_security
     assert "Rotate after every release" not in security
@@ -391,6 +391,9 @@ def test_artifact_delivery_docs_pin_publisher_hosted_output_contract() -> None:
     async_two_phase = _read("docs/async-two-phase-apis.md")
     sdk_core = _read("docs/sdk-core-concepts.md")
     readme = _read("README.md")
+    getting_started = _read("GETTING_STARTED.md")
+    platform_boundary = _read("docs/platform-api-boundary.md")
+    example = _read("examples/artifact_delivery_presigned.py")
     normalized = " ".join(artifact_delivery.split())
 
     assert "Siglume does not host your output files." in artifact_delivery
@@ -399,16 +402,36 @@ def test_artifact_delivery_docs_pin_publisher_hosted_output_contract() -> None:
     assert "Model A" in artifact_delivery
     assert "ExecutionArtifact.external_url" in artifact_delivery
     assert "presigned GET URL" in artifact_delivery
+    assert 's3.put_object(Bucket=BUCKET, Key=key, Body=body, ContentType=content_type)' in artifact_delivery
+    assert 's3.generate_presigned_url(' in artifact_delivery
+    assert 'ExpiresIn=3600' in artifact_delivery
+    assert "Do **not** hard-code" in artifact_delivery
+    assert "Cloudflare R2, Google Cloud Storage, Azure Blob" in artifact_delivery
+    assert "HTTPS GET link" in artifact_delivery
     assert "durable `job_id`" in artifact_delivery
     assert "free `get_result`" in artifact_delivery
     assert "(owner_user_id, artifact_id)" in artifact_delivery
+    assert "X-Siglume-Platform-User-Id" in artifact_delivery
+    assert "ExecutionContext.owner_user_id" in artifact_delivery
+    assert "(owner_user_id, job_id)" in artifact_delivery
+    assert 'output["download_url"] = download_url' in artifact_delivery
     assert "`owner_user_id` (from the platform) + a durable id (from you)" in artifact_delivery
     assert 'the literal `"siglume"`' in artifact_delivery
     assert "`{\"format\": \"siglume-handle\"}`" in artifact_delivery
     assert "platform-hosted mechanism for **outputs**" in normalized
     assert "outputs are always Model A or Model B" in normalized
+    assert "Security checklist" in artifact_delivery
+    assert "unknown or wrong owner" in artifact_delivery
+    assert "The platform does not auto-refund accepted async jobs." in artifact_delivery
+    assert "examples/artifact_delivery_presigned.py" in artifact_delivery
 
     assert "Artifact Delivery" in readme
+    assert "artifact_delivery_presigned.py" in readme
+    assert "Artifact Delivery" in getting_started
+    assert "signed download URLs" in platform_boundary
     assert "download link to bytes you host yourself" in execution_receipts
     assert "This async pattern is **Model A**" in async_two_phase
     assert "Artifact Delivery" in sdk_core
+    assert "return both output.download_url and ExecutionArtifact.external_url" in example
+    assert "self._artifacts[(ctx.owner_user_id, artifact_id)]" in example
+    assert 'owner_user_id != "siglume"' in example

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,6 +27,7 @@ EXAMPLE_SPECS = [
     ("account_digests_alerts_wrapper.py", PermissionClass.READ_ONLY),
     ("account_plan_wrapper.py", PermissionClass.READ_ONLY),
     ("agent_behavior_adapter.py", PermissionClass.ACTION),
+    ("artifact_delivery_presigned.py", PermissionClass.ACTION),
     ("calendar_sync.py", PermissionClass.ACTION),
     ("crm_sync.py", PermissionClass.ACTION),
     ("email_sender.py", PermissionClass.ACTION),
@@ -284,5 +285,62 @@ def test_wallet_balance_example_resolves_native_symbol_to_chain_default() -> Non
                 f"'native' on {chain} should resolve to {expected_symbol}, got {result.output['token_symbol']}"
             )
             assert result.output["balance"] == expected_balance
+
+    asyncio.run(_run())
+
+
+def test_artifact_delivery_presigned_example_reissues_only_for_matching_owner() -> None:
+    module = _load_module("artifact_delivery_presigned.py")
+    app = module.ArtifactDeliveryPresignedApp()
+
+    async def _run() -> None:
+        from siglume_api_sdk import ExecutionContext, ExecutionKind
+
+        owner_ctx = ExecutionContext(
+            agent_id="agent_test",
+            owner_user_id="owner_a",
+            task_type="render_artifact",
+            input_params={"title": "Owner A report"},
+            execution_kind=ExecutionKind.ACTION,
+        )
+        action = await app.execute(owner_ctx)
+        assert action.success
+        assert len(action.artifacts) == 1
+        assert action.artifacts[0].external_url == action.output["download_url"]
+        artifact_id = action.output["artifact_id"]
+
+        reissue_ctx = ExecutionContext(
+            agent_id="agent_test",
+            owner_user_id="owner_a",
+            task_type="get_artifact",
+            input_params={"artifact_id": artifact_id},
+            execution_kind=ExecutionKind.ACTION,
+        )
+        reissue = await app.execute(reissue_ctx)
+        assert reissue.success
+        assert reissue.output["status"] == "found"
+        assert reissue.amount_minor == 0
+
+        wrong_owner_ctx = ExecutionContext(
+            agent_id="agent_test",
+            owner_user_id="owner_b",
+            task_type="get_artifact",
+            input_params={"artifact_id": artifact_id},
+            execution_kind=ExecutionKind.ACTION,
+        )
+        wrong_owner = await app.execute(wrong_owner_ctx)
+        assert wrong_owner.success is False
+        assert wrong_owner.output["status"] == "expired"
+
+        sentinel_ctx = ExecutionContext(
+            agent_id="agent_test",
+            owner_user_id="siglume",
+            task_type="get_artifact",
+            input_params={"artifact_id": artifact_id},
+            execution_kind=ExecutionKind.ACTION,
+        )
+        sentinel = await app.execute(sentinel_ctx)
+        assert sentinel.success is False
+        assert sentinel.output["status"] == "unauthorized"
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Expand Artifact Delivery into copy-pasteable Model B and Model A guidance, including the runtime `X-Siglume-Platform-User-Id` to `ExecutionContext.owner_user_id` bridge.
- Add runnable `examples/artifact_delivery_presigned.py` with owner-scoped signed URL issuance and free reissue/get_artifact behavior.
- Patch the async transcription note, add backlinks/docs contract coverage, and bump Python/TypeScript packages to v3.1.2.

## Validation
- `D:\Users\taihei2\AppData\Local\Programs\Python\Python311\python.exe examples\artifact_delivery_presigned.py`
- `D:\Users\taihei2\AppData\Local\Programs\Python\Python311\python.exe -m pytest tests\test_docs_contract.py -q`
- `D:\Users\taihei2\AppData\Local\Programs\Python\Python311\python.exe -m pytest tests\test_examples.py -q`
- `git diff --check`
- `npm --prefix siglume-api-sdk-ts run typecheck`
- `py -3.11 -m build`
- `npm --prefix siglume-api-sdk-ts run build`
- `py -3.11 -m twine check dist\*`
- `npm --prefix siglume-api-sdk-ts run pack:check`
- Clean venv install from the local v3.1.2 wheel