### PR TITLE
[codex] Remove retired core package references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,7 +392,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Docs align with `siglume-agent-core` v0.9.0.** README now documents the
+- **Docs align with the former public core split.** README now documents the
   API Store tool-selection pipeline used by `siglume dev simulate` and
   `siglume dev market-vitals`, with links to the public agent-core selection
   and orchestration modules.
@@ -407,10 +407,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Documentation cross-links to `siglume-agent-core`** — README,
+- **Documentation cross-links to the then-public core package** — README,
   GETTING_STARTED, `docs/publish-flow.md`, and `docs/sdk-core-concepts.md`
   now cross-link to the open-source decision logic at
-  [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core)
+  the then-public core package
   (AGPL-3.0 PyPI package). The README gains a new top-level section
   **"How your API actually gets selected — the algorithm is public"**
   with a 5-stage pipeline diagram (`installed_tool_prefilter` → `tool_selector`

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1883,11 +1883,18 @@ Your tool manual is automatically scored 0-100 with a letter grade:
 
 **Grade C, D, or F manuals cannot be published — minimum grade B is required.** Fix the issues and resubmit.
 
-> **Score locally before you submit.** The same A–F scorer is published as open source: [`siglume-agent-core.tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01). Install with `pip install siglume-agent-core` and call `score_manual_quality(my_manual)` to get the same grade you'll see at registration time, without burning a CLI/API key or hitting the platform.
-
-> **Want to know whether the planner would even pick your API once published?** [`siglume-agent-core.dev_simulator`](https://github.com/taihei-05/siglume-agent-core#7-dev_simulator-v07) runs the `tool_selector` selection pipeline (top-N catalog → keyword pre-filter → single `tool_choice="auto"` turn) against the live catalog and returns the predicted tool chain — without executing any of it. Pair it with `score_manual_quality` to validate **both** "will I pass the publish gate?" and "will I get picked once published?" before submission.
+> **Score locally before you submit.** Run `siglume validate .` and
+> `siglume score . --offline`, or call `validate_tool_manual()` and
+> `score_tool_manual_offline()` from `siglume_api_sdk`. These checks catch
+> structural validation errors and the A-F quality grade before you spend a
+> registration request.
 >
-> This models **Siglume's own server-side runtime (Path 2)**. When a buyer connects their AI over MCP — the primary path today — *their* AI selects the tool from your Tool Manual and Siglume only resolves + dispatches it, so the keyword pipeline never runs. The simulator is still a good proxy for "is my Tool Manual concrete enough to be chosen," but treat it as guidance, not a guarantee. See [How your API actually gets selected](README.md#how-your-api-actually-gets-selected--and-whats-open-source) for the two-path breakdown.
+> **Selection after publishing.** The primary path today is MCP: the buyer's
+> AI reads your Tool Manual and chooses whether to call your API. Siglume lists
+> eligible installed tools and dispatches selected calls; it does not require
+> publishers to run a separate planner package locally. See
+> [How your API actually gets selected](README.md#how-your-api-actually-gets-selected)
+> for the supported selection model.
 
 ### What gets penalized
 

--- a/README.md
+++ b/README.md
@@ -494,127 +494,52 @@ required fields, scoring rules, and examples.
 
 ---
 
-## How your API actually gets selected — and what's open source
+## How your API actually gets selected
 
-Once your API is published, **the decision to call it is made by the buyer's agent, not by Siglume.** *How* that decision is reached depends on how the buyer's agent is connected to the store — and there are two paths today that select tools differently:
+Once your API is published, **the decision to call it is made by the buyer's
+agent, not by Siglume.** The primary path today is MCP: the buyer points their
+own AI client at Siglume, Siglume lists your installed tool when account and
+policy checks pass, and the buyer's AI reads your Tool Manual to decide whether
+to call it. Siglume resolves the selected tool and dispatches it to your
+`invoke_url`; it does not ask publishers to run a separate platform planner
+package locally.
 
-**Path 1 — MCP connectors (Claude and other MCP clients), the primary path today.** The buyer points their own AI at Siglume over MCP. Siglume lists your tool to that AI whenever it is installed for the agent, the publisher OAuth is healthy (`account_readiness = ready`), and it is not a `payment`-class or high-risk (`double_confirm`) capability. From there, **the buyer's own AI reads your Tool Manual and decides which tool to call.** Siglume resolves the named tool and dispatches it to your `invoke_url` — it does **not** re-rank your tool with its own keyword selector, and it does **not** run an LLM tool-use loop on your behalf. On this path the keyword pipeline below does not run; your only lever is the Tool Manual.
+Your strongest lever is therefore the Tool Manual:
 
-**Path 2 — Siglume's own server-side tool-use runtime.** The pipeline in the box below is the open-core logic Siglume's first-party runtime imports, and it is exactly what the `siglume dev simulate` dry run executes against the live catalog. Every decision stage is open source — the same code the platform imports from the AGPL-licensed [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) PyPI package. (This SDK itself is MIT-licensed; the OSS claim is about agent-core, not about the SDK code in *this* repo.) Throughout this section, "the planner" / "the orchestrator" refer to this server-side runtime.
+- Write concrete `summary_for_model`, `trigger_conditions`, and
+  `do_not_use_when` entries that match the requests your target buyers would
+  actually make.
+- Keep `input_schema.properties.*.description` short and precise. Long or vague
+  schema descriptions can fail structural validation before quality scoring is
+  considered.
+- Use `usage_hints` and `result_hints` to explain behavior that affects caller
+  decisions, such as async polling, attachment handling, or important limits.
 
-```
-   You publish via siglume-api-sdk  ──►  Buyer agent installs your API
-                                                    │
-                                                    ▼
-   ┌──────────────────────────────────────────────────────────┐
-   │ Pre-publish (you, on your machine)                       │
-   │  • tool_manual_validator   — grade your manual A-F       │  agent-core v0.1
-   │  • dev_simulator           — "would the planner pick     │  agent-core v0.7+
-   │                              my API for this offer?"     │
-   └──────────────────────────────────────────────────────────┘
-                                                    │
-                                                    ▼
-   ┌──────────────────────────────────────────────────────────┐
-   │ Path 2 only - Siglume's own runtime selects              │
-   │  1. installed_tool_prefilter — TF-IDF top-N from the     │  agent-core v0.2
-   │     agent's installed pool                               │
-   │  2. tool_selector            — keyword score + permission│  agent-core v0.3
-   │     gate → top-K candidates  (THE "why was my tool       │
-   │     picked / not picked?" function)                      │
-   │  3. orchestrate_helpers + orchestrate — system-prompt    │  agent-core v0.5/v0.6
-   │     build + multi-turn LLM tool-use loop                 │
-   │  4. provider_adapters        — Anthropic / OpenAI call   │  agent-core v0.1
-   │  5. capability_failure_learning — on failure, write a    │  agent-core v0.4
-   │     learning card so future runs avoid this tool         │
-   └──────────────────────────────────────────────────────────┘
-```
+### Pre-publish checks
 
-> **Which path is your buyer on?** If they connect through an MCP client — the common case for Claude users today — it is **Path 1**: their own AI reads your Tool Manual and decides, and Siglume only lists the tool and dispatches the call. The keyword pipeline in the box above runs only on **Path 2** (Siglume's own runtime and the `siglume dev simulate` dry run). `installed_tool_prefilter` in particular is a prompt-budget helper for that path's prompt build, not a gate that runs on every request. Net: the dry run is a good proxy for "is my Tool Manual concrete enough to be chosen," but a live MCP buyer's AI may weigh it differently — treat the simulator as guidance, not a guarantee.
-
-### Reading list by question
-
-These modules govern **Path 2** (Siglume's own runtime) and the pre-publish tools. On **Path 1** (MCP) there is no Siglume-side selection function to read — the buyer's AI picks from your Tool Manual, so manual quality is the lever, not a platform scorer.
-
-| If you want to know… | Read this in agent-core |
-|---|---|
-| Why my Tool Manual was graded A / B / C / D / F | [`tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01) |
-| Why my published API was / wasn't picked **when Siglume's own runtime ran the loop (Path 2)** | [`tool_selector`](https://github.com/taihei-05/siglume-agent-core#4-tool_selector-v03) — `select_tools()` is THE selection function on that path |
-| What happens when an agent has too many installed tools to fit in the prompt | [`installed_tool_prefilter`](https://github.com/taihei-05/siglume-agent-core#3-installed_tool_prefilter-v02) |
-| What rules govern "tool got blocked after a recent failure" | [`capability_failure_learning`](https://github.com/taihei-05/siglume-agent-core#5-capability_failure_learning-v04) |
-| How the LLM tool-use loop runs end-to-end | [`orchestrate`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) |
-| How buyer-supplied input maps into my API's `input_schema` | [`orchestrate_helpers`](https://github.com/taihei-05/siglume-agent-core#6-orchestrate_helpers-and-orchestrate-v05--v06) — `build_orchestrate_system_prompt()` |
-| How to dry-run "would the planner have picked my API for this offer text?" before publishing | [`dev_simulator`](https://github.com/taihei-05/siglume-agent-core#7-dev_simulator-v07) |
-
-### Pre-publish dry run with agent-core
-
-`tool_manual_validator` and `dev_simulator` are designed to run locally before you `siglume register`. They serve **two different questions**:
-
-**(1) Will I pass the publish gate (minimum grade B)?** — offline grading, no API key needed:
+Use the SDK's bundled validator and scorer before `siglume register`:
 
 ```bash
-pip install siglume-agent-core         # no extras needed for the scorer
+siglume validate .
+siglume score . --offline
 ```
 
-```python
-from siglume_agent_core.tool_manual_validator import score_manual_quality
+For scripted checks:
 
-quality = score_manual_quality(my_tool_manual)
+```python
+from siglume_api_sdk import score_tool_manual_offline, validate_tool_manual
+
+valid, issues = validate_tool_manual(my_tool_manual)
+quality = score_tool_manual_offline(my_tool_manual)
+
+print(valid)
+for issue in issues:
+    print(issue.code, issue.field, issue.message)
 print(f"Grade {quality.grade} ({quality.overall_score}/100)")
-# Same scorer that decides if you pass the publish gate.
-# Minimum grade B is required (A or B both publish; C/D/F are blocked).
 ```
 
-**(2) Will the planner actually pick my API once published?** — the **easiest path** is the SDK's wrapped CLI, which does the catalog fetch and the LLM call for you against the live store (rate-limited to 10 calls per publisher per UTC day):
-
-```bash
-siglume dev simulate "translate this English doc to Japanese and post to Notion"
-```
-
-For self-hosted / scripted use you can call the underlying agent-core function directly. It needs an `[anthropic]` extra and you supply the catalog rows + LLM callable yourself:
-
-```bash
-pip install 'siglume-agent-core[anthropic]'
-```
-
-```python
-from siglume_agent_core.dev_simulator import (
-    simulate_planner, LLMSimulateResponse, LLMSimulateToolUseBlock,
-)
-from anthropic import Anthropic
-
-# rows: Sequence[(ProductListingLike, CapabilityReleaseLike)]
-# fetch from your own DB / API; structurally typed Protocols, no SQLAlchemy
-rows = fetch_my_catalog_rows()
-
-def my_anthropic_call(system_prompt, tools, user_msg) -> LLMSimulateResponse:
-    client = Anthropic(timeout=30.0)
-    resp = client.messages.create(
-        model="claude-haiku-4-5-20251001", max_tokens=2048,
-        system=system_prompt, tools=tools,
-        messages=[{"role": "user", "content": user_msg}],
-    )
-    blocks = [
-        LLMSimulateToolUseBlock(name=str(b.name), input=dict(b.input or {}))
-        for b in (resp.content or []) if getattr(b, "type", None) == "tool_use"
-    ]
-    return LLMSimulateResponse(tool_use_blocks=blocks)
-
-result = simulate_planner(
-    rows,
-    offer_text="translate this English doc to Japanese and post to Notion",
-    quota_used_today=0, quota_limit=10,
-    llm_call=my_anthropic_call,
-)
-for call in result.predicted_chain:
-    print(call.tool_name, call.listing_title)
-```
-
-If the planner picks your API for the offers your target buyers would write, you're publish-ready. If not, improve the Tool Manual fields the selection pipeline actually reads:
-
-- `tool_selector` runs a keyword-based hard filter (the `tool_selector` step above, Path 2) over your `capability_key`, `display_name`, `description`, and `usage_hints`. If none of those overlap the buyer's request, the LLM never even sees your API as a candidate. Make these four fields concrete and request-shaped.
-- Once your API *is* in the candidate set, the LLM reads a short tool-description string while picking between candidates. That string is sourced from your manual via the fallback chain `tool_prompt_compact` → `compact_prompt` → `description` → `summary_for_model` → listing description / title / `capability_key`. In practice the LLM almost always sees `tool_prompt_compact` (or `compact_prompt`), so polish that field first; `summary_for_model` and the others are only fallbacks if the earlier sources are empty. `trigger_conditions` is captured in the schema for the publish gate's quality check but is not threaded into the LLM-visible tool description today — keep it accurate, but don't expect it to move the planner directly.
-
-These same Tool Manual fields feed both gates that matter to you: the [Acceptance bar](#acceptance-bar) (the pre-publish scorer that decides whether you can *list*) and the selection step that decides whether you actually get *picked* once listed — your buyer's own AI on Path 1, or `tool_selector` on Path 2. Polishing them is the one lever that helps on every path, so do it before you worry about anything else. (See also [Important: revenue is not guaranteed](#important-revenue-is-not-guaranteed).)
+The publish gate requires both structural validation and quality scoring to
+pass. A grade of A or B is not enough if structural validation returns errors.
 
 ---
 

--- a/docs/publish-flow.md
+++ b/docs/publish-flow.md
@@ -78,7 +78,10 @@ There is no normal human review step in the self-serve publish flow anymore.
    - optional `input_form_spec` ([authoring guide](input-form-spec.md))
 3. Runs contract, pricing, payout, external OAuth declaration, and runtime validation preflight checks.
 
-   The **Tool Manual quality scorer** (grade A–F, minimum B to publish) used at this step is also published as open source — see [`siglume-agent-core.tool_manual_validator`](https://github.com/taihei-05/siglume-agent-core#1-tool_manual_validator-v01). The same scoring code runs in this preflight check and locally; you can predict your grade before `auto-register` ever runs.
+   The **Tool Manual validation and quality checks** also run locally through
+   this SDK. Use `siglume validate .` plus `siglume score . --offline`, or call
+   `validate_tool_manual()` and `score_tool_manual_offline()` from
+   `siglume_api_sdk`, before `auto-register`.
 4. Runs a mandatory fail-closed LLM legal review on the submitted package.
 5. Verifies the public API is reachable from the internet.
 6. Sends a functional test request using your runtime auth header shared secret.

--- a/docs/sdk-core-concepts.md
+++ b/docs/sdk-core-concepts.md
@@ -169,4 +169,3 @@ such as images and documents; the current decoded size limit is 25 MB.
 - [Dry Run and Approval](./dry-run-and-approval.md) - safe execution for `ACTION` / `PAYMENT` tiers
 - [Execution Receipts](./execution-receipts.md) - what to return after execution
 - [Artifact Delivery](./artifact-delivery.md) - where output bytes live (you host them), with Model B `external_url` links and Model A async `job_id` claim tickets scoped by `owner_user_id`
-- [`siglume-agent-core`](https://github.com/taihei-05/siglume-agent-core) - open-source decision logic used after you publish

--- a/release-notes/RELEASE_NOTES_v0.10.2.md
+++ b/release-notes/RELEASE_NOTES_v0.10.2.md
@@ -13,7 +13,7 @@ selected, or missing demand.
 - Ships the broader `siglume dev` observability surface: planner simulation,
   gap reports, listing stats, miss analysis, keyword suggestions, and execution
   receipt tailing.
-- Cross-links the public SDK docs to `siglume-agent-core`, so publishers can
+- Cross-links the public SDK docs to the then-public core package, so publishers can
   inspect the open-source selection logic behind scoring and simulation.
 - Keeps Python and TypeScript package versions aligned at `0.10.2`.
 

--- a/release-notes/RELEASE_NOTES_v0.10.3.md
+++ b/release-notes/RELEASE_NOTES_v0.10.3.md
@@ -1,7 +1,7 @@
 # Siglume API SDK v0.10.3
 
-v0.10.3 is a documentation-alignment patch release for the `siglume-agent-core`
-v0.9.0 split.
+v0.10.3 is a documentation-alignment patch release for the former public core
+split.
 
 ## What changed
 

--- a/schemas/tool-manual-grader-rules.json
+++ b/schemas/tool-manual-grader-rules.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-19",
-  "source_of_truth": "agent_sns.application.capability_runtime.tool_manual_validator.score_manual_quality",
+  "source_of_truth": "siglume_agent_core.tool_manual_validator.score_manual_quality",
   "max_score": 100,
   "grade_thresholds": {
     "A": 90,

--- a/schemas/tool-manual-grader-rules.json
+++ b/schemas/tool-manual-grader-rules.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-19",
-  "source_of_truth": "siglume_agent_core.tool_manual_validator.score_manual_quality",
+  "source_of_truth": "Siglume production Tool Manual quality scorer",
   "max_score": 100,
   "grade_thresholds": {
     "A": 90,

--- a/siglume-api-sdk-ts/src/cli/project.ts
+++ b/siglume-api-sdk-ts/src/cli/project.ts
@@ -27,6 +27,7 @@ import type {
   SiglumeClientShape,
   ToolManual,
   ToolManualIssue,
+  ToolManualQualityReport,
 } from "../index";
 import { SiglumeProjectError } from "../errors";
 import {
@@ -81,6 +82,40 @@ function remoteQualityOk(report: { validation_ok?: boolean; publishable?: boolea
   const validationOk = report.validation_ok ?? true;
   const publishable = report.publishable ?? (report.grade === "A" || report.grade === "B");
   return Boolean(validationOk) && Boolean(publishable);
+}
+
+function formatRemoteQualityIssue(issue: ToolManualIssue): string {
+  const codePrefix = issue.code ? `[${issue.code}] ` : "";
+  const fieldPrefix = issue.field ? `${issue.field}: ` : "";
+  return `${codePrefix}${fieldPrefix}${issue.message || "remote validation failed"}`;
+}
+
+function remoteQualityBlockingErrors(report: ToolManualQualityReport): string[] {
+  const grade = report.grade;
+  const score = report.overall_score;
+  const validationOk = report.validation_ok ?? true;
+  const gradePublishable = grade === "A" || grade === "B";
+  const effectivePublishable = report.publishable ?? gradePublishable;
+  const errors: string[] = [];
+
+  if (!validationOk) {
+    errors.push(
+      `remote Tool Manual structural validation failed (validation.ok=false). Quality grade ${grade} (${score}/100) ` +
+        "only measures content quality; publication also requires structural validation to pass.",
+    );
+    for (const issue of report.validation_errors ?? []) {
+      errors.push(formatRemoteQualityIssue(issue));
+    }
+  }
+
+  if (!effectivePublishable && (validationOk || !gradePublishable)) {
+    errors.push(`remote Tool Manual quality is not publishable: ${grade} (${score}/100)`);
+  }
+
+  if (errors.length === 0 && !remoteQualityOk(report)) {
+    errors.push(`remote Tool Manual quality is not publishable: ${grade} (${score}/100)`);
+  }
+  return errors;
 }
 
 function sampleValueForSchema(schema: Record<string, unknown>): unknown {
@@ -593,7 +628,7 @@ async function registrationPreflight(project: LoadedProject, client: SiglumeClie
     errors.push("tool_manual.json is not valid for production registration");
   }
   if (!remoteQualityOk(remoteQuality)) {
-    errors.push(`remote Tool Manual quality is not publishable: ${remoteQuality.grade} (${remoteQuality.overall_score}/100)`);
+    errors.push(...remoteQualityBlockingErrors(remoteQuality));
   }
   const preflight = {
     manifest_issues: manifestIssues,

--- a/siglume-api-sdk-ts/src/tool-manual-validator.ts
+++ b/siglume-api-sdk-ts/src/tool-manual-validator.ts
@@ -14,6 +14,7 @@ const PLATFORM_INJECTED_FIELDS = new Set([
 ]);
 const COMPOSITION_KEYWORDS = new Set(["oneOf", "anyOf", "allOf"]);
 const INPUT_SCHEMA_FORBIDDEN_KEYS = new Set(["patternProperties"]);
+const MAX_PROPERTY_DESCRIPTION_LENGTH = 500;
 
 type ManualInput = ToolManual | Record<string, unknown> | { to_dict(): unknown } | unknown;
 
@@ -86,6 +87,72 @@ function checkSchemaForbiddenRecursive(
     } else if (key === "items" && isRecord(value)) {
       const subPath = path ? `${path}.items` : "items";
       checkSchemaForbiddenRecursive(value, rootField, pushIssue, subPath);
+    }
+  }
+}
+
+function descriptionLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function checkOnePropertyDescriptionLength(
+  text: unknown,
+  rootField: string,
+  pushIssue: (nextIssue: ToolManualIssue) => void,
+  path: string,
+): void {
+  if (typeof text !== "string") {
+    return;
+  }
+  const length = descriptionLength(text);
+  if (length > MAX_PROPERTY_DESCRIPTION_LENGTH) {
+    pushIssue(
+      issue(
+        "INPUT_SCHEMA",
+        `Property description exceeds ${MAX_PROPERTY_DESCRIPTION_LENGTH} chars ` +
+          `(got ${length})${path ? ` at ${path}` : ""}`,
+        rootField,
+      ),
+    );
+  }
+}
+
+function checkPropertyDescriptionLengthsRecursive(
+  schema: unknown,
+  rootField: string,
+  pushIssue: (nextIssue: ToolManualIssue) => void,
+  path = "",
+): void {
+  if (!isRecord(schema)) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "properties" && isRecord(value)) {
+      for (const [propertyName, propertyDefinition] of Object.entries(value)) {
+        const propertyPath = path ? `${path}.${propertyName}` : propertyName;
+        if (isRecord(propertyDefinition)) {
+          checkOnePropertyDescriptionLength(
+            propertyDefinition.description,
+            rootField,
+            pushIssue,
+            propertyPath,
+          );
+        }
+        checkPropertyDescriptionLengthsRecursive(propertyDefinition, rootField, pushIssue, propertyPath);
+      }
+    } else if (key === "items" && isRecord(value)) {
+      const itemsPath = path ? `${path}.items` : "items";
+      checkOnePropertyDescriptionLength(value.description, rootField, pushIssue, itemsPath);
+      checkPropertyDescriptionLengthsRecursive(value, rootField, pushIssue, itemsPath);
+    } else if (COMPOSITION_KEYWORDS.has(key) && Array.isArray(value)) {
+      value.forEach((branch, index) => {
+        const branchPath = path ? `${path}.${key}[${index}]` : `${key}[${index}]`;
+        if (isRecord(branch)) {
+          checkOnePropertyDescriptionLength(branch.description, rootField, pushIssue, branchPath);
+        }
+        checkPropertyDescriptionLengthsRecursive(branch, rootField, pushIssue, branchPath);
+      });
     }
   }
 }
@@ -267,6 +334,7 @@ export function validate_tool_manual(manualInput: ManualInput): [boolean, ToolMa
       pushError("INPUT_SCHEMA", "additionalProperties must be false", "input_schema");
     }
     checkSchemaForbiddenRecursive(inputSchema, "input_schema", (nextIssue) => issues.push(nextIssue));
+    checkPropertyDescriptionLengthsRecursive(inputSchema, "input_schema", (nextIssue) => issues.push(nextIssue));
     const properties = inputSchema.properties;
     if (isRecord(properties)) {
       for (const fieldName of Object.keys(properties)) {

--- a/siglume-api-sdk-ts/test/project.test.ts
+++ b/siglume-api-sdk-ts/test/project.test.ts
@@ -336,6 +336,52 @@ describe("cli project helpers", () => {
     expect(autoRegisterCalled).toBe(false);
   });
 
+  it("surfaces remote structural validation errors during registration", async () => {
+    const projectDir = await createObjectProject();
+    let autoRegisterCalled = false;
+
+    try {
+      await runRegistration(
+        projectDir,
+        {},
+        {
+          env: { SIGLUME_API_KEY: "sig_test_key" },
+          client_factory: () =>
+            ({
+              async preview_quality_score() {
+                return publishableQualityReport({
+                  overall_score: 100,
+                  grade: "A",
+                  publishable: false,
+                  validation_ok: false,
+                  validation_errors: [
+                    {
+                      code: "INPUT_SCHEMA",
+                      field: "input_schema",
+                      message: "Property description exceeds 500 chars (got 635) at operation",
+                      severity: "error",
+                    },
+                  ],
+                });
+              },
+              async auto_register() {
+                autoRegisterCalled = true;
+                throw new Error("auto_register should not run");
+              },
+            }) as unknown as SiglumeClientShape,
+        },
+      );
+      throw new Error("registration should have failed");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain("remote Tool Manual structural validation failed (validation.ok=false)");
+      expect(message).toContain("Quality grade A (100/100) only measures content quality");
+      expect(message).toContain("[INPUT_SCHEMA] input_schema: Property description exceeds 500 chars (got 635) at operation");
+      expect(message).not.toContain("remote Tool Manual quality is not publishable: A (100/100)");
+    }
+    expect(autoRegisterCalled).toBe(false);
+  });
+
   it("allows provider-managed connected accounts with connect_url", async () => {
     const projectDir = await createObjectProject({
       manifest: {

--- a/siglume-api-sdk-ts/test/validator.test.ts
+++ b/siglume-api-sdk-ts/test/validator.test.ts
@@ -42,6 +42,23 @@ describe("validate_tool_manual", () => {
     expect(issues.some((issue) => issue.field === "input_schema.query.oneOf[1].patternProperties")).toBe(true);
   });
 
+  it("rejects input schema property descriptions over 500 characters", () => {
+    const manual = cloneBase();
+    const inputSchema = manual.input_schema as { properties: Record<string, Record<string, unknown>> };
+    (inputSchema.properties.query as Record<string, unknown>).description = "x".repeat(501);
+
+    const [ok, issues] = validate_tool_manual(manual);
+
+    expect(ok).toBe(false);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        code: "INPUT_SCHEMA",
+        field: "input_schema",
+        message: "Property description exceeds 500 chars (got 501) at query",
+      }),
+    );
+  });
+
   it("warns about platform-injected input fields", () => {
     const manual = cloneBase();
     (manual.input_schema as Record<string, unknown>).properties = {

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -740,8 +740,8 @@ class ToolManualQualityReport:
 
 
 # ── Tool Manual Validation (server-mirror) ──
-# Client-side mirror of the authoritative server validator at
-# agent_sns.application.capability_runtime.tool_manual_validator.
+# Client-side mirror of the authoritative server validator published as
+# siglume_agent_core.tool_manual_validator.
 # Catches common structural mistakes before a network round-trip.
 # The server is always authoritative — keep rule sets in sync.
 
@@ -774,7 +774,7 @@ def _check_schema_forbidden_recursive(
 
     Server parity: matches `_check_composition_keywords` and
     `_check_forbidden_key` in
-    `agent_sns.application.capability_runtime.tool_manual_validator`.
+    `siglume_agent_core.tool_manual_validator`.
     """
     if not isinstance(schema, dict):
         return

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -758,6 +758,7 @@ _COMPOSITION_KEYWORDS = frozenset({"oneOf", "anyOf", "allOf"})
 # Mirrors server `_check_forbidden_key` sweep; patternProperties is the
 # headline case because loose property globs defeat schema validation.
 _INPUT_SCHEMA_FORBIDDEN_KEYS = frozenset({"patternProperties"})
+_MAX_PROPERTY_DESCRIPTION_LEN = 500
 
 
 def _check_schema_forbidden_recursive(
@@ -809,6 +810,78 @@ def _check_schema_forbidden_recursive(
         elif key == "items" and isinstance(val, dict):
             sub_path = f"{path}.items" if path else "items"
             _check_schema_forbidden_recursive(val, root_field, err_fn, path=sub_path)
+
+
+def _check_one_property_description_length(
+    text: Any,
+    root_field: str,
+    err_fn,
+    path: str,
+) -> None:
+    if not isinstance(text, str):
+        return
+    if len(text) > _MAX_PROPERTY_DESCRIPTION_LEN:
+        location = f" at {path}" if path else ""
+        err_fn(
+            "INPUT_SCHEMA",
+            f"Property description exceeds {_MAX_PROPERTY_DESCRIPTION_LEN} chars "
+            f"(got {len(text)}){location}",
+            root_field,
+        )
+
+
+def _check_property_description_lengths_recursive(
+    schema: Any,
+    root_field: str,
+    err_fn,
+    *,
+    path: str = "",
+) -> None:
+    if not isinstance(schema, dict):
+        return
+
+    for key, val in schema.items():
+        if key == "properties" and isinstance(val, dict):
+            for property_name, property_schema in val.items():
+                property_path = f"{path}.{property_name}" if path else str(property_name)
+                if isinstance(property_schema, dict):
+                    _check_one_property_description_length(
+                        property_schema.get("description"),
+                        root_field,
+                        err_fn,
+                        property_path,
+                    )
+                _check_property_description_lengths_recursive(
+                    property_schema,
+                    root_field,
+                    err_fn,
+                    path=property_path,
+                )
+        elif key == "items" and isinstance(val, dict):
+            items_path = f"{path}.items" if path else "items"
+            _check_one_property_description_length(
+                val.get("description"),
+                root_field,
+                err_fn,
+                items_path,
+            )
+            _check_property_description_lengths_recursive(val, root_field, err_fn, path=items_path)
+        elif key in _COMPOSITION_KEYWORDS and isinstance(val, list):
+            for index, branch in enumerate(val):
+                branch_path = f"{path}.{key}[{index}]" if path else f"{key}[{index}]"
+                if isinstance(branch, dict):
+                    _check_one_property_description_length(
+                        branch.get("description"),
+                        root_field,
+                        err_fn,
+                        branch_path,
+                    )
+                _check_property_description_lengths_recursive(
+                    branch,
+                    root_field,
+                    err_fn,
+                    path=branch_path,
+                )
 
 
 def validate_tool_manual(
@@ -994,6 +1067,7 @@ def validate_tool_manual(
         # _check_forbidden_key recursive sweep. A top-level-only check was
         # letting nested violations through, producing false confidence.
         _check_schema_forbidden_recursive(inp, "input_schema", _err)
+        _check_property_description_lengths_recursive(inp, "input_schema", _err)
         # platform-injected fields (top-level properties only; matches server)
         props = inp.get("properties", {})
         if isinstance(props, dict):

--- a/siglume_api_sdk.py
+++ b/siglume_api_sdk.py
@@ -740,8 +740,8 @@ class ToolManualQualityReport:
 
 
 # ── Tool Manual Validation (server-mirror) ──
-# Client-side mirror of the authoritative server validator published as
-# siglume_agent_core.tool_manual_validator.
+# Client-side mirror of the authoritative Tool Manual validator used by
+# Siglume production.
 # Catches common structural mistakes before a network round-trip.
 # The server is always authoritative — keep rule sets in sync.
 
@@ -774,7 +774,7 @@ def _check_schema_forbidden_recursive(
 
     Server parity: matches `_check_composition_keywords` and
     `_check_forbidden_key` in
-    `siglume_agent_core.tool_manual_validator`.
+    Siglume production.
     """
     if not isinstance(schema, dict):
         return

--- a/siglume_api_sdk/cli/project.py
+++ b/siglume_api_sdk/cli/project.py
@@ -104,6 +104,48 @@ def _remote_quality_ok(report: Any) -> bool:
     return validation_ok and bool(publishable)
 
 
+def _issue_value(issue: Any, name: str, default: Any = None) -> Any:
+    if isinstance(issue, dict):
+        return issue.get(name, default)
+    return getattr(issue, name, default)
+
+
+def _format_remote_quality_issue(issue: Any) -> str:
+    code = str(_issue_value(issue, "code", "") or "")
+    field = str(_issue_value(issue, "field", "") or "")
+    message = str(_issue_value(issue, "message", "") or "remote validation failed")
+    code_prefix = f"[{code}] " if code else ""
+    field_prefix = f"{field}: " if field else ""
+    return f"{code_prefix}{field_prefix}{message}"
+
+
+def _remote_quality_blocking_errors(report: Any) -> list[str]:
+    grade = str(getattr(report, "grade", "?"))
+    score = getattr(report, "overall_score", "?")
+    validation_ok = bool(getattr(report, "validation_ok", True))
+    publishable = getattr(report, "publishable", None)
+    grade_publishable = grade in {"A", "B"}
+    effective_publishable = grade_publishable if publishable is None else bool(publishable)
+    errors: list[str] = []
+
+    if not validation_ok:
+        errors.append(
+            "remote Tool Manual structural validation failed (validation.ok=false). "
+            f"Quality grade {grade} ({score}/100) only measures content quality; "
+            "publication also requires structural validation to pass."
+        )
+        validation_errors = getattr(report, "validation_errors", None) or []
+        for issue in validation_errors:
+            errors.append(_format_remote_quality_issue(issue))
+
+    if not effective_publishable and (validation_ok or not grade_publishable):
+        errors.append(f"remote Tool Manual quality is not publishable: {grade} ({score}/100)")
+
+    if not errors and not _remote_quality_ok(report):
+        errors.append(f"remote Tool Manual quality is not publishable: {grade} ({score}/100)")
+    return errors
+
+
 def build_tool_manual_template(manifest: AppManifest) -> dict[str, Any]:
     job_text = str(manifest.job_to_be_done or manifest.name or manifest.capability_key.replace("-", " "))
     summary_text = str(manifest.short_description or manifest.job_to_be_done or manifest.name or manifest.capability_key.replace("-", " "))
@@ -1476,9 +1518,7 @@ def _registration_preflight(project: LoadedProject, client: SiglumeClient) -> di
     if not manual_valid:
         errors.append("tool_manual.json is not valid for production registration")
     if not _remote_quality_ok(remote_quality):
-        grade = getattr(remote_quality, "grade", "?")
-        score = getattr(remote_quality, "overall_score", "?")
-        errors.append(f"remote Tool Manual quality is not publishable: {grade} ({score}/100)")
+        errors.extend(_remote_quality_blocking_errors(remote_quality))
     preflight = {
         "manifest_issues": manifest_issues,
         "tool_manual_valid": manual_valid,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,6 +509,60 @@ def test_register_blocks_non_publishable_remote_quality(monkeypatch, tmp_path) -
     assert FakeClient.auto_register_called is False
 
 
+def test_register_surfaces_remote_validation_errors(monkeypatch, tmp_path) -> None:
+    runner = CliRunner()
+    project_dir = tmp_path / "remote-validation-blocked"
+    _write_register_project(project_dir)
+
+    class FakeClient:
+        auto_register_called = False
+
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def preview_quality_score(self, manual):
+            from siglume_api_sdk import ToolManualIssue, ToolManualQualityReport
+
+            return ToolManualQualityReport(
+                overall_score=100,
+                grade="A",
+                issues=[],
+                keyword_coverage_estimate=100,
+                improvement_suggestions=[],
+                publishable=False,
+                validation_ok=False,
+                validation_errors=[
+                    ToolManualIssue(
+                        code="INPUT_SCHEMA",
+                        field="input_schema",
+                        message="Property description exceeds 500 chars (got 635) at operation",
+                    )
+                ],
+            )
+
+        def auto_register(self, *args, **kwargs):
+            self.auto_register_called = True
+            raise AssertionError("auto_register should not run after failed preflight")
+
+    monkeypatch.setattr(project_module, "resolve_api_key", lambda: "sig_test_key")
+    monkeypatch.setattr(project_module, "SiglumeClient", FakeClient)
+
+    result = runner.invoke(main, ["register", str(project_dir), "--draft-only", "--json"])
+
+    assert result.exit_code == 1
+    assert "remote Tool Manual structural validation failed (validation.ok=false)" in result.output
+    assert "Quality grade A (100/100) only measures content quality" in result.output
+    assert "[INPUT_SCHEMA] input_schema: Property description exceeds 500 chars (got 635) at operation" in result.output
+    assert "remote Tool Manual quality is not publishable: A (100/100)" not in result.output
+    assert FakeClient.auto_register_called is False
+
+
 def test_register_allows_api_managed_connected_account_without_oauth_seed(monkeypatch, tmp_path) -> None:
     runner = CliRunner()
     project_dir = tmp_path / "api-managed-oauth"

--- a/tests/test_tool_manual.py
+++ b/tests/test_tool_manual.py
@@ -103,3 +103,21 @@ def test_forbidden_input_schema_keywords_fail_validation() -> None:
 
     assert ok is False
     assert any(issue.code == "INPUT_SCHEMA" and issue.field == "input_schema.patternProperties" for issue in issues)
+
+
+def test_input_schema_property_description_over_500_chars_fails_validation() -> None:
+    manual = _valid_manual()
+    manual["input_schema"]["properties"]["query"]["description"] = "x" * 501
+
+    ok, issues = validate_tool_manual(manual)
+    report = score_tool_manual_offline(manual)
+
+    assert ok is False
+    assert any(
+        issue.code == "INPUT_SCHEMA"
+        and issue.field == "input_schema"
+        and issue.message == "Property description exceeds 500 chars (got 501) at query"
+        for issue in issues
+    )
+    assert report.validation_ok is False
+    assert report.publishable is False


### PR DESCRIPTION
## Summary
- carry the register preflight validation-error UX fix branch under the same name as the monorepo sync PR
- remove public references to the retired external core package/repository from historical SDK docs/release notes
- keep the public SDK mirror aligned with `packages/contracts/sdk` in the Siglume monorepo

## Validation
- monorepo SDK mirror check against this checkout passes
- `py -3.11 -m pytest packages/contracts/sdk/tests` from the monorepo mirror: 365 passed